### PR TITLE
Remove push trigger on main for `CI` GitHub Action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,9 +12,7 @@ name: CI
 
 # Controls when the action will run. 
 on:
-  # Triggers the workflow on push or pull request events but only for the main branch
-  push:
-    branches: [ main ]
+  # Triggers the workflow on pull request events but only for the main branch
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/24459435/152518188-9f797829-e2ce-4030-874d-f764052e6c29.png)

We enabled the option `Require branches to be up to date before merging`. This will ensure that the latest `main` is in the branch. Therefore, running the CI after merging is not necessary, because it will be the same code.

With this change, we have an action with only triggers on PR, which we can use for app previews (e.g. with Firebase Hosting).
