### PR TITLE
Remove `Time.copyWithAddedMinutes` and add `Time.isNextDayWith`

### DIFF
--- a/lib/time/lib/src/time.dart
+++ b/lib/time/lib/src/time.dart
@@ -34,7 +34,7 @@ class Time {
   }
 
   factory Time.fromTotalMinutes(int totalMinutes) {
-    final hour = totalMinutes ~/ 60;
+    final hour = (totalMinutes ~/ 60) % 24;
     final minute = totalMinutes.remainder(60);
     return Time(hour: hour, minute: minute);
   }
@@ -81,6 +81,13 @@ class Time {
     return Time(hour: hours, minute: minutes);
   }
 
+  /// Returns a bool indicating whether the new time added to the [duration] is
+  /// a new day.
+  bool isNextDayWith(Duration duration) {
+    final minutesOfADay = 24 * 60;
+    return totalMinutes + duration.inMinutes >= minutesOfADay;
+  }
+
   bool isBefore(Time other) {
     return totalMinutes < other.totalMinutes;
   }
@@ -95,11 +102,6 @@ class Time {
 
   int compareTo(Time other) {
     return totalMinutes.compareTo(other.totalMinutes);
-  }
-
-  Time copyWithAddedMinutes(int addedMinutes) {
-    final newTotalMinutes = totalMinutes + addedMinutes;
-    return Time.fromTotalMinutes(newTotalMinutes);
   }
 
   @override

--- a/lib/time/test/time_test.dart
+++ b/lib/time/test/time_test.dart
@@ -104,16 +104,17 @@ void main() {
     expect(Time(hour: 0).compareTo(Time(hour: 5)), -1);
   });
 
-  test('.copyWithAddedMinutes()', () {
-    expect(Time(hour: 0).copyWithAddedMinutes((60)), Time(hour: 1));
-    expect(Time(hour: 0).copyWithAddedMinutes(23), Time(hour: 0, minute: 23));
-    expect(Time(hour: 0).copyWithAddedMinutes(70), Time(hour: 1, minute: 10));
-    expect(
-      Time(hour: 23).copyWithAddedMinutes(120),
-      Time(hour: 1),
-      skip:
-          'Not working because .fromTotalMinutes() needs to do modulo 24. Ticket: https://github.com/SharezoneApp/sharezone-app/issues/303',
-    );
+  test('.fromTotalMinutes()', () {
+    expect(Time.fromTotalMinutes(0), Time(hour: 0));
+    expect(Time.fromTotalMinutes(70), Time(hour: 1, minute: 10));
+    expect(Time.fromTotalMinutes(24 * 60 + 10), Time(hour: 0, minute: 10));
+  });
+
+  test('.isNextDayWith()', () {
+    expect(Time(hour: 0, minute: 0).isNextDayWith(Duration(hours: 1)), false);
+    expect(Time(hour: 0, minute: 0).isNextDayWith(Duration(hours: 10)), false);
+    expect(Time(hour: 23, minute: 0).isNextDayWith(Duration(hours: 1)), true);
+    expect(Time(hour: 23, minute: 0).isNextDayWith(Duration(hours: 2)), true);
   });
 
   test('.fromTimeOfDay()', () {

--- a/lib/user/lib/src/models/timetable/period.dart
+++ b/lib/user/lib/src/models/timetable/period.dart
@@ -169,12 +169,17 @@ class Periods {
           number: 1, startTime: Time(hour: 7), endTime: Time(hour: 8));
     } else {
       final lastPeriod = getPeriods()?.last;
-      final durationOfLastPeriod =
+      final minutesOfLastPeriod =
           lastPeriod.endTime.differenceInMinutes(lastPeriod.startTime);
       final newEndTime =
-          lastPeriod.endTime.copyWithAddedMinutes(durationOfLastPeriod);
+          lastPeriod.endTime.add(Duration(minutes: minutesOfLastPeriod));
 
-      if (newEndTime.isAfter(Time(hour: 24))) return null;
+      final wouldBeNextDay = lastPeriod.endTime
+          .isNextDayWith(Duration(minutes: minutesOfLastPeriod));
+      if (wouldBeNextDay) {
+        // When the new period would be longer than a day, we don't add it.
+        return null;
+      }
 
       final newPeriod = Period(
           number: lastPeriod.number + 1,

--- a/lib/user/lib/src/models/timetable/period.dart
+++ b/lib/user/lib/src/models/timetable/period.dart
@@ -171,8 +171,6 @@ class Periods {
       final lastPeriod = getPeriods()?.last;
       final minutesOfLastPeriod =
           lastPeriod.endTime.differenceInMinutes(lastPeriod.startTime);
-      final newEndTime =
-          lastPeriod.endTime.add(Duration(minutes: minutesOfLastPeriod));
 
       final wouldBeNextDay = lastPeriod.endTime
           .isNextDayWith(Duration(minutes: minutesOfLastPeriod));
@@ -180,6 +178,8 @@ class Periods {
         // When the new period would be longer than a day, we don't add it.
         return null;
       }
+      final newEndTime =
+          lastPeriod.endTime.add(Duration(minutes: minutesOfLastPeriod));
 
       final newPeriod = Period(
           number: lastPeriod.number + 1,


### PR DESCRIPTION
Just a quick refactoring of remove `Time.copyWithAddedMinutes` and adding `Time.isNextDayWith`. `Time.copyWithAddedMinutes` has been used in the timetable settings to configure the period times.

Manually testing:

https://user-images.githubusercontent.com/24459435/192994797-142927c4-6cf6-452c-962b-c9f32d45c2b0.MP4


Closes #303