### PR TITLE
Migrate `util` package to null saftey

### DIFF
--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -113,10 +113,10 @@ packages:
     dependency: transitive
     description:
       name: asn1lib
-      sha256: "35e6681078cf198c5d5e83fdc5fcf4ad39a5f29564c181b370b5c29361f28660"
+      sha256: ab96a1cb3beeccf8145c52e449233fe68364c9641623acd3adad66f8184f1039
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "1.4.0"
   async:
     dependency: transitive
     description:
@@ -495,10 +495,10 @@ packages:
     dependency: transitive
     description:
       name: encrypt
-      sha256: e0389e80d523df05de1494e2e70e204e2ebafeaaf387bd726622e4cd89636eb8
+      sha256: "4fd4e4fdc21b9d7d4141823e1e6515cd94e7b8d84749504c232999fba25d9bbb"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.0"
+    version: "5.0.1"
   equatable:
     dependency: transitive
     description:
@@ -1101,10 +1101,10 @@ packages:
     dependency: transitive
     description:
       name: http
-      sha256: "2ed163531e071c2c6b7c659635112f24cb64ecbebf6af46b550d536c0b1aa112"
+      sha256: "6aa2946395183537c8b880962d935877325d6a09a2867c3970c05c0fed6ac482"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.4"
+    version: "0.13.5"
   http_multi_server:
     dependency: transitive
     description:
@@ -1208,10 +1208,10 @@ packages:
     dependency: transitive
     description:
       name: logging
-      sha256: "293ae2d49fd79d4c04944c3a26dfd313382d5f52e821ec57119230ae16031ad4"
+      sha256: "04094f2eb032cbb06c6f6e8d3607edcfcb0455e2bb6cbc010cb01171dcb64e6d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.1.1"
   markdown:
     dependency: transitive
     description:
@@ -1537,10 +1537,10 @@ packages:
     dependency: transitive
     description:
       name: pointycastle
-      sha256: ed0cc2e91e0996a6582e87e73fb13cf8e858346d725049740afe8ca9125ebbf4
+      sha256: db7306cf0249f838d1a24af52b5a5887c5bf7f31d8bb4e827d071dc0939ad346
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0-rc0"
+    version: "3.6.2"
   pool:
     dependency: transitive
     description:
@@ -1640,10 +1640,10 @@ packages:
     dependency: transitive
     description:
       name: rsa_pkcs
-      sha256: "64da191b7bb2884aa509e83ef88721cd2715ed853d3a90d2380cf66038fd5e43"
+      sha256: "17a52b0c010319f0d4c7bcc635eb89e2efeaec44975b3fb45f850b350a2b0513"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   rxdart:
     dependency: "direct main"
     description:

--- a/lib/abgabe/abgabe_client_lib/pubspec.yaml
+++ b/lib/abgabe/abgabe_client_lib/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   gcloud: any
   googleapis: any
   googleapis_auth: any
-  logging: ^1.0.1
+  logging: ^1.1.1
   meta: ^1.1.8
   optional: 4.1.0
   rxdart: ^0.27.1

--- a/lib/util/lib/src/encryption/aes_encryption.dart
+++ b/lib/util/lib/src/encryption/aes_encryption.dart
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: EUPL-1.2
 
 import 'package:encrypt/encrypt.dart';
-import 'package:meta/meta.dart';
 
 class AESEncryptable {
   final Key key;
@@ -16,8 +15,8 @@ class AESEncryptable {
   AESEncryptable._(this.key, this.iv);
 
   factory AESEncryptable.fromKeyString({
-    @required String key,
-    @required String iv,
+    required String key,
+    required String iv,
   }) {
     return AESEncryptable._(Key.fromBase64(key), IV.fromBase64(iv));
   }

--- a/lib/util/lib/src/encryption/rsa_encryption.dart
+++ b/lib/util/lib/src/encryption/rsa_encryption.dart
@@ -8,25 +8,28 @@
 
 import "package:pointycastle/export.dart" as pointycastle;
 import 'package:encrypt/encrypt.dart';
-import 'package:meta/meta.dart';
 import 'package:util/src/encryption/rsa_pem.dart';
 
 class RSAEncryptable {
   final pointycastle.RSAPublicKey _publicKey;
-  final pointycastle.RSAPrivateKey _privateKey;
+  final pointycastle.RSAPrivateKey? _privateKey;
   RSAEncryptable._(this._privateKey, this._publicKey);
 
   RSAEncryptable.fromPointCastleObjects(this._privateKey, this._publicKey);
 
-  factory RSAEncryptable.fromPublicKey({@required String publicKey}) {
+  factory RSAEncryptable.fromPublicKey({required String publicKey}) {
     final parsedPublicKey = RSAKeyParser().parse(publicKey);
-    return RSAEncryptable._(null, parsedPublicKey);
+    return RSAEncryptable._(null, parsedPublicKey as pointycastle.RSAPublicKey);
   }
 
-  factory RSAEncryptable({String publicKey, String privateKey}) {
+  factory RSAEncryptable(
+      {required String publicKey, required String privateKey}) {
     final parsedPublicKey = RSAKeyParser().parse(publicKey);
     final parsedPrivateKey = RSAKeyParser().parse(privateKey);
-    return RSAEncryptable._(parsedPrivateKey, parsedPublicKey);
+    return RSAEncryptable._(
+      parsedPrivateKey as pointycastle.RSAPrivateKey?,
+      parsedPublicKey as pointycastle.RSAPublicKey,
+    );
   }
 
   static Future<RSAEncryptable> generateFromRsaKeyGenerator() async {
@@ -38,14 +41,17 @@ class RSAEncryptable {
   }
 
   Encrypter get _encrypter {
-    return Encrypter(RSA(
+    return Encrypter(
+      RSA(
         publicKey: _publicKey,
         privateKey: _privateKey,
-        encoding: RSAEncoding.OAEP));
+        encoding: RSAEncoding.OAEP,
+      ),
+    );
   }
 
   getPrivateKeyPemString() {
-    return RsaKeyHelper().encodePrivateKeyToPem(_privateKey);
+    return RsaKeyHelper().encodePrivateKeyToPem(_privateKey!);
   }
 
   getPublicKeyPemString() {
@@ -69,6 +75,9 @@ class RSAKeyGenerator {
 
   factory RSAKeyGenerator.generate() {
     final keyPair = RsaKeyHelper().generateKeyPair();
-    return RSAKeyGenerator._(keyPair.privateKey, keyPair.publicKey);
+    return RSAKeyGenerator._(
+      keyPair.privateKey as pointycastle.RSAPrivateKey,
+      keyPair.publicKey as pointycastle.RSAPublicKey,
+    );
   }
 }

--- a/lib/util/lib/src/encryption/rsa_pem.dart
+++ b/lib/util/lib/src/encryption/rsa_pem.dart
@@ -98,7 +98,7 @@ class RsaKeyHelper {
   parsePrivateKey(String privateKey) {
     final parser = pkcs.RSAPKCSParser();
     final parserResult = parser.parsePEM(privateKey);
-    final private = parserResult.private;
+    final private = parserResult.private!;
     /*
     print("modulus: ${private.modulus}");
     print("publicExponent: ${private.publicExponent}");
@@ -126,30 +126,30 @@ class RsaKeyHelper {
 
   parsePublicKeyFromPem(pemString) {
     List<int> publicKeyDER = decodePEM(pemString);
-    var asn1Parser = new ASN1Parser(publicKeyDER);
+    var asn1Parser = new ASN1Parser(publicKeyDER as Uint8List);
     var topLevelSeq = asn1Parser.nextObject() as ASN1Sequence;
     var publicKeyBitString = topLevelSeq.elements[1];
 
-    var publicKeyAsn = new ASN1Parser(publicKeyBitString.contentBytes());
-    ASN1Sequence publicKeySeq = publicKeyAsn.nextObject();
+    var publicKeyAsn = new ASN1Parser(publicKeyBitString.contentBytes()!);
+    ASN1Sequence publicKeySeq = publicKeyAsn.nextObject() as ASN1Sequence;
     var modulus = publicKeySeq.elements[0] as ASN1Integer;
     var exponent = publicKeySeq.elements[1] as ASN1Integer;
 
     RSAPublicKey rsaPublicKey =
-        RSAPublicKey(modulus.valueAsBigInteger, exponent.valueAsBigInteger);
+        RSAPublicKey(modulus.valueAsBigInteger!, exponent.valueAsBigInteger!);
 
     return rsaPublicKey;
   }
 
   parsePrivateKeyFromPem(pemString) {
     List<int> privateKeyDER = decodePEM(pemString);
-    var asn1Parser = new ASN1Parser(privateKeyDER);
+    var asn1Parser = new ASN1Parser(privateKeyDER as Uint8List);
     var topLevelSeq = asn1Parser.nextObject() as ASN1Sequence;
     // var version = topLevelSeq.elements[0];
     // var algorithm = topLevelSeq.elements[1];
     var privateKey = topLevelSeq.elements[2];
 
-    asn1Parser = new ASN1Parser(privateKey.contentBytes());
+    asn1Parser = new ASN1Parser(privateKey.contentBytes()!);
     var pkSeq = asn1Parser.nextObject() as ASN1Sequence;
 
     // version = pkSeq.elements[0];
@@ -163,8 +163,8 @@ class RsaKeyHelper {
     // var co = pkSeq.elements[8] as ASN1Integer;
 
     RSAPrivateKey rsaPrivateKey = RSAPrivateKey(
-        modulus.valueAsBigInteger,
-        privateExponent.valueAsBigInteger,
+        modulus.valueAsBigInteger!,
+        privateExponent.valueAsBigInteger!,
         p.valueAsBigInteger,
         q.valueAsBigInteger);
 
@@ -181,8 +181,8 @@ class RsaKeyHelper {
     algorithmSeq.add(paramsAsn1Obj);
 
     var publicKeySeq = new ASN1Sequence();
-    publicKeySeq.add(ASN1Integer(publicKey.modulus));
-    publicKeySeq.add(ASN1Integer(publicKey.exponent));
+    publicKeySeq.add(ASN1Integer(publicKey.modulus!));
+    publicKeySeq.add(ASN1Integer(publicKey.exponent!));
     var publicKeySeqBitString =
         new ASN1BitString(Uint8List.fromList(publicKeySeq.encodedBytes));
 
@@ -206,16 +206,16 @@ class RsaKeyHelper {
     algorithmSeq.add(paramsAsn1Obj);
 
     var privateKeySeq = new ASN1Sequence();
-    var modulus = ASN1Integer(privateKey.n);
+    var modulus = ASN1Integer(privateKey.n!);
     var publicExponent = ASN1Integer(BigInt.parse('65537'));
-    var privateExponent = ASN1Integer(privateKey.privateExponent);
-    var p = ASN1Integer(privateKey.p);
-    var q = ASN1Integer(privateKey.q);
-    var dP = privateKey.privateExponent % (privateKey.p - BigInt.from(1));
+    var privateExponent = ASN1Integer(privateKey.privateExponent!);
+    var p = ASN1Integer(privateKey.p!);
+    var q = ASN1Integer(privateKey.q!);
+    var dP = privateKey.privateExponent! % (privateKey.p! - BigInt.from(1));
     var exp1 = ASN1Integer(dP);
-    var dQ = privateKey.privateExponent % (privateKey.q - BigInt.from(1));
+    var dQ = privateKey.privateExponent! % (privateKey.q! - BigInt.from(1));
     var exp2 = ASN1Integer(dQ);
-    var iQ = privateKey.q.modInverse(privateKey.p);
+    var iQ = privateKey.q!.modInverse(privateKey.p!);
     var co = ASN1Integer(iQ);
 
     privateKeySeq.add(version);

--- a/lib/util/lib/src/logging.dart
+++ b/lib/util/lib/src/logging.dart
@@ -11,7 +11,7 @@ import 'dart:convert';
 import 'package:logging/logging.dart';
 import 'package:http/http.dart' as http;
 
-void printLogRecord(LogRecord log, {void Function(String) printMethod}) {
+void printLogRecord(LogRecord log, {void Function(String)? printMethod}) {
   String msg = "[${log.level}] ${log.loggerName} ${log.message}\n";
   if (log.error != null) {
     msg += "Error: ${log.error}\n";
@@ -38,7 +38,7 @@ class SlackLogPublisher {
   }
 
   void tryPublishLogs(Stream<LogRecord> logs) {
-    logs?.listen((log) {
+    logs.listen((log) {
       if (log.level >= logLevelToSend) {
         tryPublishLog(log);
       }

--- a/lib/util/lib/src/string_helper.dart
+++ b/lib/util/lib/src/string_helper.dart
@@ -6,13 +6,13 @@
 //
 // SPDX-License-Identifier: EUPL-1.2
 
-bool isNotEmptyOrNull(String value) => !isEmptyOrNull(value);
+bool isNotEmptyOrNull(String? value) => !isEmptyOrNull(value);
 
-bool isEmptyOrNull(String value) {
+bool isEmptyOrNull(String? value) {
   return value == null || value.isEmpty;
 }
 
-void throwIfNullOrEmpty(String string, [String name]) {
+void throwIfNullOrEmpty(String string, [String? name]) {
   ArgumentError.checkNotNull(string, name);
   if (string.isEmpty) {
     throw ArgumentError.value(string, name ?? 'string', "can't be empty");

--- a/lib/util/pubspec.lock
+++ b/lib/util/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: "direct main"
     description:
       name: asn1lib
-      sha256: "58455d2724bc6e0889fc410debe3cc31ca6bd808a47c194de726ce295dce199f"
+      sha256: ab96a1cb3beeccf8145c52e449233fe68364c9641623acd3adad66f8184f1039
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.4.0"
   async:
     dependency: transitive
     description:
@@ -69,18 +69,18 @@ packages:
     dependency: "direct main"
     description:
       name: encrypt
-      sha256: e0389e80d523df05de1494e2e70e204e2ebafeaaf387bd726622e4cd89636eb8
+      sha256: "4fd4e4fdc21b9d7d4141823e1e6515cd94e7b8d84749504c232999fba25d9bbb"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.0"
+    version: "5.0.1"
   http:
     dependency: "direct main"
     description:
       name: http
-      sha256: b6f1f143a71e1fe1b34670f1acd6f13960ade2557c96b87e127e0cf661969791
+      sha256: "6aa2946395183537c8b880962d935877325d6a09a2867c3970c05c0fed6ac482"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.3"
+    version: "0.13.5"
   http_parser:
     dependency: transitive
     description:
@@ -101,10 +101,10 @@ packages:
     dependency: "direct main"
     description:
       name: logging
-      sha256: "0520a4826042a8a5d09ddd4755623a50d37ee536d79a70452aff8c8ad7bb6c27"
+      sha256: "04094f2eb032cbb06c6f6e8d3607edcfcb0455e2bb6cbc010cb01171dcb64e6d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.1"
   meta:
     dependency: transitive
     description:
@@ -121,30 +121,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.8.0"
-  pedantic:
-    dependency: transitive
-    description:
-      name: pedantic
-      sha256: "67fc27ed9639506c856c840ccce7594d0bdcd91bc8d53d6e52359449a1d50602"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.11.1"
   pointycastle:
     dependency: "direct main"
     description:
       name: pointycastle
-      sha256: ed0cc2e91e0996a6582e87e73fb13cf8e858346d725049740afe8ca9125ebbf4
+      sha256: db7306cf0249f838d1a24af52b5a5887c5bf7f31d8bb4e827d071dc0939ad346
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0-rc0"
+    version: "3.6.2"
   rsa_pkcs:
     dependency: "direct main"
     description:
       name: rsa_pkcs
-      sha256: "64da191b7bb2884aa509e83ef88721cd2715ed853d3a90d2380cf66038fd5e43"
+      sha256: "17a52b0c010319f0d4c7bcc635eb89e2efeaec44975b3fb45f850b350a2b0513"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   source_span:
     dependency: transitive
     description:
@@ -178,4 +170,4 @@ packages:
     source: hosted
     version: "1.3.0"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.18.0 <3.0.0"

--- a/lib/util/pubspec.yaml
+++ b/lib/util/pubspec.yaml
@@ -12,11 +12,12 @@ version: 0.0.1
 publish_to: none
 
 environment:
-  sdk: ">=2.10.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
+
 dependencies:
-  asn1lib: any
-  encrypt: any
-  http: ^0.13.3
-  logging: ^1.0.1
-  pointycastle: 3.2.0-rc0
-  rsa_pkcs: any
+  asn1lib: ^1.4.0
+  encrypt: ^5.0.1
+  http: ^0.13.5
+  logging: ^1.1.1
+  pointycastle: ^3.6.2
+  rsa_pkcs: ^2.0.1


### PR DESCRIPTION
## Description

Migrates `util` package to null safety and updates the dependencies to the newest version.

Tested `util` package is primarily used in the `authentification_qrcode` package. Therefore, I tested manually the QR Code login. Still works. Either generating a qr code and scanning a qr code.

## Related Tickets

Closes #181 