### PR TITLE
Add check-files-licence-headers job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           go-version: '^1.13.1'
       - run: go install github.com/google/addlicense@latest 
-      - run: addlicense -check -c "Sharezone UG (haftungsbeschränkt)" -f .\header_template.txt .
+      - run: addlicense -check -c "Sharezone UG (haftungsbeschränkt)" -f header_template.txt .
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `check-files-licence-headers` job checks that all files contain the appropriate licence header:
```
# Copyright (c) 2022 Sharezone UG (haftungsbeschränkt)
# Licensed under the EUPL-1.2-or-later.
#
# You may obtain a copy of the Licence at:
# https://joinup.ec.europa.eu/software/page/eupl
#
# SPDX-License-Identifier: EUPL-1.2
```
which has its template definied under `header_template.txt`.

If one wants to automatically add the licence headers then the command 
```
addlicense -check -c "Sharezone UG (haftungsbeschränkt)" -f header_template.txt .
``` 
can be run.  
The tool has to be installed via `go install github.com/google/addlicense@latest` first.

See: https://github.com/google/addlicense

Closes #25 