### PR TITLE
Add more tests to the `time` package

### DIFF
--- a/lib/time/test/time_test.dart
+++ b/lib/time/test/time_test.dart
@@ -74,14 +74,6 @@ void main() {
     expect(Time(hour: 0) == Time(hour: 1), false);
   });
 
-  test('.add()', () {
-    expect(Time(hour: 0).add(Duration(hours: 1)), Time(hour: 1));
-    expect(Time(hour: 0).add(Duration(minutes: 23)), Time(hour: 0, minute: 23));
-    expect(Time(hour: 0).add(Duration(minutes: 70)), Time(hour: 1, minute: 10));
-    expect(Time(hour: 23).add(Duration(hours: 2)), Time(hour: 1));
-    expect(Time(hour: 23).add(Duration(hours: 2)), Time(hour: 1));
-  });
-
   test('.differenceInMinutes()', () {
     expect(Time(hour: 1).differenceInMinutes(Time(hour: 2)), 60);
     expect(Time(hour: 2).differenceInMinutes(Time(hour: 1)), 60);

--- a/lib/time/test/time_test.dart
+++ b/lib/time/test/time_test.dart
@@ -45,6 +45,13 @@ void main() {
     });
   });
 
+  test('.hour', () {
+    expect(Time(hour: 0).hour, 0);
+    expect(Time(hour: 1).hour, 1);
+    expect(Time(hour: 1, minute: 1).hour, 1);
+    expect(Time(hour: 1, minute: 12).hour, 1);
+  });
+
   test('plus operator', () {
     expect(am8.add(const Duration(minutes: 45)), Time(hour: 8, minute: 45));
     expect(am8.add(const Duration(minutes: 60)), Time(hour: 9, minute: 0));

--- a/lib/time/test/time_test.dart
+++ b/lib/time/test/time_test.dart
@@ -98,6 +98,12 @@ void main() {
     expect('${Time(hour: 12, minute: 59)}', '12:59');
   });
 
+  test('.compareTo', () {
+    expect(Time(hour: 5).compareTo(Time(hour: 5)), 0);
+    expect(Time(hour: 5).compareTo(Time(hour: 0)), 1);
+    expect(Time(hour: 0).compareTo(Time(hour: 5)), -1);
+  });
+
   test('plus operator', () {
     expect(am8.add(const Duration(minutes: 45)), Time(hour: 8, minute: 45));
     expect(am8.add(const Duration(minutes: 60)), Time(hour: 9, minute: 0));

--- a/lib/time/test/time_test.dart
+++ b/lib/time/test/time_test.dart
@@ -74,6 +74,13 @@ void main() {
     expect(Time(hour: 0) == Time(hour: 1), false);
   });
 
+  test('.add()', () {
+    expect(Time(hour: 0).add(Duration(hours: 1)), Time(hour: 1));
+    expect(Time(hour: 0).add(Duration(minutes: 23)), Time(hour: 0, minute: 23));
+    expect(Time(hour: 0).add(Duration(minutes: 70)), Time(hour: 1, minute: 10));
+    expect(Time(hour: 23).add(Duration(hours: 2)), Time(hour: 1));
+  });
+
   test('plus operator', () {
     expect(am8.add(const Duration(minutes: 45)), Time(hour: 8, minute: 45));
     expect(am8.add(const Duration(minutes: 60)), Time(hour: 9, minute: 0));

--- a/lib/time/test/time_test.dart
+++ b/lib/time/test/time_test.dart
@@ -52,6 +52,13 @@ void main() {
     expect(Time(hour: 1, minute: 12).hour, 1);
   });
 
+  test('.minute', () {
+    expect(Time(hour: 0, minute: 0).minute, 0);
+    expect(Time(hour: 0, minute: 1).minute, 1);
+    expect(Time(hour: 0, minute: 10).minute, 10);
+    expect(Time(hour: 1, minute: 10).minute, 10);
+  });
+
   test('plus operator', () {
     expect(am8.add(const Duration(minutes: 45)), Time(hour: 8, minute: 45));
     expect(am8.add(const Duration(minutes: 60)), Time(hour: 9, minute: 0));

--- a/lib/time/test/time_test.dart
+++ b/lib/time/test/time_test.dart
@@ -68,6 +68,12 @@ void main() {
     expect(Time(hour: 1).totalMinutes, 60);
   });
 
+  test('==', () {
+    expect(Time(hour: 1, minute: 1), Time(hour: 1, minute: 1));
+    expect(Time(hour: 0), Time(hour: 0));
+    expect(Time(hour: 0) == Time(hour: 1), false);
+  });
+
   test('plus operator', () {
     expect(am8.add(const Duration(minutes: 45)), Time(hour: 8, minute: 45));
     expect(am8.add(const Duration(minutes: 60)), Time(hour: 9, minute: 0));

--- a/lib/time/test/time_test.dart
+++ b/lib/time/test/time_test.dart
@@ -6,6 +6,7 @@
 //
 // SPDX-License-Identifier: EUPL-1.2
 
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:time/time.dart';
 
@@ -112,6 +113,21 @@ void main() {
       Time(hour: 1),
       skip:
           'Not working because .fromTotalMinutes() needs to do modulo 24. Ticket: https://github.com/SharezoneApp/sharezone-app/issues/303',
+    );
+  });
+
+  test('.fromTimeOfDay()', () {
+    expect(
+      Time.fromTimeOfDay(TimeOfDay(hour: 1, minute: 1)),
+      Time(hour: 1, minute: 1),
+    );
+    expect(
+      Time.fromTimeOfDay(TimeOfDay(hour: 0, minute: 0)),
+      Time(hour: 0, minute: 0),
+    );
+    expect(
+      Time.fromTimeOfDay(TimeOfDay(hour: 10, minute: 10)),
+      Time(hour: 10, minute: 10),
     );
   });
 

--- a/lib/time/test/time_test.dart
+++ b/lib/time/test/time_test.dart
@@ -142,6 +142,13 @@ void main() {
     expect(Time(hour: 0).hashCode, '00:00'.hashCode);
   });
 
+  test('.toTimeOfDay()', () {
+    expect(
+      Time(hour: 0, minute: 1).toTimeOfDay(),
+      TimeOfDay(hour: 0, minute: 1),
+    );
+  });
+
   test('plus operator', () {
     expect(am8.add(const Duration(minutes: 45)), Time(hour: 8, minute: 45));
     expect(am8.add(const Duration(minutes: 60)), Time(hour: 9, minute: 0));

--- a/lib/time/test/time_test.dart
+++ b/lib/time/test/time_test.dart
@@ -91,6 +91,13 @@ void main() {
     );
   });
 
+  test('.time', () {
+    expect(Time(hour: 2).time, '02:00');
+    expect(Time(hour: 2, minute: 1).time, '02:01');
+    expect(Time(hour: 2, minute: 10).time, '02:10');
+    expect(Time(hour: 12, minute: 59).time, '12:59');
+  });
+
   test('.toString()', () {
     expect('${Time(hour: 2)}', '02:00');
     expect('${Time(hour: 2, minute: 1)}', '02:01');

--- a/lib/time/test/time_test.dart
+++ b/lib/time/test/time_test.dart
@@ -131,6 +131,13 @@ void main() {
     );
   });
 
+  test('.parse()', () {
+    expect(Time.parse('00:01'), Time(hour: 0, minute: 1));
+    expect(Time.parse('00:00'), Time(hour: 0, minute: 0));
+    expect(Time.parse('00:10'), Time(hour: 0, minute: 10));
+    expect(Time.parse('23:59'), Time(hour: 23, minute: 59));
+  });
+
   test('plus operator', () {
     expect(am8.add(const Duration(minutes: 45)), Time(hour: 8, minute: 45));
     expect(am8.add(const Duration(minutes: 60)), Time(hour: 9, minute: 0));

--- a/lib/time/test/time_test.dart
+++ b/lib/time/test/time_test.dart
@@ -91,6 +91,13 @@ void main() {
     );
   });
 
+  test('.toString()', () {
+    expect('${Time(hour: 2)}', '02:00');
+    expect('${Time(hour: 2, minute: 1)}', '02:01');
+    expect('${Time(hour: 2, minute: 10)}', '02:10');
+    expect('${Time(hour: 12, minute: 59)}', '12:59');
+  });
+
   test('plus operator', () {
     expect(am8.add(const Duration(minutes: 45)), Time(hour: 8, minute: 45));
     expect(am8.add(const Duration(minutes: 60)), Time(hour: 9, minute: 0));

--- a/lib/time/test/time_test.dart
+++ b/lib/time/test/time_test.dart
@@ -79,6 +79,16 @@ void main() {
     expect(Time(hour: 0).add(Duration(minutes: 23)), Time(hour: 0, minute: 23));
     expect(Time(hour: 0).add(Duration(minutes: 70)), Time(hour: 1, minute: 10));
     expect(Time(hour: 23).add(Duration(hours: 2)), Time(hour: 1));
+    expect(Time(hour: 23).add(Duration(hours: 2)), Time(hour: 1));
+  });
+
+  test('.differenceInMinutes()', () {
+    expect(Time(hour: 1).differenceInMinutes(Time(hour: 2)), 60);
+    expect(Time(hour: 2).differenceInMinutes(Time(hour: 1)), 60);
+    expect(
+      Time(hour: 0, minute: 30).differenceInMinutes(Time(hour: 0, minute: 40)),
+      10,
+    );
   });
 
   test('plus operator', () {

--- a/lib/time/test/time_test.dart
+++ b/lib/time/test/time_test.dart
@@ -138,6 +138,10 @@ void main() {
     expect(Time.parse('23:59'), Time(hour: 23, minute: 59));
   });
 
+  test('.hashCode', () {
+    expect(Time(hour: 0).hashCode, '00:00'.hashCode);
+  });
+
   test('plus operator', () {
     expect(am8.add(const Duration(minutes: 45)), Time(hour: 8, minute: 45));
     expect(am8.add(const Duration(minutes: 60)), Time(hour: 9, minute: 0));

--- a/lib/time/test/time_test.dart
+++ b/lib/time/test/time_test.dart
@@ -104,6 +104,18 @@ void main() {
     expect(Time(hour: 0).compareTo(Time(hour: 5)), -1);
   });
 
+  test('.copyWithAddedMinutes()', () {
+    expect(Time(hour: 0).copyWithAddedMinutes((60)), Time(hour: 1));
+    expect(Time(hour: 0).copyWithAddedMinutes(23), Time(hour: 0, minute: 23));
+    expect(Time(hour: 0).copyWithAddedMinutes(70), Time(hour: 1, minute: 10));
+    expect(
+      Time(hour: 23).copyWithAddedMinutes(120),
+      Time(hour: 1),
+      skip:
+          'Not working because .fromTotalMinutes() needs to do modulo 24. Ticket: https://github.com/SharezoneApp/sharezone-app/issues/303',
+    );
+  });
+
   test('plus operator', () {
     expect(am8.add(const Duration(minutes: 45)), Time(hour: 8, minute: 45));
     expect(am8.add(const Duration(minutes: 60)), Time(hour: 9, minute: 0));

--- a/lib/time/test/time_test.dart
+++ b/lib/time/test/time_test.dart
@@ -59,6 +59,15 @@ void main() {
     expect(Time(hour: 1, minute: 10).minute, 10);
   });
 
+  test('.totalMinutes', () {
+    expect(Time(hour: 0, minute: 0).totalMinutes, 0);
+    expect(Time(hour: 0, minute: 1).totalMinutes, 1);
+    expect(Time(hour: 0, minute: 10).totalMinutes, 10);
+    expect(Time(hour: 1, minute: 10).totalMinutes, 70);
+    expect(Time(hour: 1, minute: 0).totalMinutes, 60);
+    expect(Time(hour: 1).totalMinutes, 60);
+  });
+
   test('plus operator', () {
     expect(am8.add(const Duration(minutes: 45)), Time(hour: 8, minute: 45));
     expect(am8.add(const Duration(minutes: 60)), Time(hour: 9, minute: 0));


### PR DESCRIPTION
Just adding more tests to prepare migration to null safety. From 44.7% code coverage to 95.7% (only the `Time.now()` method is missing).