### PR TITLE
Fix Android builds for CI machines

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -36,7 +36,23 @@ if (flutterVersionName == null) {
 android {
     compileSdkVersion 31
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
+    sourceSets {
+        main.java.srcDirs += 'src/main/kotlin'
+    }
+
     lintOptions {
+        // Recommanded fix for https://github.com/flutter/flutter/issues/58247.
+        checkReleaseBuilds false
+        
         disable 'InvalidPackage'
     }
 

--- a/app/android/build.gradle
+++ b/app/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.android.tools.build:gradle:3.6.3'
+        classpath 'com.android.tools.build:gradle:4.1.0'
         classpath 'com.google.gms:google-services:4.3.4'
         classpath 'com.google.firebase:firebase-crashlytics-gradle:2.2.0'
     }

--- a/app/lib/filesharing/logic/open_cloud_file.dart
+++ b/app/lib/filesharing/logic/open_cloud_file.dart
@@ -143,8 +143,13 @@ class FirestoreFilePage extends StatelessWidget {
         id: id,
       );
     }
-    // Video Page für Android, iOS und Web
-    if (fileFormat == FileFormat.video) {
+
+    // Video Page for Android, iOS und Web
+    //
+    // We just download the video for macOS because the video_player package is
+    // not available on macOS yet. Tracking issue:
+    // https://github.com/flutter/flutter/issues/41688
+    if (fileFormat == FileFormat.video && !PlatformCheck.isMacOS) {
       return VideoFilePage(
         name: name,
         nameStream: nameStream,

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -386,6 +386,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.1"
+  csslib:
+    dependency: transitive
+    description:
+      name: csslib
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.17.1"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -964,6 +971,13 @@ packages:
       relative: true
     source: path
     version: "0.0.0"
+  html:
+    dependency: transitive
+    description:
+      name: html
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.15.0"
   html_unescape:
     dependency: transitive
     description:
@@ -1381,7 +1395,7 @@ packages:
       name: plugin_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.1.2"
   pointycastle:
     dependency: transitive
     description:
@@ -1903,26 +1917,38 @@ packages:
   video_player:
     dependency: "direct main"
     description:
-      path: "packages/video_player/video_player"
-      ref: video_player_macos_new
-      resolved-ref: "35d8ec24002de730b664cd87b43edc73de8cef8d"
-      url: "https://github.com/cbenhagen/plugins.git"
-    source: git
-    version: "2.1.3"
+      name: video_player
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.4.2"
+  video_player_android:
+    dependency: transitive
+    description:
+      name: video_player_android
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.3.4"
+  video_player_avfoundation:
+    dependency: transitive
+    description:
+      name: video_player_avfoundation
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.3.4"
   video_player_platform_interface:
     dependency: transitive
     description:
       name: video_player_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.0"
+    version: "5.1.2"
   video_player_web:
     dependency: transitive
     description:
       name: video_player_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.4"
+    version: "2.0.10"
   vm_service:
     dependency: transitive
     description:
@@ -2023,4 +2049,4 @@ packages:
     version: "3.1.0"
 sdks:
   dart: ">=2.16.0 <3.0.0"
-  flutter: ">=2.5.0"
+  flutter: ">=2.10.0"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -136,22 +136,12 @@ dependencies:
     path: ../lib/url_launcher_extended
   user:
     path: ../lib/user
-  # Is overriden, see dependency_overrides below
-  video_player: ^2.1.12
+  video_player: ^2.4.2
 
 # Falls hier etwas hinzugefügt wird, MUSS ab jetzt ein Kommentar hinzugefügt:
 # * warum der dependency_override hinzugefügt wird.
 # * ab wann der override entfernt werden kann.
-dependency_overrides:
-  # Dieser dependency_override wird verwendet, damit Videos auf macOS
-  # ebenfalls abgespielt werden können. Sobald die Pull Request
-  # (https://github.com/flutter/plugins/pull/3712) gemergt ist, kann
-  # der override wieder entfernt werden.
-  video_player:
-    git:
-      url: https://github.com/cbenhagen/plugins.git
-      path: packages/video_player/video_player
-      ref: video_player_macos_new
+# dependency_overrides:
 
 dev_dependencies:
   build_runner: ^2.1.4


### PR DESCRIPTION
## Description
As in #237 described were we unable to build for Android. This PR fixes this problem. There were several problems:

* We needed to upgrade `com.android.tools.build:gradle` to `4.1.0`
  * This fixed `Execution failed for task ':fast_rsa:stripDebugDebugSymbols'.` from #237
* But this introduced a new issue: `Could not determine artifacts for com.google.android.exoplayer:exoplayer-hls:2.12.1: Skipped due to earlier error`.
  * To fix this issue, I needed to remove the dependency overwrite for the `video_player` package.
  * This fix drops the macOS support the video player. Therefore, macOS users can't view a video inside the Sharezone App anymore. Sharezone will automatically download the video and open it with the video player installed on the machine.

Builds with proves the fix:
* https://codemagic.io/app/6274fcfc87c748ce531c7376/build/6284dfaa178d24983d85cb60
* https://github.com/SharezoneApp/sharezone-app/runs/6488373836?check_suite_focus=true

This unblocks:
* #230
* #235

Fixes #237