### PR TITLE
Replace `jcenter` with `mavenCentral` in `build.gradle`

### DIFF
--- a/app/android/build.gradle
+++ b/app/android/build.gradle
@@ -3,7 +3,7 @@ buildscript {
 
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -17,7 +17,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
## Description
`jcenter` is deprecated. This is the reason why an Android build could fail with this error message:
```
* What went wrong:
Could not determine the dependencies of task ':app:minifyProdReleaseWithR8'.
> Could not resolve all dependencies for configuration ':app:prodReleaseRuntimeClasspath'.
   > Could not determine artifacts for com.google.android.exoplayer:exoplayer-hls:2.12.1
      > Could not get resource 'https://jcenter.bintray.com/com/google/android/exoplayer/exoplayer-hls/2.12.1/exoplayer-hls-2.12.1.aar'.
         > Could not HEAD 'https://jcenter.bintray.com/com/google/android/exoplayer/exoplayer-hls/2.12.1/exoplayer-hls-2.12.1.aar'.
            > Connect to jcenter.bintray.com:443 [jcenter.bintray.com/34.95.74.180] failed: connect timed out
```

For testing, I used the Codemagic Linux Premium VMs because with these was the issue reproducible.

I replaced `jcenter` with `mavenCentral` and the builds on the Linux Premium VMs are working again. Builds on my M1 MacBook Pro also working 👍  