### PR TITLE
Remove "<>" characters when publishing a new version to TestFlight

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -260,7 +260,10 @@ jobs:
         # able to use the last commit message (title and description) as release
         # note for the alpha builds. This is not the most user friendly note but
         # it's better than nothing.
-        export LAST_COMMIT_MESSAGE=$(git log -1 --pretty=%B)
+        #
+        # The "sed 's/[<>]//g'" part is to remove the "<" and ">" characters
+        # because the App Store doesn't allow them.
+        export LAST_COMMIT_MESSAGE=$(git log -1 --pretty=%B | sed 's/[<>]//g')
 
         app-store-connect publish \
           --path build/ios/ipa/*.ipa \


### PR DESCRIPTION
The App Store does not allow "<>" characters in the changelog.

The changes transforms the string from:

```
Fix "sz pub get" not running for all packages. (#448) Co-authored-by: Nils Reichardt <me@nils.re>
```

Converting it to the following string worked:
```
Fix "sz pub get" not running for all packages. (#448) Co-authored-by: Nils Reichardt me@nils.re
```

Tested it locally:

<img width="677" alt="image" src="https://user-images.githubusercontent.com/24459435/224182253-27090041-d8c6-4d11-ac30-6689215712f2.png">


Closes #464 