### PR TITLE
Use `sharezone_lints` for `url_launcher_extended`

### DIFF
--- a/lib/url_launcher_extended/analysis_options.yaml
+++ b/lib/url_launcher_extended/analysis_options.yaml
@@ -1,0 +1,9 @@
+# Copyright (c) 2023 Sharezone UG (haftungsbeschränkt)
+# Licensed under the EUPL-1.2-or-later.
+#
+# You may obtain a copy of the Licence at:
+# https://joinup.ec.europa.eu/software/page/eupl
+#
+# SPDX-License-Identifier: EUPL-1.2
+
+include: package:sharezone_lints/analysis_options.yaml

--- a/lib/url_launcher_extended/lib/src/url_launcher_extended.dart
+++ b/lib/url_launcher_extended/lib/src/url_launcher_extended.dart
@@ -67,8 +67,8 @@ class UrlLauncherExtended {
     WebViewConfiguration webViewConfiguration = const WebViewConfiguration(),
     String? webOnlyWindowName,
   }) async {
-    final _canLaunch = await canLaunchUrl(url);
-    if (!_canLaunch) {
+    final canLaunch = await canLaunchUrl(url);
+    if (!canLaunch) {
       throw CouldNotLaunchUrlException(url);
     }
 
@@ -116,8 +116,8 @@ class UrlLauncherExtended {
       },
     );
 
-    final _canLaunch = await canLaunchUrl(emailLaunchString);
-    if (!_canLaunch) {
+    final canLaunch = await canLaunchUrl(emailLaunchString);
+    if (!canLaunch) {
       throw CouldNotLaunchMailException(address, subject: subject, body: body);
     }
 
@@ -133,13 +133,13 @@ class CouldNotLaunchMailException implements Exception {
   CouldNotLaunchMailException(this.address, {this.subject, this.body});
 
   @override
-  bool operator ==(Object o) {
-    if (identical(this, o)) return true;
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
 
-    return o is CouldNotLaunchMailException &&
-        o.address == address &&
-        o.subject == subject &&
-        o.body == body;
+    return other is CouldNotLaunchMailException &&
+        other.address == address &&
+        other.subject == subject &&
+        other.body == body;
   }
 
   @override
@@ -157,10 +157,10 @@ class CouldNotLaunchUrlException implements Exception {
   CouldNotLaunchUrlException(this.url);
 
   @override
-  bool operator ==(Object o) {
-    if (identical(this, o)) return true;
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
 
-    return o is CouldNotLaunchUrlException && o.url == url;
+    return other is CouldNotLaunchUrlException && other.url == url;
   }
 
   @override

--- a/lib/url_launcher_extended/pubspec.lock
+++ b/lib/url_launcher_extended/pubspec.lock
@@ -110,6 +110,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_lints:
+    dependency: transitive
+    description:
+      name: flutter_lints
+      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -168,6 +176,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.5"
+  lints:
+    dependency: transitive
+    description:
+      name: lints
+      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   logging:
     dependency: transitive
     description:
@@ -256,6 +272,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
+  sharezone_lints:
+    dependency: "direct dev"
+    description:
+      path: "../sharezone_lints"
+      relative: true
+    source: path
+    version: "1.0.0"
   shelf:
     dependency: transitive
     description:

--- a/lib/url_launcher_extended/pubspec.yaml
+++ b/lib/url_launcher_extended/pubspec.yaml
@@ -23,3 +23,5 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   test: ^1.22.0
+  sharezone_lints:
+    path: ../sharezone_lints

--- a/lib/url_launcher_extended/test/mock_url_launcher_extended_test.dart
+++ b/lib/url_launcher_extended/test/mock_url_launcher_extended_test.dart
@@ -9,7 +9,7 @@
 import 'package:test/test.dart';
 import 'package:url_launcher_extended/mock_url_launcher_extended.dart';
 
-import '../lib/url_launcher_extended.dart';
+import 'package:url_launcher_extended/url_launcher_extended.dart';
 
 void main() {
   group('MockUrlLauncherExtended', () {


### PR DESCRIPTION
I resolved the following warnings in this PR:

```
Nils-MBP-13-M1-3:url_launcher_extended nils$ flutter analyze
Analyzing url_launcher_extended...                                      

   info • The local variable '_canLaunch' starts with an underscore • lib/src/url_launcher_extended.dart:70:11 •
          no_leading_underscores_for_local_identifiers
   info • The local variable '_canLaunch' starts with an underscore • lib/src/url_launcher_extended.dart:119:11 •
          no_leading_underscores_for_local_identifiers
   info • The parameter name 'o' doesn't match the name 'other' in the overridden method • lib/src/url_launcher_extended.dart:136:27 •
          avoid_renaming_method_parameters
   info • The parameter name 'o' doesn't match the name 'other' in the overridden method • lib/src/url_launcher_extended.dart:160:27 •
          avoid_renaming_method_parameters
   info • Can't use a relative path to import a library in 'lib' • test/mock_url_launcher_extended_test.dart:12:8 • avoid_relative_lib_imports

5 issues found. (ran in 0.9s)
```

Part of #37 