### PR TITLE
Enable CI for every pull request (no matter which branch)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,9 +12,8 @@ name: CI
 
 # Controls when the action will run. 
 on:
-  # Triggers the workflow on pull request events but only for the main branch
+  # Triggers the workflow on pull request events
   pull_request:
-    branches: [ main ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Doesn't it make more sense to run our CI for every branch? Because otherwise the CI will not run when we split a PR into multiple branches like:

```
main
   big_feature
      sub_feature_for_feature_1
      sub_feature_for_feature_2
```

I think it would be helpful to also run the CI when you merge `sub_feature_for_feature_1` into `big_feature`. Of course, there could be the case `sub_feature_for_feature_1` has some unfinished tests or wrong lints, because it's part of `big_feature`, but I think in these special cases we could skip the CI. 