### PR TITLE
Don't require `key.properties` anymore to build for Android

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -18,7 +18,8 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 def keystorePropertiesFile = rootProject.file("key.properties")
 def keystoreProperties = new Properties()
-if (keystorePropertiesFile.exists()) {
+def hasKeystorePropertiesFile = keystorePropertiesFile.exists()
+if (hasKeystorePropertiesFile) {
     keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
 }
 
@@ -52,7 +53,7 @@ android {
     }
 
     signingConfigs {
-        if(keystorePropertiesFile.exists()) {
+        if(hasKeystorePropertiesFile) {
             release {
                 keyAlias keystoreProperties['keyAlias']
                 keyPassword keystoreProperties['keyPassword']
@@ -63,7 +64,7 @@ android {
     }
     buildTypes {
         release {
-            if(keystorePropertiesFile.exists()) {
+            if(hasKeystorePropertiesFile) {
                 signingConfig signingConfigs.release
             }
 

--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -18,7 +18,9 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 def keystorePropertiesFile = rootProject.file("key.properties")
 def keystoreProperties = new Properties()
-keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+if (keystorePropertiesFile.exists()) {
+    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+}
 
 def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
 if (flutterVersionCode == null) {
@@ -50,16 +52,21 @@ android {
     }
 
     signingConfigs {
-        release {
-            keyAlias keystoreProperties['keyAlias']
-            keyPassword keystoreProperties['keyPassword']
-            storeFile file(keystoreProperties['storeFile'])
-            storePassword keystoreProperties['storePassword']
+        if(keystorePropertiesFile.exists()) {
+            release {
+                keyAlias keystoreProperties['keyAlias']
+                keyPassword keystoreProperties['keyPassword']
+                storeFile file(keystoreProperties['storeFile'])
+                storePassword keystoreProperties['storePassword']
+            }
         }
     }
     buildTypes {
         release {
-            signingConfig signingConfigs.release
+            if(keystorePropertiesFile.exists()) {
+                signingConfig signingConfigs.release
+            }
+
             minifyEnabled true
             // Proguard is needed to run Jitsi in release mdoe
             useProguard true


### PR DESCRIPTION
## Description
For now, it was required to have a `key.properties` file with our code signing credentials when you tried to build for Android (even when running in debug mode where no code signing was done).

We now check if a `key.properties` is present. If no, don't try to code sign the android app, which is the expected behavior because you need code signing only for publishing.

This PR unblocks #230 

Closes #234 