### PR TITLE
Add `sharezone_lints` to `sharezone_utils`

### DIFF
--- a/lib/sharezone_utils/analysis_options.yaml
+++ b/lib/sharezone_utils/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:sharezone_lints/analysis_options.yaml

--- a/lib/sharezone_utils/analysis_options.yaml
+++ b/lib/sharezone_utils/analysis_options.yaml
@@ -1,1 +1,9 @@
+# Copyright (c) 2023 Sharezone UG (haftungsbeschränkt)
+# Licensed under the EUPL-1.2-or-later.
+#
+# You may obtain a copy of the Licence at:
+# https://joinup.ec.europa.eu/software/page/eupl
+#
+# SPDX-License-Identifier: EUPL-1.2
+
 include: package:sharezone_lints/analysis_options.yaml

--- a/lib/sharezone_utils/lib/src/dimensions/dimensions.dart
+++ b/lib/sharezone_utils/lib/src/dimensions/dimensions.dart
@@ -24,10 +24,11 @@ class Dimensions {
     if (width < 700) {
       return false;
     } else if (width >= 700 && width <= 700) {
-      if (height > 500)
+      if (height > 500) {
         return true;
-      else
+      } else {
         return false;
+      }
     } else {
       return true;
     }
@@ -48,9 +49,9 @@ class Dimensions {
   }
 
   double get dialogBorderRadiusDimensions {
-    if (isDesktopModus == false)
+    if (isDesktopModus == false) {
       return 0;
-    else {
+    } else {
       return 8;
     }
   }

--- a/lib/sharezone_utils/lib/src/platform/platform_check.dart
+++ b/lib/sharezone_utils/lib/src/platform/platform_check.dart
@@ -118,14 +118,14 @@ class PlatformCheckVariant extends TestVariant<Platform> {
   final Set<Platform> values;
 
   @override
-  String describeValue(Platform platform) => platform.toString();
+  String describeValue(Platform value) => value.toString();
 
   /// This method behaviour is copied from TargetPlatformVariant
   @override
   Future<Platform> setUp(Platform platform) async {
     final previous = PlatformCheck.currentPlatform;
     PlatformCheck.setCurrentPlatformForTesting(platform);
-    // Why returing [previous]? See in [TestVariant.setUp]
+    // Why returning [previous]? See in [TestVariant.setUp]
     return previous;
   }
 

--- a/lib/sharezone_utils/pubspec.lock
+++ b/lib/sharezone_utils/pubspec.lock
@@ -86,8 +86,16 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_lints:
+    dependency: transitive
+    description:
+      name: flutter_lints
+      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   flutter_test:
-    dependency: "direct dev"
+    dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -104,6 +112,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.5"
+  lints:
+    dependency: transitive
+    description:
+      name: lints
+      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   matcher:
     dependency: transitive
     description:
@@ -152,6 +168,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.27.5"
+  sharezone_lints:
+    dependency: "direct dev"
+    description:
+      path: "../sharezone_lints"
+      relative: true
+    source: path
+    version: "1.0.0"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/lib/sharezone_utils/pubspec.yaml
+++ b/lib/sharezone_utils/pubspec.yaml
@@ -18,8 +18,14 @@ dependencies:
   device_info_plus: ^8.1.0
   flutter:
     sdk: flutter
+  # We need flutter_test as a normal dependency, because we use it in the
+  # platform_check.dart file. Otherwise we would have the lint warning "The
+  # imported package 'flutter_test' isn't a dependency of the importing package"
+  # (depend_on_referenced_packages).
+  flutter_test:
+    sdk: flutter
   rxdart: ^0.27.5
 
 dev_dependencies:
-  flutter_test:
-    sdk: flutter
+  sharezone_lints:
+    path: ../sharezone_lints


### PR DESCRIPTION
The package `sharezone_utils` uses now our `sharezone_lints` package.

Part of #37 