### PR TITLE
Use one line instead of two lines for `dart-define` argument when running iOS integration tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,7 +116,7 @@ jobs:
   
   ios-integration-test:
     runs-on: macos-latest
-    if: ${{ github.event.pull_request.draft == false }}
+    # if: ${{ github.event.pull_request.draft == false }}
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,7 +116,7 @@ jobs:
   
   ios-integration-test:
     runs-on: macos-latest
-    # if: ${{ github.event.pull_request.draft == false }}
+    if: ${{ github.event.pull_request.draft == false }}
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -150,10 +150,8 @@ jobs:
             --driver=test_driver/integration_test.dart \
             --target=integration_test/app_test.dart \
             --flavor dev \
-            --dart-define \
-            USER_1_EMAIL=$USER_1_EMAIL \
-            --dart-define \
-            USER_1_PASSWORD=$USER_1_PASSWORD \
+            --dart-define=USER_1_EMAIL=$USER_1_EMAIL \
+            --dart-define=USER_1_PASSWORD=$USER_1_PASSWORD \
             -d $SIMULATOR_UDID
 
   # We are building for every PR a web preview, which will be deployed to


### PR DESCRIPTION
IMHO look this better.