### PR TITLE
Add automatically labels to pull requests based on the changed file paths

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,11 @@
+# Copyright (c) 2022 Sharezone UG (haftungsbeschränkt)
+# Licensed under the EUPL-1.2-or-later.
+#
+# You may obtain a copy of the Licence at:
+# https://joinup.ec.europa.eu/software/page/eupl
+#
+# SPDX-License-Identifier: EUPL-1.2
+
 "ci/cd":
 - .github/workflows/**
 - .github/labeler.yml

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,21 @@
+"ci/cd":
+- .github/workflows/**
+- .github/labeler.yml
+
+"documentation":
+- '**/*.md'
+
+"testing":
+- "**/*_test.dart"
+
+"platform: android":
+- 'app/android/**'
+
+"platform: ios":
+- 'app/ios/**'
+
+"platform: macos":
+- 'app/macos/**'
+
+"platform: web":
+- 'app/web/**'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,22 @@ env:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
+  # This workflow applies labels to pull requests based on the paths that are
+  # modified in the pull request.
+  #
+  # Edit `.github/labeler.yml` to configure labels.
+  #
+  # For more information, see: https://github.com/actions/labeler
+  label-pr:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v3
+    - name: Label PR
+      uses: actions/labeler@v3
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+
   analyze:
     runs-on: ubuntu-latest
     # In draft PRs we might use TODOs temporarily.


### PR DESCRIPTION
## Description
Finding pull requests with GitHub can be hard. Especially when our app has a bug and we try to find the pull request which caused the bug, might it be helpful to labels, like `platform: android` when we know it something with the Android build or changes to our CI/CD with the label `ci/cd`.

Therefore, I added the `labeler` Action to automatically add labels to our pull requests based on the changed file paths.