### PR TITLE
Revert cancel previous CI builds in the same PR

### DIFF
--- a/.github/workflows/app_ci.yml
+++ b/.github/workflows/app_ci.yml
@@ -11,14 +11,6 @@
 
 name: app-ci
 
-concurrency:
-  group: app-ci-${{ github.head_ref }}
-  # In order to conserve the use of GitHub Actions, we cancel the running action
-  # of the previous commit. This means that if you first commit "A" and then
-  # commit "B" to the pull request a few minutes later, the workflow for commit
-  # "A" will be cancelled.
-  cancel-in-progress: true
-
 on:
   merge_group:
     types:

--- a/.github/workflows/cli_ci.yml
+++ b/.github/workflows/cli_ci.yml
@@ -8,14 +8,6 @@
 
 name: cli-ci
 
-concurrency:
-  group: cli-ci-${{ github.head_ref }}
-  # In order to conserve the use of GitHub Actions, we cancel the running action
-  # of the previous commit. This means that if you first commit "A" and then
-  # commit "B" to the pull request a few minutes later, the workflow for commit
-  # "A" will be cancelled.
-  cancel-in-progress: true
-
 on:
   merge_group:
     types:


### PR DESCRIPTION
Because we have difficulties to set up merge queues, we are going to revert the concurrency features for the `app-ci` and `cli-ci` for now, to find out if this is the problem.