### PR TITLE
Use `themeMode` in SharezoneMaterialApp.

### DIFF
--- a/app/lib/main/sharezone_material_app.dart
+++ b/app/lib/main/sharezone_material_app.dart
@@ -82,7 +82,6 @@ ThemeMode _getThemeMode(ThemeBrightness themeBrightness) {
       return ThemeMode.light;
     case ThemeBrightness.system:
       return ThemeMode.system;
-    default:
   }
   throw UnimplementedError();
 }

--- a/app/lib/main/sharezone_material_app.dart
+++ b/app/lib/main/sharezone_material_app.dart
@@ -49,12 +49,9 @@ class SharezoneMaterialApp extends StatelessWidget {
         debugShowCheckedModeBanner: false,
         title: PlatformCheck.isWeb ? "Sharezone Web-App" : "Sharezone",
         color: primaryColor,
-        darkTheme: themeSettings.themeBrightness == ThemeBrightness.system
-            ? _darkTheme
-            : null,
-        theme: themeSettings.themeBrightness == ThemeBrightness.dark
-            ? _darkTheme
-            : _lightTheme,
+        darkTheme: _darkTheme,
+        theme: _lightTheme,
+        themeMode: _getThemeMode(themeSettings.themeBrightness),
         localizationsDelegates: const [
           GlobalMaterialLocalizations.delegate,
           GlobalWidgetsLocalizations.delegate,
@@ -75,4 +72,17 @@ class SharezoneMaterialApp extends StatelessWidget {
       ),
     );
   }
+}
+
+ThemeMode _getThemeMode(ThemeBrightness themeBrightness) {
+  switch (themeBrightness) {
+    case ThemeBrightness.dark:
+      return ThemeMode.dark;
+    case ThemeBrightness.light:
+      return ThemeMode.light;
+    case ThemeBrightness.system:
+      return ThemeMode.system;
+    default:
+  }
+  throw UnimplementedError();
 }


### PR DESCRIPTION
From `themeMode` docs:
> Determines which theme will be used by the application if both [theme] and [darkTheme] are provided.
> 
> If set to [ThemeMode.system], the choice of which theme to use will be based on the user's system preferences. If the [MediaQuery.platformBrightnessOf] is [Brightness.light], [theme] will be used. If it is [Brightness.dark], [darkTheme] will be used (unless it is null, in which case [theme] will be used.
> 
> If set to [ThemeMode.light] the [theme] will always be used, regardless of the user's system preference.
> 
> If set to [ThemeMode.dark] the [darkTheme] will be used regardless of the user's system preference. If [darkTheme] is null then it will fallback to using [theme].
> 
> The default value is [ThemeMode.system].