### PR TITLE
Use correct iOS bundle ID for dev environment

### DIFF
--- a/app/ios/Runner.xcodeproj/project.pbxproj
+++ b/app/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 46;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -666,7 +666,7 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				MARKETING_VERSION = 1.4.5;
-				PRODUCT_BUNDLE_IDENTIFIER = de.codingbrain.sharezone.app;
+				PRODUCT_BUNDLE_IDENTIFIER = de.codingbrain.sharezone.app.dev;
 				PRODUCT_NAME = Runner;
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -752,7 +752,7 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				MARKETING_VERSION = 1.4.5;
-				PRODUCT_BUNDLE_IDENTIFIER = de.codingbrain.sharezone.app;
+				PRODUCT_BUNDLE_IDENTIFIER = de.codingbrain.sharezone.app.dev;
 				PRODUCT_NAME = Runner;
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -836,7 +836,7 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				MARKETING_VERSION = 1.4.5;
-				PRODUCT_BUNDLE_IDENTIFIER = de.codingbrain.sharezone.app;
+				PRODUCT_BUNDLE_IDENTIFIER = de.codingbrain.sharezone.app.dev;
 				PRODUCT_NAME = Runner;
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
## Description
It seems so that we just for all the time the wrong bundle ID in the dev environment. With this PR, we are now using the `de.codingbrain.sharezone.app.dev` bundle ID for the dev environment.

I didn’t test everything manually but signing in and loading data Firestore works (needed to add the bundle ID `de.codingbrain.sharezone.app.dev` to the API restrictions)  

## Related Tickets
Fixes #248 