### PR TITLE
Fix trim "What's new" string for publishing the alpha version to TestFlight

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -265,7 +265,7 @@ jobs:
         # because whitespace at the end causes sometimes issue with publishing
         # to App Store Connect (see
         # https://github.com/SharezoneApp/sharezone-app/issues/422)
-        export LAST_COMMIT_MESSAGE=$(git log -1 --pretty=%B) | xargs
+        export LAST_COMMIT_MESSAGE=$(git log -1 --pretty=%B | xargs)
 
         app-store-connect publish \
           --path build/ios/ipa/*.ipa \


### PR DESCRIPTION
The alpha workflow is failing:

```
app-store-connect publish: error: argument --whats-new/-n: Provided value "" is not valid
```

I tested #435 locally. However, I tested it wrong which is the reason I didn't saw this issue...

This time I tested correctly and it should work 👍 
