### PR TITLE
Add concurrency options to `sz pub get`.

### DIFF
--- a/tools/sz_repo_cli/lib/src/commands/src/pub_get_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/pub_get_command.dart
@@ -7,6 +7,7 @@
 // SPDX-License-Identifier: EUPL-1.2
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:args/command_runner.dart';
 import 'package:meta/meta.dart';
@@ -16,28 +17,20 @@ import 'package:rxdart/rxdart.dart';
 import 'package:sz_repo_cli/src/common/common.dart';
 
 class PubGetCommand extends Command {
-  final GetPackagesUseCase _useCase;
-  final PackageGetResultPresenter _presenter;
-
-  PubGetCommand._(this._useCase, this._presenter) {
+  PubGetCommand(this.repo) {
     argParser
-      ..addFlag(includeFlutterAppFlagName,
-          defaultsTo: true,
-          help:
-              'Whether to also run flutter pub get in the sharezone app under /app')
+      ..addFlag(
+        'verbose',
+        abbr: 'v',
+        help: 'if verbose output should be printed (helpful for debugging)',
+        negatable: false,
+        defaultsTo: false,
+      )
+      ..addConcurrencyOption(defaultMaxConcurrency: 8)
       ..addPackageTimeoutOption(defaultInMinutes: 5);
   }
 
-  static const includeFlutterAppFlagName = 'include-app';
-
-  factory PubGetCommand(SharezoneRepo repo) {
-    return PubGetCommand._(
-        GetPackagesUseCase(
-          repo: repo,
-          getCurrentDateTime: () => DateTime.now(),
-        ),
-        PackageGetResultPresenter());
-  }
+  final SharezoneRepo repo;
 
   @override
   String get description =>
@@ -48,13 +41,43 @@ class PubGetCommand extends Command {
 
   @override
   Future<void> run() async {
-    final includeFlutterApp = argResults[includeFlutterAppFlagName] ?? true;
+    isVerbose = argResults['verbose'] ?? false;
 
-    final results = _useCase.getPackages(
-      includeFlutterApp: includeFlutterApp,
-      packageTimeout: argResults.packageTimeoutDuration,
+    final _max = argResults[maxConcurrentPackagesOptionName];
+    final maxNumberOfPackagesBeingProcessedConcurrently = _max != null
+        ? int.tryParse(argResults[maxConcurrentPackagesOptionName])
+        // null wird nachher als "keine Begrenzung" gehandhabt.
+        : null;
+
+    final taskRunner = ConcurrentPackageTaskRunner(
+      getCurrentDateTime: () => DateTime.now(),
     );
-    _presenter.present(results);
+
+    final res = taskRunner
+        .runTaskForPackages(
+          packageStream: repo
+              .streamPackages()
+              .where((package) => package.hasTestDirectory),
+          runTask: (package) => package.getPackages(),
+          maxNumberOfPackagesBeingProcessedConcurrently:
+              maxNumberOfPackagesBeingProcessedConcurrently,
+          perPackageTaskTimeout: argResults.packageTimeoutDuration,
+        )
+        .asBroadcastStream();
+
+    final presenter = PackageTasksStatusPresenter();
+    presenter.continuouslyPrintTaskStatusUpdatesToConsole(res);
+
+    final failures = await res.allFailures;
+
+    if (failures.isNotEmpty) {
+      print('There were failures. See above for more information.');
+      await presenter.printFailedTasksSummary(failures);
+      exit(1);
+    } else {
+      print('All packages tested successfully!');
+      exit(0);
+    }
   }
 }
 

--- a/tools/sz_repo_cli/lib/src/commands/src/pub_get_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/pub_get_command.dart
@@ -46,7 +46,7 @@ class PubGetCommand extends Command {
     final _max = argResults[maxConcurrentPackagesOptionName];
     final maxNumberOfPackagesBeingProcessedConcurrently = _max != null
         ? int.tryParse(argResults[maxConcurrentPackagesOptionName])
-        // null wird nachher als "keine Begrenzung" gehandhabt.
+        // null as interpreted as "no conucrrency limit" (everything at once).
         : null;
 
     final taskRunner = ConcurrentPackageTaskRunner(

--- a/tools/sz_repo_cli/lib/src/commands/src/pub_get_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/pub_get_command.dart
@@ -75,7 +75,7 @@ class PubGetCommand extends Command {
       await presenter.printFailedTasksSummary(failures);
       exit(1);
     } else {
-      print('All packages tested successfully!');
+      print('Ran "pub get" for all packages successfully!');
       exit(0);
     }
   }


### PR DESCRIPTION
Control concurrency (how many packages are processed simultaneously) via the `-c` flag.  
E.g. `sz pub get -c 5` --> `pub get` is run for 5 packages at once at most.   
Default is `-c 8`.

This option should help to avoid the `Waiting for another flutter command to release the startup lock...` problem as seen in #365.  
(It can still happen, but in any case one can just decrease the concurrency to combat the problem).

Fixes #365.