### PR TITLE
Add Fallback App CI

### DIFF
--- a/.github/workflows/app_ci.yml
+++ b/.github/workflows/app_ci.yml
@@ -26,6 +26,9 @@ on:
       # ready for review.
       - ready_for_review
     paths:
+      # When you add a new path, make sure to also add the path to the
+      # "paths-ignore" section in the "app_fallback_ci.yml" file.
+      # 
       # We only build and deploy a new version, when a user relevant files
       # changed.
       - "app/**"

--- a/.github/workflows/app_fallback_ci.yml
+++ b/.github/workflows/app_fallback_ci.yml
@@ -27,6 +27,7 @@ on:
       - reopened
       - ready_for_review
     paths-ignore:
+      - ".fvm/fvm_config.json"
       - "app/**"
       - "lib/**"
       - ".github/workflows/app_ci.yml"

--- a/.github/workflows/app_fallback_ci.yml
+++ b/.github/workflows/app_fallback_ci.yml
@@ -21,6 +21,11 @@ name: app-fallback-ci
 
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
     paths-ignore:
       - "app/**"
       - "lib/**"

--- a/.github/workflows/app_fallback_ci.yml
+++ b/.github/workflows/app_fallback_ci.yml
@@ -1,0 +1,53 @@
+# Copyright (c) 2022 Sharezone UG (haftungsbeschränkt)
+# Licensed under the EUPL-1.2-or-later.
+#
+# You may obtain a copy of the Licence at:
+# https://joinup.ec.europa.eu/software/page/eupl
+#
+# SPDX-License-Identifier: EUPL-1.2
+
+# A workaround for GitHub Actions jobs that required and based on a path.
+#
+# Currently it's not possible to set a GitHub Action to required which is
+# based on path changes. The reason for this that the action is not executed
+# when the action does not match the paths. Therefore, merging will be
+# blocked.
+#
+# A workaround is to have a job which the same name. 
+#
+# https://github.com/github/docs/commit/4364076e0fb56c2579ae90cd048939eaa2c18954
+
+name: app-fallback-ci
+
+on:
+  pull_request:
+    paths-ignore:
+      - "app/**"
+      - "lib/**"
+      - ".github/workflows/app_ci.yml"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No test required"'
+
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No analyze required"'
+  
+  android-integration-test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No android-integration-test required"'
+
+  ios-integration-test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No ios-integration-test required"'
+  
+  web-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No web-preview required"'

--- a/.github/workflows/app_fallback_ci.yml
+++ b/.github/workflows/app_fallback_ci.yml
@@ -8,7 +8,7 @@
 
 # A workaround for GitHub Actions jobs that required and based on a path.
 #
-# Currently it's not possible to set a GitHub Action to required which is
+# Currently, it's not possible to set a GitHub Action to required which is
 # based on path changes. The reason for this that the action is not executed
 # when the action does not match the paths. Therefore, merging will be
 # blocked.

--- a/.github/workflows/app_fallback_ci.yml
+++ b/.github/workflows/app_fallback_ci.yml
@@ -17,7 +17,7 @@
 #
 # https://github.com/github/docs/commit/4364076e0fb56c2579ae90cd048939eaa2c18954
 
-name: app-ci
+name: app-fallback-ci
 
 on:
   pull_request:

--- a/.github/workflows/app_fallback_ci.yml
+++ b/.github/workflows/app_fallback_ci.yml
@@ -17,7 +17,7 @@
 #
 # https://github.com/github/docs/commit/4364076e0fb56c2579ae90cd048939eaa2c18954
 
-name: app-fallback-ci
+name: app-ci
 
 on:
   pull_request:


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/24459435/221893313-7aa00dea-a22d-4280-a05f-242586596c12.png)


A workaround for GitHub Actions jobs that required and based on a path.

Currently, it's not possible to set a GitHub Action to required which is based on path changes. The reason for this that the action is not executed when the action does not match the paths. Therefore, merging will be blocked.

A workaround is to have a job which the same name. 

See: https://github.com/github/docs/commit/4364076e0fb56c2579ae90cd048939eaa2c18954

Closes #403