### PR TITLE
Add label "documentation" to `.mdx` files

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -13,6 +13,7 @@
 
 "documentation":
 - '**/*.md'
+- '**/*.mdx'
 
 "dependencies":
 - '**/pubspec.yaml'

--- a/README.md
+++ b/README.md
@@ -36,3 +36,5 @@ We have more instructions to help you get started in the [CONTRIBUTING.md](CONTR
 - [Instagram](https://www.instagram.com/sharezone.app/)
 - [Twitter](https://twitter.com/SharezoneApp)
 - [Discord](https://sharezone.net/discord)
+
+TEST

--- a/README.md
+++ b/README.md
@@ -36,5 +36,3 @@ We have more instructions to help you get started in the [CONTRIBUTING.md](CONTR
 - [Instagram](https://www.instagram.com/sharezone.app/)
 - [Twitter](https://twitter.com/SharezoneApp)
 - [Discord](https://sharezone.net/discord)
-
-TEST


### PR DESCRIPTION
For our [documentation](https://docs.sharezone.net) we use `.mdx` files. Therefore, we should also assign the "documentation" label when me make changes to `.mdx` files.