### PR TITLE
Cancel previous workflows of `app-ci`

### DIFF
--- a/.github/workflows/app_ci.yml
+++ b/.github/workflows/app_ci.yml
@@ -11,6 +11,14 @@
 
 name: app-ci
 
+concurrency:
+  group: app-ci-${{ github.head_ref }}
+  # In order to conserve the use of GitHub Actions, we cancel the running action
+  # of the previous commit. This means that if you first commit "A" and then
+  # commit "B" to the pull request a few minutes later, the workflow for commit
+  # "A" will be cancelled.
+  cancel-in-progress: true
+
 on:
   # Triggers the workflow on pull request events
   pull_request:


### PR DESCRIPTION
In order to save GitHub actions machines (we can only use 5 macOS machines simultaneously) is it helpful to automatically cancel previous builds of our CI for a PR (these builds are useless for PR checks result).