### PR TITLE
Use for `test` job a macOS machine to be able to run golden tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
       - run: addlicense -check -c "Sharezone UG (haftungsbeschränkt)" -f header_template.txt -ignore "**/GeneratedPluginRegistrant.swift" . 
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
#138 & #216 are adding golden tests. Golden tests can only run on one platform. We decided to pick macOS as the platform because primary using macOS. Therefore, should our CI use macOS machines. Otherwise, the Golden Tests are skipped.