### PR TITLE
Trim the "What's new" string when publishing a new version to TestFlight

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -260,7 +260,11 @@ jobs:
         # able to use the last commit message (title and description) as release
         # note for the alpha builds. This is not the most user friendly note but
         # it's better than nothing.
-        export LAST_COMMIT_MESSAGE=$(git log -1 --pretty=%B)
+        #
+        # The "| xargs" part is to trim the output of the "git log" command
+        # because whitespace at the end causes sometimes issue with publishing
+        # to App Store Connect.
+        export LAST_COMMIT_MESSAGE=$(git log -1 --pretty=%B) | xargs
 
         app-store-connect publish \
           --path build/ios/ipa/*.ipa \

--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -263,7 +263,8 @@ jobs:
         #
         # The "| xargs" part is to trim the output of the "git log" command
         # because whitespace at the end causes sometimes issue with publishing
-        # to App Store Connect.
+        # to App Store Connect (see
+        # https://github.com/SharezoneApp/sharezone-app/issues/422)
         export LAST_COMMIT_MESSAGE=$(git log -1 --pretty=%B) | xargs
 
         app-store-connect publish \


### PR DESCRIPTION
Sometimes our updates for TestFlight because of:

```
PATCH https://api.appstoreconnect.apple.com/v1/betaBuildLocalizations/6206a1b0-01b6-4285-976b-b795f6aaf60c returned 409: An attribute value has invalid text. - Text for whatsNew contains invalid characters/formats.
Failed to publish build/ios/ipa/sharezone.ipa
Error: Process completed with exit code 1.
```

I assume that this is because of the whitespace at the end (see #422). Therefore, we are trimming now the "What's new" string when pushing to TestFlight.

Closes #422