### PR TITLE
Disable `analyze` workflow if PR is a draft.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,9 +26,9 @@ env:
 jobs:
   analyze:
     runs-on: ubuntu-latest
-    # In "work In progress" PRs we might use TODOs temporarily.
+    # In draft PRs we might use TODOs temporarily.
     # In this case the analyze pipeline would fail, thus we won't run it.
-    if: ${{ !contains(github.event.pull_request.title, '[WIP]') }}
+    if: ${{ github.event.pull_request.draft == false }}
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Since this repo is public, we have access to the paid features of GitHub. Therefore, we can use the draft PR feature instead of writing `[WIP]` at the beginning of a pull request.