### PR TITLE
Bump build number for Android alpha builds

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -158,9 +158,10 @@ jobs:
         # bug.
         #
         # We use the latest build number from the App Store Connect API, because
-        # the is now easy API to get the latest build number from Firebase
-        # Distribution and the build number from App Store Connect is the same
-        # as the one from Firebase Distribution.
+        # this build number is always the the newest one and there is no easy
+        # API to get the latest build number from Firebase Distribution and the
+        # build number from App Store Connect is the same as the one from
+        # Firebase Distribution.
         #
         # Bumping the build number for Firebase Distribution has no effect on
         # the PlayStore build number.

--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -152,7 +152,7 @@ jobs:
         APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.SHAREZONE_APP_STORE_CONNECT_ISSUER_ID }}
         APP_STORE_CONNECT_PRIVATE_KEY: ${{ secrets.SHAREZONE_APP_STORE_CONNECT_PRIVATE_KEY }}
       run: |
-        # Even when Firebase Distribution does not required a new build number,
+        # Even when Firebase Distribution does not require a new build number,
         # we still bump it to identify the different builds easier. Therefore,
         # users can easier say in which version of the app they encountered a
         # bug.

--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -139,7 +139,34 @@ jobs:
     
     - name: Build Android
       working-directory: app
-      run: | 
+      env:
+        # The iOS and App Store environment variables are used by the Codemagic
+        # CLI tool. It's important to use the same names as the CLI tool
+        # expects. 
+        #
+        # From https://appstoreconnect.apple.com/apps/1434868489/
+        IOS_APP_ID: 1434868489
+        # The following secrets are used by the Codemagic CLI tool. It's important
+        # to use the same names as the CLI tool expects.
+        APP_STORE_CONNECT_KEY_IDENTIFIER: ${{ secrets.SHAREZONE_APP_STORE_CONNECT_KEY_IDENTIFIER }}
+        APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.SHAREZONE_APP_STORE_CONNECT_ISSUER_ID }}
+        APP_STORE_CONNECT_PRIVATE_KEY: ${{ secrets.SHAREZONE_APP_STORE_CONNECT_PRIVATE_KEY }}
+      run: |
+        # Even when Firebase Distribution does not required a new build number,
+        # we still bump it to identify the different builds easier. Therefore,
+        # users can easier say in which version of the app they encountered a
+        # bug.
+        #
+        # We use the latest build number from the App Store Connect API, because
+        # the is now easy API to get the latest build number from Firebase
+        # Distribution and the build number from App Store Connect is the same
+        # as the one from Firebase Distribution.
+        #
+        # Bumping the build number for Firebase Distribution has no effect on
+        # the PlayStore build number.
+        LATEST_BUILD_NUMBER=$(app-store-connect get-latest-build-number $IOS_APP_ID | head -2 | tail -1)
+        BUMPED_BUILD_NUMBER=$(expr $LATEST_BUILD_NUMBER + 1)
+
         # We are publishing APKs instead of App Bundles to Firebase Distribution
         # because they easier to install. App Bundles are installed via the
         # PlayStore which resulted in problems in the past.
@@ -148,7 +175,8 @@ jobs:
           --release \
           --flavor prod \
           --target=lib/main_prod.dart \
-          --dart-define DEVELOPMENT_STAGE=ALPHA
+          --dart-define DEVELOPMENT_STAGE=ALPHA \
+          --build-number $BUMPED_BUILD_NUMBER
 
     - name: Install Firebase CLI
       run: sudo npm i -g firebase-tools


### PR DESCRIPTION
## Description

On Android it's hard to say in which version exactly a bug occurred (or in version the app is working again).

Therefore, we are bumping now the Android build number. We use for this the latest AppStore build number (as SOT for the build number) because there is no easy API for Firebase Distribution to get the latest build number. The only cases where this could be a problem would be when the iOS build fails (this would result in a duplicated build number on Android). However, even when this happens is that not dramatic because the build number is just for us and is not required to be increased for every build. 

Problem on Android (it's always 1.6.2 (318)):

https://user-images.githubusercontent.com/24459435/224200019-99127317-bcd4-4bb9-9e49-42c1130e2901.mp4

