### PR TITLE
Update to Flutter v3.7.6

### DIFF
--- a/.fvm/fvm_config.json
+++ b/.fvm/fvm_config.json
@@ -1,4 +1,4 @@
 {
-  "flutterSdkVersion": "3.7.5",
+  "flutterSdkVersion": "3.7.6",
   "flavors": {}
 }


### PR DESCRIPTION
Changelog: https://github.com/flutter/flutter/wiki/Hotfixes-to-the-Stable-Channel#376-mar-01-2023

1. Upgraded to Flutter v3.7.6
2. Executed `sz pub get`