### PR TITLE
Add `sharezone_lints` to `notifications` package

### DIFF
--- a/lib/notifications/analysis_options.yaml
+++ b/lib/notifications/analysis_options.yaml
@@ -1,0 +1,9 @@
+# Copyright (c) 2023 Sharezone UG (haftungsbeschränkt)
+# Licensed under the EUPL-1.2-or-later.
+#
+# You may obtain a copy of the Licence at:
+# https://joinup.ec.europa.eu/software/page/eupl
+#
+# SPDX-License-Identifier: EUPL-1.2
+
+include: package:sharezone_lints/analysis_options.yaml

--- a/lib/notifications/lib/src/action_registration.dart
+++ b/lib/notifications/lib/src/action_registration.dart
@@ -21,8 +21,8 @@ import 'package:notifications/src/action_executor.dart';
 /// `ShowDialog.title` and `ShowDialog.body`).
 ///
 /// Is usually implemented by a subclass of [ActionExecutor].
-typedef FutureOr<void> ActionRequestExecutorFunc<T extends ActionRequest>(
-    T actionRequest);
+typedef ActionRequestExecutorFunc<T extends ActionRequest> = FutureOr<void>
+    Function(T actionRequest);
 
 /// Parse the [ActionRequest] of type [T] from the [notification] and
 /// report non-fatal errors via the [instrumentation].

--- a/lib/notifications/lib/src/notification_parser.dart
+++ b/lib/notifications/lib/src/notification_parser.dart
@@ -18,7 +18,7 @@ class PushNotificationParser {
 
   factory PushNotificationParser(
     List<ActionRegistration<ActionRequest>> actionRegistrations,
-    PushNotificationActionHandlerInstrumentation _instrumentation,
+    PushNotificationActionHandlerInstrumentation instrumentation,
   ) {
     final parserMap = <String?, PushNotificationParsingFunc>{};
 
@@ -39,7 +39,7 @@ class PushNotificationParser {
     }
 
     return PushNotificationParser._(parserMap,
-        PushNotificationParserInstrumentationFactory(_instrumentation));
+        PushNotificationParserInstrumentationFactory(instrumentation));
   }
 
   /// Finds the corresponding parsing function for the [notification] by looking

--- a/lib/notifications/lib/src/push_notification.dart
+++ b/lib/notifications/lib/src/push_notification.dart
@@ -48,7 +48,7 @@ class PushNotification {
     required this.title,
     required this.body,
     Map<String, dynamic>? actionData,
-  }) : this.actionData = actionData ?? const {};
+  }) : actionData = actionData ?? const {};
 
   factory PushNotification.fromFirebase(RemoteMessage message) {
     final actionType = message.data['actionType'];

--- a/lib/notifications/lib/src/push_notification_action_handler.dart
+++ b/lib/notifications/lib/src/push_notification_action_handler.dart
@@ -213,21 +213,20 @@ void _checkForDuplicateActionTypeRegistrations(
 }
 
 extension on ActionRegistration {
-  bool hasIntersection(ActionRegistration _other) =>
-      registerForActionTypeStrings
-          .intersection(_other.registerForActionTypeStrings)
-          .isNotEmpty;
+  bool hasIntersection(ActionRegistration other) => registerForActionTypeStrings
+      .intersection(other.registerForActionTypeStrings)
+      .isNotEmpty;
 
   Set<ActionRegistration> getDuplicates(
       List<ActionRegistration> registrations) {
-    Set<ActionRegistration> _duplicates = {};
+    Set<ActionRegistration> duplicates = {};
 
     for (var registration in registrations.where((r) => r != this)) {
       if (hasIntersection(registration)) {
-        _duplicates.add(registration);
+        duplicates.add(registration);
       }
     }
-    return _duplicates;
+    return duplicates;
   }
 }
 

--- a/lib/notifications/pubspec.lock
+++ b/lib/notifications/pubspec.lock
@@ -66,7 +66,7 @@ packages:
     source: hosted
     version: "1.1.1"
   collection:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: collection
       sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
@@ -174,6 +174,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_lints:
+    dependency: transitive
+    description:
+      name: flutter_lints
+      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -232,6 +240,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.5"
+  lints:
+    dependency: transitive
+    description:
+      name: lints
+      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   logging:
     dependency: transitive
     description:
@@ -257,7 +273,7 @@ packages:
     source: hosted
     version: "0.2.0"
   meta:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: meta
       sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
@@ -320,6 +336,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
+  sharezone_lints:
+    dependency: "direct dev"
+    description:
+      path: "../sharezone_lints"
+      relative: true
+    source: path
+    version: "1.0.0"
   shelf:
     dependency: transitive
     description:

--- a/lib/notifications/pubspec.yaml
+++ b/lib/notifications/pubspec.yaml
@@ -17,14 +17,16 @@ environment:
   flutter: ">=1.17.0 <2.0.0"
 
 dependencies:
+  collection: ^1.17.0
   equatable: ^2.0.5
   firebase_messaging: ^14.2.5
   flutter:
     sdk: flutter
+  meta: ^1.8.0
 
 dev_dependencies:
   test: ^1.22.0
   flutter_test:
     sdk: flutter
-
-flutter: null
+  sharezone_lints:
+    path: ../sharezone_lints

--- a/lib/notifications/test/docs_example_test.dart
+++ b/lib/notifications/test/docs_example_test.dart
@@ -6,6 +6,8 @@
 //
 // SPDX-License-Identifier: EUPL-1.2
 
+import 'dart:developer';
+
 import 'package:test/test.dart';
 import 'package:notifications/notifications.dart';
 
@@ -21,7 +23,7 @@ void main() {
         );
       },
       executeActionRequest: (request) {
-        print(request.stringToPrint);
+        log(request.stringToPrint);
       },
     );
 
@@ -33,7 +35,7 @@ void main() {
     );
 
     handler.handlePushNotification(
-      PushNotification(
+      const PushNotification(
         actionType: 'print-secret-string',
         actionData: {'secret-message': 'SHAREZONE4EVER'},
         title: 'Title',

--- a/lib/notifications/test/docs_example_test.dart
+++ b/lib/notifications/test/docs_example_test.dart
@@ -6,10 +6,13 @@
 //
 // SPDX-License-Identifier: EUPL-1.2
 
-import 'dart:developer';
-
 import 'package:test/test.dart';
 import 'package:notifications/notifications.dart';
+
+// Because this file is an example for the documentation, we allow to use the
+// print method.
+//
+// ignore_for_file: avoid_print
 
 void main() {
   test('Example usage for documentation of the $PushNotificationActionHandler',
@@ -23,7 +26,7 @@ void main() {
         );
       },
       executeActionRequest: (request) {
-        log(request.stringToPrint);
+        print(request.stringToPrint);
       },
     );
 


### PR DESCRIPTION
This PR fixes the following warnings:

```
Analyzing notifications...                                              

   info • Use the generic function type syntax in 'typedef's • lib/src/action_registration.dart:24:24 • prefer_generic_function_type_aliases
   info • The imported package 'meta' isn't a dependency of the importing package • lib/src/instrumentation.dart:9:8 •
          depend_on_referenced_packages
   info • The local variable '_instrumentation' starts with an underscore • lib/src/notification_parser.dart:21:50 •
          no_leading_underscores_for_local_identifiers
   info • The imported package 'collection' isn't a dependency of the importing package • lib/src/push_notification.dart:9:8 •
          depend_on_referenced_packages
   info • Unnecessary 'this.' qualifier • lib/src/push_notification.dart:51:8 • unnecessary_this
   info • The local variable '_other' starts with an underscore • lib/src/push_notification_action_handler.dart:216:43 •
          no_leading_underscores_for_local_identifiers
   info • The local variable '_duplicates' starts with an underscore • lib/src/push_notification_action_handler.dart:223:29 •
          no_leading_underscores_for_local_identifiers
   info • Don't invoke 'print' in production code • test/docs_example_test.dart:24:9 • avoid_print
   info • Use 'const' with the constructor to improve performance • test/docs_example_test.dart:36:7 • prefer_const_constructors

9 issues found. (ran in 1.4s)
```

Part of #37