### PR TITLE
Use `--web-renderer canvaskit` flag instead of `--dart-define=FLUTTER_WEB_USE_SKIA=true` to deploy the web app via `sz deploy web-app`

### DIFF
--- a/tools/sz_repo_cli/lib/src/commands/src/deploy_web_app_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/deploy_web_app_command.dart
@@ -101,7 +101,8 @@ class DeployWebAppCommand extends Command {
           'build',
           'web',
           '--release',
-          '--dart-define=FLUTTER_WEB_USE_SKIA=true'
+          '--web-renderer',
+          'canvaskit',
         ],
         workingDirectory: _repo.sharezoneFlutterApp.location.path,
       );


### PR DESCRIPTION
Regarding the official Flutter docs, you can set the renderer via the `--web-renderer` flag: https://docs.flutter.dev/development/platform-integration/web/renderers#command-line-options