### PR TITLE
Fix android build (`Could not resolve com.github.MatrixFrog:android-scalablevideoview:v1.0.4-jitpack.`)

### DIFF
--- a/app/android/build.gradle
+++ b/app/android/build.gradle
@@ -18,6 +18,13 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+
+        // Workaround for https://github.com/saibotma/jitsi_meet_wrapper/issues/53
+        jcenter() {
+            content {
+                includeModule("com.yqritc", "android-scalablevideoview")
+            }
+        }
     }
 }
 

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -1066,14 +1066,14 @@ packages:
       name: jitsi_meet_wrapper
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.4"
+    version: "0.0.5"
   jitsi_meet_wrapper_platform_interface:
     dependency: transitive
     description:
       name: jitsi_meet_wrapper_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.2"
+    version: "0.0.3"
   js:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -89,7 +89,7 @@ dependencies:
   hausaufgabenheft_logik:
     path: ../lib/hausaufgabenheft_logik
   intl: ^0.17.0
-  jitsi_meet_wrapper: ^0.0.4
+  jitsi_meet_wrapper: ^0.0.5
   key_value_store:
     path: ../lib/key_value_store
   last_online_reporting:


### PR DESCRIPTION
Found this workaround here: https://github.com/react-native-video/react-native-video/issues/2454#issuecomment-913709132

Seems to work: https://codemagic.io/app/629c82ea463af7ff553fc7a5/build/63343dafb31705033692a7fa

This PR is extracted from #257