### PR TITLE
Format & fix typo in `url_launcher_extended` package

### DIFF
--- a/lib/url_launcher_extended/lib/src/mock_url_launcher_extended.dart
+++ b/lib/url_launcher_extended/lib/src/mock_url_launcher_extended.dart
@@ -50,8 +50,11 @@ class MockUrlLauncherExtended extends UrlLauncherExtended {
   }
 
   @override
-  Future<bool> tryLaunchMailOrThrow(String address,
-      {String subject, String body}) async {
+  Future<bool> tryLaunchMailOrThrow(
+    String address, {
+    String subject,
+    String body,
+  }) async {
     logCalledLaunchMail = true;
     return true;
   }

--- a/lib/url_launcher_extended/lib/src/url_launcher_extended.dart
+++ b/lib/url_launcher_extended/lib/src/url_launcher_extended.dart
@@ -16,48 +16,50 @@ class UrlLauncherExtended {
   /// Parses the specified URL string and delegates handling of it to the
   /// underlying platform.
   ///
-  /// The returned future completes with a [PlatformException] on invalid URLs and
-  /// schemes which cannot be handled, that is when [canLaunch] would complete
-  /// with false.
+  /// The returned future completes with a [PlatformException] on invalid URLs
+  /// and schemes which cannot be handled, that is when [canLaunch] would
+  /// complete with false.
   ///
-  /// [forceSafariVC] is only used in iOS with iOS version >= 9.0. By default (when unset), the launcher
-  /// opens web URLs in the Safari View Controller, anything else is opened
-  /// using the default handler on the platform. If set to true, it opens the
-  /// URL in the Safari View Controller. If false, the URL is opened in the
-  /// default browser of the phone. Note that to work with universal links on iOS,
-  /// this must be set to false to let the platform's system handle the URL.
-  /// Set this to false if you want to use the cookies/context of the main browser
-  /// of the app (such as SSO flows). This setting will nullify [universalLinksOnly]
-  /// and will always launch a web content in the built-in Safari View Controller regardless
-  /// if the url is a universal link or not.
+  /// [forceSafariVC] is only used in iOS with iOS version >= 9.0. By default
+  /// (when unset), the launcher opens web URLs in the Safari View Controller,
+  /// anything else is opened using the default handler on the platform. If set
+  /// to true, it opens the URL in the Safari View Controller. If false, the URL
+  /// is opened in the default browser of the phone. Note that to work with
+  /// universal links on iOS, this must be set to false to let the platform's
+  /// system handle the URL. Set this to false if you want to use the
+  /// cookies/context of the main browser of the app (such as SSO flows). This
+  /// setting will nullify [universalLinksOnly] and will always launch a web
+  /// content in the built-in Safari View Controller regardless if the url is a
+  /// universal link or not.
   ///
-  /// [universalLinksOnly] is only used in iOS with iOS version >= 10.0. This setting is only validated
-  /// when [forceSafariVC] is set to false. The default value of this setting is false.
-  /// By default (when unset), the launcher will either launch the url in a browser (when the
-  /// url is not a universal link), or launch the respective native app content (when
-  /// the url is a universal link). When set to true, the launcher will only launch
-  /// the content if the url is a universal link and the respective app for the universal
-  /// link is installed on the user's device; otherwise throw a [PlatformException].
+  /// [universalLinksOnly] is only used in iOS with iOS version >= 10.0. This
+  /// setting is only validated when [forceSafariVC] is set to false. The
+  /// default value of this setting is false. By default (when unset), the
+  /// launcher will either launch the url in a browser (when the url is not a
+  /// universal link), or launch the respective native app content (when the url
+  /// is a universal link). When set to true, the launcher will only launch the
+  /// content if the url is a universal link and the respective app for the
+  /// universal link is installed on the user's device; otherwise throw a
+  /// [PlatformException].
   ///
   /// [forceWebView] is an Android only setting. If null or false, the URL is
-  /// always launched with the default browser on device. If set to true, the URL
-  /// is launched in a WebView. Unlike iOS, browser context is shared across
-  /// WebViews.
-  /// [enableJavaScript] is an Android only setting. If true, WebView enable
-  /// javascript.
-  /// [enableDomStorage] is an Android only setting. If true, WebView enable
-  /// DOM storage.
-  /// [headers] is an Android only setting that adds headers to the WebView.
+  /// always launched with the default browser on device. If set to true, the
+  /// URL is launched in a WebView. Unlike iOS, browser context is shared across
+  /// WebViews. [enableJavaScript] is an Android only setting. If true, WebView
+  /// enable javascript. [enableDomStorage] is an Android only setting. If true,
+  /// WebView enable DOM storage. [headers] is an Android only setting that adds
+  /// headers to the WebView.
   ///
-  /// Note that if any of the above are set to true but the URL is not a web URL,
-  /// this will throw a [PlatformException].
+  /// Note that if any of the above are set to true but the URL is not a web
+  /// URL, this will throw a [PlatformException].
   ///
   /// [statusBarBrightness] Sets the status bar brightness of the application
   /// after opening a link on iOS. Does nothing if no value is passed. This does
   /// not handle resetting the previous status bar style.
   ///
-  /// Returns true if launch url is successful; false is only returned when [universalLinksOnly]
-  /// is set to true and the universal link failed to launch.
+  /// Returns true if launch url is successful; false is only returned when
+  /// [universalLinksOnly] is set to true and the universal link failed to
+  /// launch.
   ///
   /// (Copied form launch url_launcher)
   Future<bool> launch(

--- a/lib/url_launcher_extended/test/mock_url_launcher_extended_test.dart
+++ b/lib/url_launcher_extended/test/mock_url_launcher_extended_test.dart
@@ -30,8 +30,8 @@ void main() {
       expect(canLaunch, false);
     });
 
-    test('.launch loggs call', () async {
-      // Before method call the logged attribut should return false.
+    test('.launch logs call', () async {
+      // Before method call the logged attribute should return false.
       expect(mockUrlLauncherExtended.logCalledLaunch, false);
 
       await mockUrlLauncherExtended.launch("urlString");
@@ -39,8 +39,8 @@ void main() {
       expect(mockUrlLauncherExtended.logCalledLaunch, true);
     });
 
-    test('.launchMail loggs call', () async {
-      // Before method call the logged attribut should return false.
+    test('.launchMail logs call', () async {
+      // Before method call the logged attribute should return false.
       expect(mockUrlLauncherExtended.logCalledLaunchMail, false);
 
       await mockUrlLauncherExtended.tryLaunchMailOrThrow("test@sharezone.net");
@@ -48,14 +48,14 @@ void main() {
       expect(mockUrlLauncherExtended.logCalledLaunchMail, true);
     });
 
-    test('.tryLaunchOrThrow launchs link if it can', () async {
+    test('.tryLaunchOrThrow launches link if it can', () async {
       // .canLaunch is already true
       final result =
           await mockUrlLauncherExtended.tryLaunchOrThrow("urlString");
       expect(result, true);
     });
 
-    test('.tryLaunchOrThrow throws expection if link can not be launch',
+    test('.tryLaunchOrThrow throws exception if link can not be launch',
         () async {
       mockUrlLauncherExtended.setCanLaunch(false);
 


### PR DESCRIPTION
Just formats the doc comment of the `launch` method and fixes some typos.