### PR TITLE
Add path filters to `merge_queue` for our CI

### DIFF
--- a/.github/workflows/app_ci.yml
+++ b/.github/workflows/app_ci.yml
@@ -12,9 +12,6 @@
 name: app-ci
 
 on:
-  merge_group:
-    types:
-      - checks_requested
   # Triggers the workflow on pull request events
   pull_request:
     types:
@@ -29,9 +26,16 @@ on:
       # ready for review.
       - ready_for_review
     paths:
-      # When you add a new path, make sure to also add the path to the
-      # "paths-ignore" section in the "app_fallback_ci.yml" file.
-      # 
+      # IMPORTANT!
+      #
+      # When you add a new path, make sure to also add the path to the following
+      # locations:
+      # * "paths" section of "merge_group" in the "app_ci.yml" file
+      # * "paths-ignore" section of "pull_request" in the "app_fallback_ci.yml"
+      #   file
+      #
+      # ---
+      #
       # When we change the Flutter version, we need to trigger this workflow.
       - ".fvm/fvm_config.json"
       # We only build and deploy a new version, when a user relevant files
@@ -46,6 +50,22 @@ on:
       # applied.
       #
       # See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-and-excluding-paths.
+      - "!**.md"
+      - "!**.mdx"
+      - "!**.gitignore"
+      - "!**/firebase.json"
+      - "!**/.firebaserc"
+  merge_group:
+    types:
+      - checks_requested
+    # It's important to the paths also to the "merge_group" event, so that the
+    # workflow is only triggered when it's necessary.
+    paths:
+      # Keep this in sync with "pull_request". See comment above for more
+      # information.
+      - "app/**"
+      - "lib/**"
+      - ".github/workflows/app_ci.yml"
       - "!**.md"
       - "!**.mdx"
       - "!**.gitignore"

--- a/.github/workflows/app_fallback_ci.yml
+++ b/.github/workflows/app_fallback_ci.yml
@@ -23,6 +23,8 @@ on:
   merge_group:
     types:
       - checks_requested
+    # For fallback CIs we don't need to add the paths-ignore because it's no
+    # harm when the fallback checks being executed.
   pull_request:
     types:
       - opened

--- a/.github/workflows/cli_ci.yml
+++ b/.github/workflows/cli_ci.yml
@@ -9,9 +9,6 @@
 name: cli-ci
 
 on:
-  merge_group:
-    types:
-      - checks_requested
   pull_request:
     types:
       - opened
@@ -24,6 +21,25 @@ on:
       # need to trigger these jobs again when the pull request is changing to
       # ready for review.
       - ready_for_review
+    paths:
+      # IMPORTANT!
+      #
+      # When you add a new path, make sure to also add the path to the following
+      # locations:
+      # * "paths" section of "merge_group" in the "cli_ci.yml" file
+      # * "paths-ignore" section of "pull_request" in the "cli_fallback_ci.yml"
+      #   file
+      #
+      # When we change the Flutter version, we need to trigger this workflow.
+      - .fvm/fvm_config.json
+      - "cli/**"
+      - ".github/workflows/cli_ci.yml"
+      - "!**.md"
+      - "!**.mdx"
+      - "!**.gitignore"
+  merge_group:
+    types:
+      - checks_requested
     paths:
       - .fvm/fvm_config.json
       - "cli/**"

--- a/.github/workflows/cli_fallback_ci.yml
+++ b/.github/workflows/cli_fallback_ci.yml
@@ -23,6 +23,8 @@ on:
   merge_group:
     types:
       - checks_requested
+    # For fallback CIs we don't need to add the paths-ignore because it's no
+    # harm when the fallback checks being executed.
   pull_request:
     types:
       - opened


### PR DESCRIPTION
We need to add paths filters to our `merge_queue`. Otherwise, we are going to execute the workflows _always_ in our merge queue.

For the future a GitHub Action check would be helpful to make sure these checks are in sync (#454)