### PR TITLE
Rename `deploy-web-alpha` workflow to `alpha`

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -6,7 +6,7 @@
 #
 # SPDX-License-Identifier: EUPL-1.2
 
-name: deploy-web-app
+name: alpha
 
 on:
   push:
@@ -17,10 +17,11 @@ on:
       # changed.
       - "app/lib/**"
       - "lib/**"
+      - "app/pubspec.lock"
       - "app/pubspec.yaml"
       # We trigger also this workflow, if this workflow is changed, so that new
       # changes will be applied.
-      - ".github/workflows/deploy_web_app.yml"
+      - ".github/workflows/alpha.yml"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
The name `alpha` makes more sense because the triggers for this workflow are relevant for building a new alpha version - no matter for which platform. Especially when implementing #215 can we add the job to the `alpha` workflow.