### PR TITLE
Revert to trim the "What's new" string for publishing to TestFlight

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -260,12 +260,7 @@ jobs:
         # able to use the last commit message (title and description) as release
         # note for the alpha builds. This is not the most user friendly note but
         # it's better than nothing.
-        #
-        # The "| xargs" part is to trim the output of the "git log" command
-        # because whitespace at the end causes sometimes issue with publishing
-        # to App Store Connect (see
-        # https://github.com/SharezoneApp/sharezone-app/issues/422)
-        export LAST_COMMIT_MESSAGE=$(git log -1 --pretty=%B | xargs)
+        export LAST_COMMIT_MESSAGE=$(git log -1 --pretty=%B)
 
         app-store-connect publish \
           --path build/ios/ipa/*.ipa \


### PR DESCRIPTION
We should revert the change of trimming the "What's new" string because this seems to be not a real fix for #422 (and it's not working). #429, #428, #430 published successfully and had a whitespace at the end. I need more time and information to figure what in #422 happened.