### PR TITLE
Fix `Looking up a deactivated widget's ancestor is unsafe.` when open the web/macOS app

### DIFF
--- a/app/lib/download_app_tip/widgets/download_app_tip_card.dart
+++ b/app/lib/download_app_tip/widgets/download_app_tip_card.dart
@@ -22,11 +22,11 @@ import '../models/download_app_tip.dart';
 /// auch eine App verfügbar ist.
 void showTipCardIfIsAvailable(BuildContext context) {
   WidgetsBinding.instance.addPostFrameCallback((_) {
+    if (!context.mounted) return;
     Overlay.of(context)
         .insert(OverlayEntry(builder: (context) => const _TipCard()));
   });
 }
-
 
 class _TipCard extends StatelessWidget {
   const _TipCard();
@@ -42,15 +42,15 @@ class _TipCard extends StatelessWidget {
           duration: const Duration(milliseconds: 350),
           child: tip != null
               ? OverlayCard(
-                title: Text(tip.title.toUpperCase()),
-                content: Text(tip.description),
-                onClose: () => bloc.closeTip(tip),
-                actionText: tip.actionText.toUpperCase(),
-                onAction: () {
-                  bloc.markTipAsOpened(tip);
-                  launchURL(tip.actionLink);
-                },
-              )
+                  title: Text(tip.title.toUpperCase()),
+                  content: Text(tip.description),
+                  onClose: () => bloc.closeTip(tip),
+                  actionText: tip.actionText.toUpperCase(),
+                  onAction: () {
+                    bloc.markTipAsOpened(tip);
+                    launchURL(tip.actionLink);
+                  },
+                )
               // Ein Container-Widget kann nicht verwendet werden, weil ansonsten
               // die OverlayCard beim animierten Wechsel (durch den AnimatedSwitcher)
               // für einen sehr kurzen Augenblick in der Mitter des Screens ist und


### PR DESCRIPTION
## Description

The issue was missing mounted check.

## Demo

https://user-images.githubusercontent.com/24459435/224119355-1ca8ea6e-1536-4725-8ba1-2a474b981ce2.mov

You see that no error is printed in the console.

## Related Tickets

Closes #459 
