### PR TITLE
Remove the new prefix for the macOS app prompt

### DIFF
--- a/app/lib/download_app_tip/models/download_app_tip.dart
+++ b/app/lib/download_app_tip/models/download_app_tip.dart
@@ -45,7 +45,7 @@ class MacOsTip extends DownloadAppTip {
   String get actionText => "Download für Mac";
 
   @override
-  String get title => "Neu: Download für Mac";
+  String get title => "Download für Mac";
 }
 
 class IOsTip extends DownloadAppTip {


### PR DESCRIPTION
When the user opens the web app with an Apple device, the macOS prompt comes. Because we released our macOS 2 years ago, we can now remove the new prefix.

![image](https://user-images.githubusercontent.com/24459435/163854903-66cffafb-8bd8-4f0a-be8b-1296cbd1b714.png)
