### PR TITLE
Add `merge_group` feature to our CI

### DIFF
--- a/.github/workflows/app_ci.yml
+++ b/.github/workflows/app_ci.yml
@@ -20,6 +20,9 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  merge_group:
+    types:
+      - checks_requested
   # Triggers the workflow on pull request events
   pull_request:
     types:

--- a/.github/workflows/app_fallback_ci.yml
+++ b/.github/workflows/app_fallback_ci.yml
@@ -20,6 +20,9 @@
 name: app-fallback-ci
 
 on:
+  merge_group:
+    types:
+      - checks_requested
   pull_request:
     types:
       - opened

--- a/.github/workflows/cli_ci.yml
+++ b/.github/workflows/cli_ci.yml
@@ -17,6 +17,9 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  merge_group:
+    types:
+      - checks_requested
   pull_request:
     types:
       - opened

--- a/.github/workflows/cli_fallback_ci.yml
+++ b/.github/workflows/cli_fallback_ci.yml
@@ -20,6 +20,9 @@
 name: cli-fallback-ci
 
 on:
+  merge_group:
+    types:
+      - checks_requested
   pull_request:
     types:
       - opened

--- a/.github/workflows/licence.yml
+++ b/.github/workflows/licence.yml
@@ -10,6 +10,9 @@ name: licence-ci
 
 # Controls when the action will run. 
 on:
+  merge_group:
+    types:
+      - checks_requested
   # Triggers the workflow on pull request events
   pull_request:
     types:


### PR DESCRIPTION
Allows us to use the GitHub Merge Queue feature (similar to the GitLab Merge Train feature). Docs: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group