### PR TITLE
Set permissions for workflows to follow a good security practice.

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -29,12 +29,11 @@ on:
 env:
   CI_CD_DART_SCRIPTS_PACKAGE_PATH: "tools/sz_repo_cli/"
 
-# Declare default permissions as none.
+# Set permissions to none.
 #
-# Having workflows without setting the permission for the workflow is considered
-# a bad security practice and it is causing alerts from our scanning tools.
+# Using the broad default permissions is considered a bad security practice 
+# and would cause alerts from our scanning tools.
 permissions: {}
-
 jobs:
   deploy-alpha-web-app:
     runs-on: ubuntu-latest

--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -29,6 +29,12 @@ on:
 env:
   CI_CD_DART_SCRIPTS_PACKAGE_PATH: "tools/sz_repo_cli/"
 
+# Declare default permissions as none.
+#
+# Having workflows without setting the permission for the workflow is considered
+# a bad security practice and it is causing alerts from our scanning tools.
+permissions: {}
+
 jobs:
   deploy-alpha-web-app:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,7 +162,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write # for FirebaseExtended/action-hosting-deploy to comment on PRs
-      checks: write
+      checks: write # for FirebaseExtended/action-hosting-deploy
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,18 +162,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write # for FirebaseExtended/action-hosting-deploy to comment on PRs
-      contents: read
-      # actions: write
       checks: write
-      # deployments: write #--
-      # statuses: write
-      # repository-projects: write
-      # discussions: write #---
-      # id-token: write
-      # issues: write
-      # packages: write
-      # pages: write
-      # security-events: write
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,9 +162,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write # for FirebaseExtended/action-hosting-deploy to comment on PRs
-      contents: write
-      # actions: write
-      # checks: write
+      contents: read
+      actions: write
+      checks: write
       # deployments: write #--
       # statuses: write
       # repository-projects: write

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,12 @@ on:
 env:
   CI_CD_DART_SCRIPTS_PACKAGE_PATH: "tools/sz_repo_cli/"
 
+# Declare default permissions as none.
+#
+# Having workflows without setting the permission for the workflow is considered
+# a bad security practice and it is causing alerts from our scanning tools.
+permissions: {}
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   analyze:
@@ -154,6 +160,8 @@ jobs:
   # 4. Adjust website restrictions for Firebase Key "Sharezone Web Key".
   web-preview:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,18 +162,18 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write # for FirebaseExtended/action-hosting-deploy to comment on PRs
-      contents: read
-      actions: read
-      checks: read
-      deployments: read #--
-      statuses: read
-      repository-projects: read
-      discussions: read #---
+      contents: write
+      actions: write
+      checks: write
+      deployments: write #--
+      statuses: write
+      repository-projects: write
+      discussions: write #---
       id-token: write
-      issues: read
-      packages: read
-      pages: read
-      security-events: read
+      issues: write
+      packages: write
+      pages: write
+      security-events: write
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -164,7 +164,6 @@ jobs:
       pull-requests: write # for FirebaseExtended/action-hosting-deploy to comment on PRs
       contents: read
       actions: read
-      id-token: read
       checks: read
       deployments: read
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -168,7 +168,12 @@ jobs:
       deployments: read #--
       statuses: read
       repository-projects: read
-      discussions: read
+      discussions: read #---
+      id-token: read
+      issues: read
+      packages: read
+      pages: read
+      security-events: read
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,6 +162,18 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      actions: write
+      checks: write
+      contents: write
+      deployments: write
+      discussions: write
+      id-token: write
+      issues: write
+      packages: write
+      pages: write
+      repository-projects: write
+      security-events: write
+      statuses: write
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -163,7 +163,7 @@ jobs:
     permissions:
       pull-requests: write # for FirebaseExtended/action-hosting-deploy to comment on PRs
       contents: read
-      actions: write
+      # actions: write
       checks: write
       # deployments: write #--
       # statuses: write

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,10 +21,10 @@ on:
 env:
   CI_CD_DART_SCRIPTS_PACKAGE_PATH: "tools/sz_repo_cli/"
 
-# Declare default permissions as none.
+# Set permissions to none.
 #
-# Having workflows without setting the permission for the workflow is considered
-# a bad security practice and it is causing alerts from our scanning tools.
+# Using the broad default permissions is considered a bad security practice 
+# and would cause alerts from our scanning tools.
 permissions: {}
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,7 +162,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write # for FirebaseExtended/action-hosting-deploy to comment on PRs
-      checks: write # for FirebaseExtended/action-hosting-deploy to comment on PRs (without write permissions for checks the action doesn't post a comment to the PR)
+      checks: write # for FirebaseExtended/action-hosting-deploy to comment on PRs (without write permissions for checks the action doesn't post a comment to the PR, we don't know why)
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -165,7 +165,10 @@ jobs:
       contents: read
       actions: read
       checks: read
-      deployments: read
+      deployments: read #--
+      statuses: read
+      repository-projects: read
+      discussions: read
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -169,7 +169,7 @@ jobs:
       statuses: read
       repository-projects: read
       discussions: read #---
-      id-token: read
+      id-token: write
       issues: read
       packages: read
       pages: read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -167,13 +167,13 @@ jobs:
       checks: write
       deployments: write #--
       statuses: write
-      repository-projects: write
-      discussions: write #---
-      id-token: write
-      issues: write
-      packages: write
-      pages: write
-      security-events: write
+      # repository-projects: write
+      # discussions: write #---
+      # id-token: write
+      # issues: write
+      # packages: write
+      # pages: write
+      # security-events: write
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -164,6 +164,9 @@ jobs:
       pull-requests: write # for FirebaseExtended/action-hosting-deploy to comment on PRs
       contents: read
       actions: read
+      id-token: read
+      checks: read
+      deployments: read
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -163,10 +163,10 @@ jobs:
     permissions:
       pull-requests: write # for FirebaseExtended/action-hosting-deploy to comment on PRs
       contents: write
-      actions: write
-      checks: write
-      deployments: write #--
-      statuses: write
+      # actions: write
+      # checks: write
+      # deployments: write #--
+      # statuses: write
       # repository-projects: write
       # discussions: write #---
       # id-token: write

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,7 +162,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write # for FirebaseExtended/action-hosting-deploy to comment on PRs
-      checks: write # for FirebaseExtended/action-hosting-deploy
+      checks: write # for FirebaseExtended/action-hosting-deploy to comment on PRs (without write permissions for checks the action doesn't post a comment to the PR)
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -163,6 +163,7 @@ jobs:
     permissions:
       pull-requests: write # for FirebaseExtended/action-hosting-deploy to comment on PRs
       contents: read
+      actions: read
     steps:
       - uses: actions/checkout@v2
 
@@ -181,8 +182,8 @@ jobs:
       - name: Deploy to Firebase Hosting (sharezone-debug)
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:
-          repoToken: '${{ secrets.GITHUB_TOKEN }}'
-          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_SHAREZONE_DEBUG }}'
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_SHAREZONE_DEBUG }}
           projectId: sharezone-debug
           entryPoint: "./app"
           expires: '7d'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -161,19 +161,8 @@ jobs:
   web-preview:
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
-      actions: write
-      checks: write
-      contents: write
-      deployments: write
-      discussions: write
-      id-token: write
-      issues: write
-      packages: write
-      pages: write
-      repository-projects: write
-      security-events: write
-      statuses: write
+      pull-requests: write # for FirebaseExtended/action-hosting-deploy to comment on PRs
+      contents: read
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Having workflows without setting the permission for the workflow is considered a bad security practice and it is causing alerts from our scanning tools.