### PR TITLE
Use FVM

### DIFF
--- a/.fvm/fvm_config.json
+++ b/.fvm/fvm_config.json
@@ -1,0 +1,4 @@
+{
+  "flutterSdkVersion": "2.5.2",
+  "flavors": {}
+}

--- a/.github/workflows/deploy_web_app.yml
+++ b/.github/workflows/deploy_web_app.yml
@@ -26,7 +26,6 @@ on:
   workflow_dispatch:
 
 env:
-  FLUTTER_VERSION: "2.5.2"
   CI_CD_DART_SCRIPTS_PACKAGE_PATH: "tools/sz_repo_cli/"
 
 jobs:
@@ -35,11 +34,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Set Flutter version from FVM config file to environment variables
+      uses: kuhnroyal/flutter-fvm-config-action@v1
+
     - name: Install Flutter
       uses: subosito/flutter-action@v1
       with:
         flutter-version: ${{ env.FLUTTER_VERSION }}
-        channel: any
+        channel: ${{ env.FLUTTER_CHANNEL }}
     
     - name: Activate sz_repo_cli package
       run: pub global activate --source path "$CI_CD_DART_SCRIPTS_PACKAGE_PATH"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,6 @@ on:
   workflow_dispatch:
 
 env:
-  FLUTTER_VERSION: "2.5.2"
   CI_CD_DART_SCRIPTS_PACKAGE_PATH: "tools/sz_repo_cli/"
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
@@ -33,10 +32,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Set Flutter version from FVM config file to environment variables
+        uses: kuhnroyal/flutter-fvm-config-action@v1
+
       - uses: subosito/flutter-action@v1
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: 'any'
+          channel: ${{ env.FLUTTER_CHANNEL }}
 
       - name: Activate sz_repo_cli package
         run: pub global activate --source path "$CI_CD_DART_SCRIPTS_PACKAGE_PATH"
@@ -62,10 +64,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Set Flutter version from FVM config file to environment variables
+        uses: kuhnroyal/flutter-fvm-config-action@v1
+
       - uses: subosito/flutter-action@v1
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: 'any'
+          channel: ${{ env.FLUTTER_CHANNEL }}
 
       - name: Activate sz_repo_cli package
         run: pub global activate --source path "$CI_CD_DART_SCRIPTS_PACKAGE_PATH"
@@ -95,10 +100,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Set Flutter version from FVM config file to environment variables
+        uses: kuhnroyal/flutter-fvm-config-action@v1
+
       - uses: subosito/flutter-action@v1
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: 'any'
+          channel: ${{ env.FLUTTER_CHANNEL }}
 
       - name: Build web app
         working-directory: app

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,10 @@
 # IDE
 .vscode/*
 !.vscode/launch.json
+!.vscode/settings.json
+
+# FVM will create a relative symlink in your project from .fvm/flutter_sdk to
+# the cache of the selected version. We should add this to our .gitignore.
+#
+# Source: https://fvm.app/docs/getting_started/configuration#project
+.fvm/flutter_sdk

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,17 @@
+{
+    // Set the path of the Flutter SDK to the path of the FVM Flutter version.
+    //
+    // VS Code will always use the version selected within the project for all
+    // IDE tooling.
+    //
+    // Source: https://fvm.app/docs/getting_started/configuration#option-1---automatic-switching-recommended
+    "dart.flutterSdkPath": ".fvm/flutter_sdk",
+    "search.exclude": {
+        // Remove .fvm files from search
+        "**/.fvm": true
+    },
+    "files.watcherExclude": {
+        // Remove .fvm files from file watching
+        "**/.fvm": true
+    }
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,3 +69,13 @@ git clone https://github.com/SharezoneApp/sharezone-app.git
 
 After cloning the repository, we recommend to execute the following steps:
 1. Get all dependencies with `sz packages get`
+
+### Flutter Version Management (FVM)
+We use [FVM](https://fvm.app) to have a consistent Flutter version across the developers and our CI/CD. You find in `.fvm/fvm_config.json` the Flutter, which we currently using.
+
+To install & use FVM, follow the following steps:
+1. Install FVM by running `dart pub global activate fvm` or use the other installation methods (see [FVM docs](https://fvm.app/docs/getting_started/installation))
+2. Navigate to the root of the repository
+3. Run `fvm install` (This installs the Flutter version from `.fvm/fvm_config.json`)
+
+When you are using VS Code, no further steps should be necessary, because we included the `.vscode/setting.json` to git. However, when you are using Android Studio, you need to configure your IDE to use the Flutter version of FVM. Follow the [official documentation](https://fvm.app/docs/getting_started/configuration#android-studio) to configure Android Studio.


### PR DESCRIPTION
## Description
This PR introduces the use of [FVM](https://fvm.app/). FVM allows to us have a SOT of our Flutter version. Therefore, it's easier to keep the same Flutter version across different developers. Additionally, we can use in CI/CD the same Flutter version in every workflow.

## Additional setup
The use of FVM require additionally setup steps for a new developer:
```sh
# Install FVM
dart pub global activate fvm

# Install Flutter version
fvm install
```

## How to change the Flutter version
1. Change the version in `.fvm/fvm_config.json`
2. Run `fvm install`

## Related Tickets
Closes #144 