### PR TITLE
Use `sharezone_lints` in `time` package

### DIFF
--- a/lib/time/analysis_options.yaml
+++ b/lib/time/analysis_options.yaml
@@ -1,0 +1,9 @@
+# Copyright (c) 2023 Sharezone UG (haftungsbeschränkt)
+# Licensed under the EUPL-1.2-or-later.
+#
+# You may obtain a copy of the Licence at:
+# https://joinup.ec.europa.eu/software/page/eupl
+#
+# SPDX-License-Identifier: EUPL-1.2
+
+include: package:sharezone_lints/analysis_options.yaml

--- a/lib/time/lib/src/time.dart
+++ b/lib/time/lib/src/time.dart
@@ -83,7 +83,7 @@ class Time {
   /// Returns a bool indicating whether the new time added to the [duration] is
   /// a new day.
   bool isNextDayWith(Duration duration) {
-    final minutesOfADay = 24 * 60;
+    const minutesOfADay = 24 * 60;
     return totalMinutes + duration.inMinutes >= minutesOfADay;
   }
 

--- a/lib/time/pubspec.lock
+++ b/lib/time/pubspec.lock
@@ -54,6 +54,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_lints:
+    dependency: transitive
+    description:
+      name: flutter_lints
+      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -75,6 +83,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.5"
+  lints:
+    dependency: transitive
+    description:
+      name: lints
+      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   matcher:
     dependency: transitive
     description:
@@ -107,6 +123,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.8.2"
+  sharezone_lints:
+    dependency: "direct dev"
+    description:
+      path: "../sharezone_lints"
+      relative: true
+    source: path
+    version: "1.0.0"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/lib/time/pubspec.yaml
+++ b/lib/time/pubspec.yaml
@@ -22,3 +22,5 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  sharezone_lints:
+    path: ../sharezone_lints

--- a/lib/time/test/time_test.dart
+++ b/lib/time/test/time_test.dart
@@ -111,32 +111,36 @@ void main() {
   });
 
   test('.isNextDayWith()', () {
-    expect(Time(hour: 0, minute: 0).isNextDayWith(Duration(hours: 1)), false);
-    expect(Time(hour: 0, minute: 0).isNextDayWith(Duration(hours: 10)), false);
-    expect(Time(hour: 23, minute: 0).isNextDayWith(Duration(hours: 1)), true);
-    expect(Time(hour: 23, minute: 0).isNextDayWith(Duration(hours: 2)), true);
+    expect(Time(hour: 0, minute: 0).isNextDayWith(const Duration(hours: 1)),
+        false);
+    expect(Time(hour: 0, minute: 0).isNextDayWith(const Duration(hours: 10)),
+        false);
+    expect(Time(hour: 23, minute: 0).isNextDayWith(const Duration(hours: 1)),
+        true);
+    expect(Time(hour: 23, minute: 0).isNextDayWith(const Duration(hours: 2)),
+        true);
   });
 
   test('.fromTimeOfDay()', () {
     expect(
-      Time.fromTimeOfDay(TimeOfDay(hour: 1, minute: 1)),
+      Time.fromTimeOfDay(const TimeOfDay(hour: 1, minute: 1)),
       Time(hour: 1, minute: 1),
     );
     expect(
-      Time.fromTimeOfDay(TimeOfDay(hour: 0, minute: 0)),
+      Time.fromTimeOfDay(const TimeOfDay(hour: 0, minute: 0)),
       Time(hour: 0, minute: 0),
     );
     expect(
-      Time.fromTimeOfDay(TimeOfDay(hour: 10, minute: 10)),
+      Time.fromTimeOfDay(const TimeOfDay(hour: 10, minute: 10)),
       Time(hour: 10, minute: 10),
     );
   });
 
   test('.parse()', () {
-    expect(Time.parse('00:01'), Time(hour: 0, minute: 1));
-    expect(Time.parse('00:00'), Time(hour: 0, minute: 0));
-    expect(Time.parse('00:10'), Time(hour: 0, minute: 10));
-    expect(Time.parse('23:59'), Time(hour: 23, minute: 59));
+    expect(const Time.parse('00:01'), Time(hour: 0, minute: 1));
+    expect(const Time.parse('00:00'), Time(hour: 0, minute: 0));
+    expect(const Time.parse('00:10'), Time(hour: 0, minute: 10));
+    expect(const Time.parse('23:59'), Time(hour: 23, minute: 59));
   });
 
   test('.hashCode', () {
@@ -146,7 +150,7 @@ void main() {
   test('.toTimeOfDay()', () {
     expect(
       Time(hour: 0, minute: 1).toTimeOfDay(),
-      TimeOfDay(hour: 0, minute: 1),
+      const TimeOfDay(hour: 0, minute: 1),
     );
   });
 


### PR DESCRIPTION
I fixed the following warnings with this PR:

```
Analyzing time...                                                       

   info • Use 'const' for final variables initialized to a constant value • lib/src/time.dart:86:5 • prefer_const_declarations
   info • Use 'const' with the constructor to improve performance • test/time_test.dart:114:51 • prefer_const_constructors
   info • Use 'const' with the constructor to improve performance • test/time_test.dart:115:51 • prefer_const_constructors
   info • Use 'const' with the constructor to improve performance • test/time_test.dart:116:52 • prefer_const_constructors
   info • Use 'const' with the constructor to improve performance • test/time_test.dart:117:52 • prefer_const_constructors
   info • Use 'const' with the constructor to improve performance • test/time_test.dart:122:26 • prefer_const_constructors
   info • Use 'const' with the constructor to improve performance • test/time_test.dart:126:26 • prefer_const_constructors
   info • Use 'const' with the constructor to improve performance • test/time_test.dart:130:26 • prefer_const_constructors
   info • Use 'const' with the constructor to improve performance • test/time_test.dart:136:12 • prefer_const_constructors
   info • Use 'const' with the constructor to improve performance • test/time_test.dart:137:12 • prefer_const_constructors
   info • Use 'const' with the constructor to improve performance • test/time_test.dart:138:12 • prefer_const_constructors
   info • Use 'const' with the constructor to improve performance • test/time_test.dart:139:12 • prefer_const_constructors
   info • Use 'const' with the constructor to improve performance • test/time_test.dart:149:7 • prefer_const_constructors

13 issues found. (ran in 1.4s)
```

Part of #37 