### PR TITLE
Switch from `dorny/path-filter` to `AurorNZ/path-filter` for path filters in our CI

### DIFF
--- a/.github/workflows/app_ci.yml
+++ b/.github/workflows/app_ci.yml
@@ -54,7 +54,7 @@ jobs:
       changesFound: ${{ steps.filter.outputs.changesFound }}
     steps:
       - uses: actions/checkout@v3
-      - uses: dorny/paths-filter@v2
+      - uses: AurorNZ/paths-filter@v3
         id: filter
         with:
           filters: |

--- a/.github/workflows/cli_ci.yml
+++ b/.github/workflows/cli_ci.yml
@@ -70,7 +70,7 @@ jobs:
               - "tools/sz_repo_cli/**"
               # We trigger also this workflow, if this workflow is changed, so that new
               # changes will be applied.
-              # - ".github/workflows/cli_ci.yml"
+              - ".github/workflows/cli_ci.yml"
               # The following paths are excluded from the above paths. It's important to
               # list the paths at the end of the file, so that the exclude paths are
               # applied.

--- a/.github/workflows/cli_ci.yml
+++ b/.github/workflows/cli_ci.yml
@@ -59,7 +59,7 @@ jobs:
       changesFound: ${{ steps.filter.outputs.changesFound }}
     steps:
       - uses: actions/checkout@v3
-      - uses: dorny/paths-filter@v2
+      - uses: AurorNZ/paths-filter@v3
         id: filter
         with:
           filters: |

--- a/.github/workflows/cli_ci.yml
+++ b/.github/workflows/cli_ci.yml
@@ -70,7 +70,7 @@ jobs:
               - "tools/sz_repo_cli/**"
               # We trigger also this workflow, if this workflow is changed, so that new
               # changes will be applied.
-              - ".github/workflows/cli_ci.yml"
+              # - ".github/workflows/cli_ci.yml"
               # The following paths are excluded from the above paths. It's important to
               # list the paths at the end of the file, so that the exclude paths are
               # applied.

--- a/lib/user/lib/user.dart
+++ b/lib/user/lib/user.dart
@@ -18,5 +18,3 @@ export 'src/models/tips/user_tip_key.dart';
 export 'src/models/tips/user_tips.dart';
 export 'src/models/state_enum.dart';
 export 'src/models/features.dart';
-
-// TEMP

--- a/lib/user/lib/user.dart
+++ b/lib/user/lib/user.dart
@@ -18,3 +18,5 @@ export 'src/models/tips/user_tip_key.dart';
 export 'src/models/tips/user_tips.dart';
 export 'src/models/state_enum.dart';
 export 'src/models/features.dart';
+
+// TEMP


### PR DESCRIPTION
`AurorNZ/path-filter` allows negative paths, like `!**.gitignore`. With `dorny/path-filter` results `!**.gitignore` always to true...