### PR TITLE
Left-Align markdown notice on 5th event creation page.

### DIFF
--- a/app/lib/timetable/timetable_add_event/tabs/optional_tab.dart
+++ b/app/lib/timetable/timetable_add_event/tabs/optional_tab.dart
@@ -81,6 +81,7 @@ class _DescriptionField extends StatelessWidget {
         return Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16),
           child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
               PrefilledTextField(
                 prefilledText: description,

--- a/app/lib/timetable/timetable_add_event/tabs/optional_tab.dart
+++ b/app/lib/timetable/timetable_add_event/tabs/optional_tab.dart
@@ -98,7 +98,10 @@ class _DescriptionField extends StatelessWidget {
                 textInputAction: TextInputAction.done,
               ),
               const SizedBox(height: 10),
-              MarkdownSupport(),
+              Padding(
+                padding: const EdgeInsets.only(left: 4.0),
+                child: MarkdownSupport(),
+              ),
             ],
           ),
         );


### PR DESCRIPTION
Original issue from GitLab: https://gitlab.com/codingbrain/sharezone/sharezone-app/-/issues/1444

Original look:

![image](https://user-images.githubusercontent.com/29028262/151863629-36cfdaee-d7ae-4eb8-bca8-1a6e001f76d0.png)

Fixed version:
![image_2022-01-31_20-53-51](https://user-images.githubusercontent.com/29028262/151863772-d9e28510-ff80-4855-9b8d-ebff5e474048.png)

![image_2022-01-31_20-53-23](https://user-images.githubusercontent.com/29028262/151863704-80931cc7-3dcf-4642-9170-c7e9aaeb79a0.png)

I added a little bit of padding - this is how it would look like without (i think a bit too much left):

![image_2022-01-31_20-54-22](https://user-images.githubusercontent.com/29028262/151863844-9d32fa02-712c-4c89-9ead-7c0e50b25816.png)

