### PR TITLE
Upgrade `subosito/flutter-action` in CI from v1 to v2

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -39,7 +39,7 @@ jobs:
       uses: kuhnroyal/flutter-fvm-config-action@v1
 
     - name: Install Flutter
-      uses: subosito/flutter-action@v1
+      uses: subosito/flutter-action@v2
       with:
         flutter-version: ${{ env.FLUTTER_VERSION }}
         channel: ${{ env.FLUTTER_CHANNEL }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Set Flutter version from FVM config file to environment variables
         uses: kuhnroyal/flutter-fvm-config-action@v1
 
-      - uses: subosito/flutter-action@v1
+      - uses: subosito/flutter-action@1e6ee87cb840500837bcd50a667fb28815d8e310 # v2.7.1
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: ${{ env.FLUTTER_CHANNEL }}
@@ -82,7 +82,7 @@ jobs:
       - name: Set Flutter version from FVM config file to environment variables
         uses: kuhnroyal/flutter-fvm-config-action@v1
 
-      - uses: subosito/flutter-action@v1
+      - uses: subosito/flutter-action@1e6ee87cb840500837bcd50a667fb28815d8e310 # v2.7.1
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: ${{ env.FLUTTER_CHANNEL }}
@@ -124,7 +124,7 @@ jobs:
       - name: Set Flutter version from FVM config file to environment variables
         uses: kuhnroyal/flutter-fvm-config-action@v1
 
-      - uses: subosito/flutter-action@v1
+      - uses: subosito/flutter-action@1e6ee87cb840500837bcd50a667fb28815d8e310 # v2.7.1
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: ${{ env.FLUTTER_CHANNEL }}
@@ -176,7 +176,7 @@ jobs:
       - name: Set Flutter version from FVM config file to environment variables
         uses: kuhnroyal/flutter-fvm-config-action@v1
 
-      - uses: subosito/flutter-action@v1
+      - uses: subosito/flutter-action@1e6ee87cb840500837bcd50a667fb28815d8e310 # v2.7.1
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: ${{ env.FLUTTER_CHANNEL }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Set Flutter version from FVM config file to environment variables
         uses: kuhnroyal/flutter-fvm-config-action@v1
 
-      - uses: subosito/flutter-action@1e6ee87cb840500837bcd50a667fb28815d8e310 # v2.7.1
+      - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: ${{ env.FLUTTER_CHANNEL }}
@@ -82,7 +82,7 @@ jobs:
       - name: Set Flutter version from FVM config file to environment variables
         uses: kuhnroyal/flutter-fvm-config-action@v1
 
-      - uses: subosito/flutter-action@1e6ee87cb840500837bcd50a667fb28815d8e310 # v2.7.1
+      - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: ${{ env.FLUTTER_CHANNEL }}
@@ -124,7 +124,7 @@ jobs:
       - name: Set Flutter version from FVM config file to environment variables
         uses: kuhnroyal/flutter-fvm-config-action@v1
 
-      - uses: subosito/flutter-action@1e6ee87cb840500837bcd50a667fb28815d8e310 # v2.7.1
+      - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: ${{ env.FLUTTER_CHANNEL }}
@@ -176,7 +176,7 @@ jobs:
       - name: Set Flutter version from FVM config file to environment variables
         uses: kuhnroyal/flutter-fvm-config-action@v1
 
-      - uses: subosito/flutter-action@1e6ee87cb840500837bcd50a667fb28815d8e310 # v2.7.1
+      - uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: ${{ env.FLUTTER_CHANNEL }}


### PR DESCRIPTION
Sometimes is our `ios-integration-testing` workflow failing because of:

```
Assertion failed: (timeout != -1), function uv__io_poll, file ../deps/uv/src/unix/kqueue.c, line 256.
```

![image](https://user-images.githubusercontent.com/24459435/192727315-a8dba471-f0aa-4d00-9c2e-1ed09d8cc644.png)

Therefore, I created a ticket https://github.com/subosito/flutter-action/issues/189 in the repository of the action. The maintainer recommended me to upgrade to v2.