### PR TITLE
update focusmanager to the "new" one

### DIFF
--- a/app/lib/auth/email_and_password_link_page.dart
+++ b/app/lib/auth/email_and_password_link_page.dart
@@ -100,8 +100,9 @@ class _EmailAndPasswordLinkPageState extends State<EmailAndPasswordLinkPage> {
                             children: <Widget>[
                               NameField(
                                 focusNode: nameFocusNode,
-                                onEditingComplete: () => FocusScope.of(context)
-                                    .requestFocus(emailFocusNode),
+                                onEditingComplete: () => FocusManager
+                                    .instance.primaryFocus
+                                    .unfocus(),
                                 initialName: widget.user.name,
                                 nameStream: bloc.name,
                                 onChanged: bloc.changeName,

--- a/app/lib/auth/login_page.dart
+++ b/app/lib/auth/login_page.dart
@@ -384,7 +384,7 @@ class EmailLoginField extends StatelessWidget {
           focusNode: emailFocusNode,
           onChanged: (email) => onChanged(email.trim()),
           onEditingComplete: () =>
-              FocusScope.of(context).requestFocus(passwordFocusNode),
+              FocusManager.instance.primaryFocus?.unfocus(),
           keyboardType: TextInputType.emailAddress,
           textInputAction: TextInputAction.next,
           autofocus: autofocus ?? false,

--- a/app/lib/auth/reset_pw_page.dart
+++ b/app/lib/auth/reset_pw_page.dart
@@ -184,7 +184,7 @@ class _SubmitButton extends StatelessWidget {
         child: ContinueRoundButton(
           tooltip: 'Passwort zurücksetzen',
           onTap: () {
-            FocusScope.of(context).requestFocus(FocusNode());
+            FocusManager.instance.primaryFocus?.unfocus();
             sendDataToFrankfurtSnackBar(context);
             snapshot.hasData && snapshot.data == true
                 ? bloc

--- a/app/lib/comments/widgets/user_comment_field.dart
+++ b/app/lib/comments/widgets/user_comment_field.dart
@@ -53,7 +53,7 @@ class _UserCommentFieldState extends State<UserCommentField> {
                 bloc.addComment(text);
                 text = null;
                 controller.clear();
-                FocusScope.of(context).requestFocus(FocusNode());
+                FocusManager.instance.primaryFocus?.unfocus();
               } else {
                 showSnackSec(
                     context: context,

--- a/app/lib/filesharing/dialog/course_tile.dart
+++ b/app/lib/filesharing/dialog/course_tile.dart
@@ -31,7 +31,7 @@ class CourseTile extends StatelessWidget {
   Future<void> onTap(BuildContext context) async {
     final api = BlocProvider.of<SharezoneContext>(context).api;
 
-    FocusScope.of(context).requestFocus(FocusNode());
+    FocusManager.instance.primaryFocus?.unfocus();
     await Future.delayed(const Duration(milliseconds: 150));
 
     _showCourseListDialog(context, api);

--- a/app/lib/filesharing/dialog/file_card.dart
+++ b/app/lib/filesharing/dialog/file_card.dart
@@ -16,7 +16,7 @@ import 'package:sharezone_widgets/widgets.dart';
 Future<void> showRemoveFileFromBlocDialog(
     {@required BuildContext context,
     @required VoidCallback removeFileFromBlocMethod}) async {
-  FocusScope.of(context).requestFocus(FocusNode()); // Closing keyboard
+  FocusManager.instance.primaryFocus?.unfocus(); // Closing keyboard
   await Future.delayed(const Duration(milliseconds: 200));
 
   showDialog(

--- a/app/lib/groups/group_join/widgets/group_join_text_field.dart
+++ b/app/lib/groups/group_join/widgets/group_join_text_field.dart
@@ -59,7 +59,9 @@ class _GroupJoinTextFieldState extends State<GroupJoinTextField> {
             ),
             child: Theme(
               data: Theme.of(context).copyWith(
-                primaryColor: Colors.white, colorScheme: ColorScheme.fromSwatch().copyWith(secondary: Colors.white),
+                primaryColor: Colors.white,
+                colorScheme:
+                    ColorScheme.fromSwatch().copyWith(secondary: Colors.white),
               ),
               child: TextField(
                 maxLength: 6,
@@ -139,7 +141,7 @@ class _GroupJoinTextFieldState extends State<GroupJoinTextField> {
   }
 
   void _openKeyboardForSharecodeField() {
-    FocusScope.of(context).requestFocus(sharecodeFieldFocusNode);
+    FocusManager.instance.primaryFocus?.unfocus();
   }
 
   Future<void> showCopySharecodeFromClipboardDialog(Sharecode sharecode) async {

--- a/app/lib/groups/src/pages/course/course_edit/course_edit_page.dart
+++ b/app/lib/groups/src/pages/course/course_edit/course_edit_page.dart
@@ -145,7 +145,7 @@ class _SubjectField extends StatelessWidget {
         return PrefilledTextField(
           autofocus: true,
           onEditingComplete: () =>
-              FocusScope.of(context).requestFocus(nextNode),
+              FocusManager.instance.primaryFocus?.unfocus(),
           textInputAction: TextInputAction.next,
           decoration: InputDecoration(
             labelText: "Fach",
@@ -176,7 +176,7 @@ class _AbbreviationField extends StatelessWidget {
       prefilledText: initialAbbreviation,
       textInputAction: TextInputAction.next,
       decoration: InputDecoration(labelText: "Kürzel des Fachs"),
-      onEditingComplete: () => FocusScope.of(context).requestFocus(nextNode),
+      onEditingComplete: () => FocusManager.instance.primaryFocus?.unfocus(),
       onChanged: bloc.changeAbbreviation,
       maxLength: 3,
     );

--- a/app/lib/groups/src/pages/course/create/course_create_page.dart
+++ b/app/lib/groups/src/pages/course/create/course_create_page.dart
@@ -157,7 +157,7 @@ class _Subject extends StatelessWidget {
             textInputAction: TextInputAction.next,
             onChanged: bloc.changeSubject,
             onEditingComplete: () =>
-                FocusScope.of(context).requestFocus(nextFocusNode),
+                FocusManager.instance.primaryFocus?.unfocus(),
           ),
         );
       },
@@ -180,8 +180,7 @@ class _Abbreviation extends StatelessWidget {
     return PrefilledTextField(
       prefilledText: abbreviation,
       focusNode: focusNode,
-      onEditingComplete: () =>
-          FocusScope.of(context).requestFocus(nextFocusNode),
+      onEditingComplete: () => FocusManager.instance.primaryFocus?.unfocus(),
       textInputAction: TextInputAction.next,
       onChanged: bloc.changeAbbreviation,
       decoration: const InputDecoration(

--- a/app/lib/groups/src/pages/school_class/create_course/school_class_create_course.dart
+++ b/app/lib/groups/src/pages/school_class/create_course/school_class_create_course.dart
@@ -149,7 +149,7 @@ class _Subject extends StatelessWidget {
             textInputAction: TextInputAction.next,
             onChanged: bloc.changeSubject,
             onEditingComplete: () =>
-                FocusScope.of(context).requestFocus(nextFocusNode),
+                FocusManager.instance.primaryFocus?.unfocus(),
           ),
         );
       },
@@ -172,8 +172,7 @@ class _Abbreviation extends StatelessWidget {
     return PrefilledTextField(
       prefilledText: abbreviation,
       focusNode: focusNode,
-      onEditingComplete: () =>
-          FocusScope.of(context).requestFocus(nextFocusNode),
+      onEditingComplete: () => FocusManager.instance.primaryFocus?.unfocus(),
       textInputAction: TextInputAction.next,
       onChanged: bloc.changeAbbreviation,
       decoration: const InputDecoration(

--- a/app/lib/pages/settings/my_profile/change_email.dart
+++ b/app/lib/pages/settings/my_profile/change_email.dart
@@ -153,7 +153,7 @@ class __NewEmailFieldState extends State<_NewEmailField> {
           autofocus: true,
           autofillHints: const [AutofillHints.email],
           onEditingComplete: () =>
-              FocusScope.of(context).requestFocus(widget.passwordNode),
+              FocusManager.instance.primaryFocus?.unfocus(),
           textInputAction: TextInputAction.next,
           decoration: InputDecoration(
             labelText: "Neu",

--- a/app/lib/pages/settings/my_profile/change_password.dart
+++ b/app/lib/pages/settings/my_profile/change_password.dart
@@ -35,7 +35,7 @@ class ChangePasswordPage extends StatelessWidget {
                   labelText: "Aktuelles Passwort",
                   autofocus: true,
                   onEditComplete: () =>
-                      FocusScope.of(context).requestFocus(newPasswordNode)),
+                      FocusManager.instance.primaryFocus?.unfocus()),
               const SizedBox(height: 16),
               _NewPasswordField(newPasswordNode: newPasswordNode),
               const SizedBox(height: 16),

--- a/lib/sharezone_widgets/lib/src/form.dart
+++ b/lib/sharezone_widgets/lib/src/form.dart
@@ -106,7 +106,7 @@ class _OneTextFieldDialogState extends State<OneTextFieldDialog> {
 
   Future<void> delayKeyboard(BuildContext context) async {
     Future.delayed(const Duration(milliseconds: 150));
-    FocusScope.of(context).requestFocus(focusNode);
+    FocusManager.instance.primaryFocus?.unfocus();
   }
 
   @override

--- a/lib/sharezone_widgets/lib/src/prefilled_text_field.dart
+++ b/lib/sharezone_widgets/lib/src/prefilled_text_field.dart
@@ -58,10 +58,10 @@ class PrefilledTextField extends StatefulWidget {
   /// [StatefulWidget] parent. See [FocusNode] for more information.
   ///
   /// To give the keyboard focus to this widget, provide a [focusNode] and then
-  /// use the current [FocusScope] to request the focus:
+  /// use the [FocusManager] to request the focus:
   ///
   /// ```dart
-  /// FocusScope.of(context).requestFocus(myFocusNode);
+  /// FocusManager.instance.primaryFocus?.unfocus();
   /// ```
   ///
   /// This happens automatically when the widget is tapped.

--- a/lib/sharezone_widgets/lib/src/theme/theme.dart
+++ b/lib/sharezone_widgets/lib/src/theme/theme.dart
@@ -23,20 +23,20 @@ Future<void> delayKeyboard(
     @required FocusNode focusNode,
     Duration duration = const Duration(milliseconds: 250)}) async {
   await Future.delayed(duration);
-  FocusScope.of(context).requestFocus(focusNode);
+  FocusManager.instance.primaryFocus?.unfocus();
 }
 
 Future<void> hideKeyboardWithDelay(
     {@required BuildContext context,
     Duration duration = const Duration(milliseconds: 250)}) async {
   await Future.delayed(duration);
-  FocusScope.of(context).requestFocus(FocusNode());
+  FocusManager.instance.primaryFocus?.unfocus();
 }
 
 void hideKeyboard(
     {@required BuildContext context,
     Duration duration = const Duration(milliseconds: 250)}) {
-  FocusScope.of(context).requestFocus(FocusNode());
+  FocusManager.instance.primaryFocus?.unfocus();
 }
 
 const double cardElevation = 1.5; // Elevation of Cards

--- a/lib/sharezone_widgets/lib/src/widgets.dart
+++ b/lib/sharezone_widgets/lib/src/widgets.dart
@@ -100,8 +100,8 @@ class DatePicker extends StatelessWidget {
                     : "Datum auswählen",
                 padding: padding,
                 onPressed: () async {
-                  FocusScope.of(context)
-                      .requestFocus(FocusNode()); // Close keyboard
+                  FocusManager.instance.primaryFocus
+                      ?.unfocus(); // Close keyboard
                   await Future.delayed(const Duration(
                       milliseconds: 150)); // Waiting for closing keyboard
                   _selectDate(context);

--- a/lib/sharezone_widgets/lib/src/widgets.dart
+++ b/lib/sharezone_widgets/lib/src/widgets.dart
@@ -26,7 +26,7 @@ Future<void> waitingForBottomModelSheetClosing() async =>
     await Future.delayed(const Duration(milliseconds: 100));
 
 Future<void> closeKeyboardAndWait(BuildContext context) async {
-  FocusScope.of(context).requestFocus(FocusNode());
+  FocusManager.instance.primaryFocus?.unfocus();
   await Future.delayed(const Duration(milliseconds: 150));
 }
 
@@ -63,7 +63,7 @@ class DatePicker extends StatelessWidget {
   final EdgeInsets padding;
 
   Future<void> _selectDate(BuildContext context) async {
-    FocusScope.of(context).requestFocus(FocusNode());
+    FocusManager.instance.primaryFocus?.unfocus();
     final DateTime tomorrow =
         DateTime(DateTime.now().year, DateTime.now().month, DateTime.now().day)
             .add(const Duration(days: 1));


### PR DESCRIPTION
As described in #338, so far the legacy variant has been used for the Focus. I have updated this to the "new" method. All components have been tested accordingly and work in the iOS 16.1 simulator.

Closes #338 