### PR TITLE
Set up empty documentation page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1,0 +1,8 @@
+{
+    "name": "docs.page",
+    "theme": "#36B9B9",
+    "sidebar": [
+      ["Home", "/"],
+      ["Another Page", "/another-page"],
+    ]
+  }

--- a/docs.json
+++ b/docs.json
@@ -1,6 +1,6 @@
 {
-    "name": "docs.page",
-    "theme": "#36B9B9",
+    "name": "Sharezone Docs",
+    "theme": "#6BB7E6",
     "sidebar": [
       ["Home", "/"],
       ["Another Page", "/another-page"],

--- a/docs/another-page.mdx
+++ b/docs/another-page.mdx
@@ -1,0 +1,1 @@
+# Another Page

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,0 +1,1 @@
+# Example Docs!

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,1 +1,3 @@
 # Example Docs!
+
+This page is work in progess.


### PR DESCRIPTION
Setting up an empty documentation page to start configure our documentation. The work of this documentation page will be done in the future pull requests. Just an empty documentation page to set up easier something like DNS config and have docs preview for future docs PR (with the docs.page app).

After merging this PR the docs will be available under https://docs.page/SharezoneApp/sharezone-app.

Closes #342