### PR TITLE
Use fix versions for tools and Actions in our CI

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -89,10 +89,10 @@ jobs:
     # So we can just use "sz COMMAND" instead of "dart ../path/to/script.dart ..."
     - run: echo $(realpath ./bin) >> $GITHUB_PATH
     
-    - name: Install firebase CLI
+    - name: Install Firebase CLI
       run: |
         cd app
-        sudo npm i -g firebase-tools
+        sudo npm i -g firebase-tools@11.24.1
 
     - name: Build and deploy web-app
       env:
@@ -180,7 +180,7 @@ jobs:
           --build-number $BUMPED_BUILD_NUMBER
 
     - name: Install Firebase CLI
-      run: sudo npm i -g firebase-tools
+      run: sudo npm i -g firebase-tools@11.24.1
 
     - name: Publish to Firebase Distribution
       working-directory: app

--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -62,7 +62,7 @@ env:
 permissions: {}
 jobs:
   deploy-alpha-web-app:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@27135e314dd1818f797af1db9dae03a9f045786b
 
@@ -102,7 +102,7 @@ jobs:
         sz deploy web-app --stage alpha --message "Workflow $GITHUB_JOB, commit $GITHUB_SHA" --credentials sharezone-prod-key.json
 
   deploy-alpha-android-app:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@27135e314dd1818f797af1db9dae03a9f045786b
     
@@ -203,7 +203,7 @@ jobs:
           --release-notes "$LAST_COMMIT_MESSAGE"
 
   deploy-alpha-ios-app:
-    runs-on: macos-latest
+    runs-on: macos-12
     timeout-minutes: 120
     defaults:
       run:

--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -80,7 +80,7 @@ jobs:
 
     - name: Install FVM
       run: |
-        flutter pub global activate fvm
+        flutter pub global activate fvm 2.4.1
         fvm config --cache-path '${{ runner.tool_cache }}/flutter'
     
     - name: Activate sz_repo_cli package
@@ -120,7 +120,7 @@ jobs:
 
     - name: Install FVM
       run: |
-        flutter pub global activate fvm
+        flutter pub global activate fvm 2.4.1
         fvm config --cache-path '${{ runner.tool_cache }}/flutter'
 
     - name: Setup signing
@@ -246,7 +246,7 @@ jobs:
 
     - name: Install FVM
       run: |
-        flutter pub global activate fvm
+        flutter pub global activate fvm 2.4.1
         fvm config --cache-path '${{ runner.tool_cache }}/flutter'
     
     - name: Build iOS app

--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -67,7 +67,7 @@ jobs:
     - uses: actions/checkout@27135e314dd1818f797af1db9dae03a9f045786b
 
     - name: Set Flutter version from FVM config file to environment variables
-      uses: kuhnroyal/flutter-fvm-config-action@v1
+      uses: kuhnroyal/flutter-fvm-config-action@e91317131a2da710b9cd9b7a24f2c0ade9eeb61d
 
     - uses: subosito/flutter-action@v2
       with:
@@ -107,7 +107,7 @@ jobs:
     - uses: actions/checkout@27135e314dd1818f797af1db9dae03a9f045786b
     
     - name: Set Flutter version from FVM config file to environment variables
-      uses: kuhnroyal/flutter-fvm-config-action@v1
+      uses: kuhnroyal/flutter-fvm-config-action@e91317131a2da710b9cd9b7a24f2c0ade9eeb61d
 
     - uses: subosito/flutter-action@v2
       with:
@@ -233,7 +233,7 @@ jobs:
         xcode-project use-profiles
 
     - name: Set Flutter version from FVM config file to environment variables
-      uses: kuhnroyal/flutter-fvm-config-action@v1
+      uses: kuhnroyal/flutter-fvm-config-action@e91317131a2da710b9cd9b7a24f2c0ade9eeb61d
 
     - uses: subosito/flutter-action@v2
       with:

--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -64,7 +64,7 @@ jobs:
   deploy-alpha-web-app:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@27135e314dd1818f797af1db9dae03a9f045786b
 
     - name: Set Flutter version from FVM config file to environment variables
       uses: kuhnroyal/flutter-fvm-config-action@v1
@@ -104,7 +104,7 @@ jobs:
   deploy-alpha-android-app:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@27135e314dd1818f797af1db9dae03a9f045786b
     
     - name: Set Flutter version from FVM config file to environment variables
       uses: kuhnroyal/flutter-fvm-config-action@v1
@@ -209,7 +209,7 @@ jobs:
       run:
         working-directory: app
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@27135e314dd1818f797af1db9dae03a9f045786b
 
     - name: Install Codemagic CLI Tools
       run: pip3 install codemagic-cli-tools

--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -69,7 +69,7 @@ jobs:
     - name: Set Flutter version from FVM config file to environment variables
       uses: kuhnroyal/flutter-fvm-config-action@e91317131a2da710b9cd9b7a24f2c0ade9eeb61d
 
-    - uses: subosito/flutter-action@v2
+    - uses: subosito/flutter-action@dbf1fa04f4d2e52c33185153d06cdb5443aa189d
       with:
         flutter-version: ${{ env.FLUTTER_VERSION }}
         channel: ${{ env.FLUTTER_CHANNEL }}
@@ -109,7 +109,7 @@ jobs:
     - name: Set Flutter version from FVM config file to environment variables
       uses: kuhnroyal/flutter-fvm-config-action@e91317131a2da710b9cd9b7a24f2c0ade9eeb61d
 
-    - uses: subosito/flutter-action@v2
+    - uses: subosito/flutter-action@dbf1fa04f4d2e52c33185153d06cdb5443aa189d
       with:
         flutter-version: ${{ env.FLUTTER_VERSION }}
         channel: ${{ env.FLUTTER_CHANNEL }}
@@ -235,7 +235,7 @@ jobs:
     - name: Set Flutter version from FVM config file to environment variables
       uses: kuhnroyal/flutter-fvm-config-action@e91317131a2da710b9cd9b7a24f2c0ade9eeb61d
 
-    - uses: subosito/flutter-action@v2
+    - uses: subosito/flutter-action@dbf1fa04f4d2e52c33185153d06cdb5443aa189d
       with:
         flutter-version: ${{ env.FLUTTER_VERSION }}
         channel: ${{ env.FLUTTER_CHANNEL }}

--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -212,7 +212,7 @@ jobs:
     - uses: actions/checkout@27135e314dd1818f797af1db9dae03a9f045786b
 
     - name: Install Codemagic CLI Tools
-      run: pip3 install codemagic-cli-tools
+      run: pip3 install codemagic-cli-tools==0.39.1
 
     - name: Setup signing
       env:

--- a/.github/workflows/app_ci.yml
+++ b/.github/workflows/app_ci.yml
@@ -211,7 +211,7 @@ jobs:
         run: flutter build apk --target=integration_test/app_test.dart --flavor dev --dart-define USER_1_EMAIL=$USER_1_EMAIL --dart-define USER_1_PASSWORD=$USER_1_PASSWORD
       
       - name: Run integration tests
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@743ec40c5b752113b0a597cc07f6354cc4284c16
         env:
           USER_1_EMAIL: ${{ secrets.INTEGRATION_TEST_USER_1_EMAIL }}
           USER_1_PASSWORD: ${{ secrets.INTEGRATION_TEST_USER_1_PASSWORD }}

--- a/.github/workflows/app_ci.yml
+++ b/.github/workflows/app_ci.yml
@@ -53,7 +53,7 @@ jobs:
     outputs:
       changesFound: ${{ steps.filter.outputs.changesFound }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@27135e314dd1818f797af1db9dae03a9f045786b
       - uses: AurorNZ/paths-filter@v3
         id: filter
         with:
@@ -86,7 +86,7 @@ jobs:
     # In this case the analyze pipeline would fail, thus we won't run it.
     if: ${{ github.event.pull_request.draft == false && needs.changes.outputs.changesFound == 'true' }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@27135e314dd1818f797af1db9dae03a9f045786b
 
       - name: Set Flutter version from FVM config file to environment variables
         uses: kuhnroyal/flutter-fvm-config-action@v1
@@ -119,7 +119,7 @@ jobs:
     if: ${{ needs.changes.outputs.changesFound == 'true' }}
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@27135e314dd1818f797af1db9dae03a9f045786b
 
       - name: Set Flutter version from FVM config file to environment variables
         uses: kuhnroyal/flutter-fvm-config-action@v1
@@ -175,7 +175,7 @@ jobs:
     if: ${{ github.event.pull_request.draft == false && needs.changes.outputs.changesFound == 'true' }}
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@27135e314dd1818f797af1db9dae03a9f045786b
 
       # Java is needed for building the APK, see
       # https://github.com/marketplace/actions/flutter-action.
@@ -263,7 +263,7 @@ jobs:
     if: ${{ github.event.pull_request.draft == false && needs.changes.outputs.changesFound == 'true' }}
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@27135e314dd1818f797af1db9dae03a9f045786b
 
       - name: Set Flutter version from FVM config file to environment variables
         uses: kuhnroyal/flutter-fvm-config-action@v1
@@ -332,7 +332,7 @@ jobs:
       pull-requests: write # for FirebaseExtended/action-hosting-deploy to comment on PRs
       checks: write # for FirebaseExtended/action-hosting-deploy to comment on PRs (without write permissions for checks the action doesn't post a comment to the PR, we don't know why)
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@27135e314dd1818f797af1db9dae03a9f045786b
 
       - name: Set Flutter version from FVM config file to environment variables
         uses: kuhnroyal/flutter-fvm-config-action@v1

--- a/.github/workflows/app_ci.yml
+++ b/.github/workflows/app_ci.yml
@@ -359,7 +359,7 @@ jobs:
             --target=lib/main_dev.dart
 
       - name: Deploy to Firebase Hosting (sharezone-debug)
-        uses: FirebaseExtended/action-hosting-deploy@v0
+        uses: FirebaseExtended/action-hosting-deploy@4d0d0023f1d92b9b7d16dda64b3d7abd2c98974b
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_SHAREZONE_DEBUG }}

--- a/.github/workflows/app_ci.yml
+++ b/.github/workflows/app_ci.yml
@@ -54,7 +54,7 @@ jobs:
       changesFound: ${{ steps.filter.outputs.changesFound }}
     steps:
       - uses: actions/checkout@27135e314dd1818f797af1db9dae03a9f045786b
-      - uses: AurorNZ/paths-filter@v3
+      - uses: AurorNZ/paths-filter@1497c53e78ed46e4d9fcb735b3870e1a504bdb10
         id: filter
         with:
           filters: |

--- a/.github/workflows/app_ci.yml
+++ b/.github/workflows/app_ci.yml
@@ -211,7 +211,7 @@ jobs:
         run: flutter build apk --target=integration_test/app_test.dart --flavor dev --dart-define USER_1_EMAIL=$USER_1_EMAIL --dart-define USER_1_PASSWORD=$USER_1_PASSWORD
       
       - name: Run integration tests
-        uses: reactivecircus/android-emulator-runner@743ec40c5b752113b0a597cc07f6354cc4284c16
+        uses: reactivecircus/android-emulator-runner@e1248ae048e31ec2e171adc06be585d06c1f936e
         env:
           USER_1_EMAIL: ${{ secrets.INTEGRATION_TEST_USER_1_EMAIL }}
           USER_1_PASSWORD: ${{ secrets.INTEGRATION_TEST_USER_1_PASSWORD }}

--- a/.github/workflows/app_ci.yml
+++ b/.github/workflows/app_ci.yml
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/checkout@27135e314dd1818f797af1db9dae03a9f045786b
 
       - name: Set Flutter version from FVM config file to environment variables
-        uses: kuhnroyal/flutter-fvm-config-action@v1
+        uses: kuhnroyal/flutter-fvm-config-action@e91317131a2da710b9cd9b7a24f2c0ade9eeb61d
 
       - uses: subosito/flutter-action@v2
         with:
@@ -122,7 +122,7 @@ jobs:
       - uses: actions/checkout@27135e314dd1818f797af1db9dae03a9f045786b
 
       - name: Set Flutter version from FVM config file to environment variables
-        uses: kuhnroyal/flutter-fvm-config-action@v1
+        uses: kuhnroyal/flutter-fvm-config-action@e91317131a2da710b9cd9b7a24f2c0ade9eeb61d
 
       - uses: subosito/flutter-action@v2
         with:
@@ -185,7 +185,7 @@ jobs:
           java-version: '11'
 
       - name: Set Flutter version from FVM config file to environment variables
-        uses: kuhnroyal/flutter-fvm-config-action@v1
+        uses: kuhnroyal/flutter-fvm-config-action@e91317131a2da710b9cd9b7a24f2c0ade9eeb61d
 
       - uses: subosito/flutter-action@main
         with:
@@ -266,7 +266,7 @@ jobs:
       - uses: actions/checkout@27135e314dd1818f797af1db9dae03a9f045786b
 
       - name: Set Flutter version from FVM config file to environment variables
-        uses: kuhnroyal/flutter-fvm-config-action@v1
+        uses: kuhnroyal/flutter-fvm-config-action@e91317131a2da710b9cd9b7a24f2c0ade9eeb61d
 
       - uses: subosito/flutter-action@v2
         with:
@@ -335,7 +335,7 @@ jobs:
       - uses: actions/checkout@27135e314dd1818f797af1db9dae03a9f045786b
 
       - name: Set Flutter version from FVM config file to environment variables
-        uses: kuhnroyal/flutter-fvm-config-action@v1
+        uses: kuhnroyal/flutter-fvm-config-action@e91317131a2da710b9cd9b7a24f2c0ade9eeb61d
 
       - uses: subosito/flutter-action@v2
         with:

--- a/.github/workflows/app_ci.yml
+++ b/.github/workflows/app_ci.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Set Flutter version from FVM config file to environment variables
         uses: kuhnroyal/flutter-fvm-config-action@e91317131a2da710b9cd9b7a24f2c0ade9eeb61d
 
-      - uses: subosito/flutter-action@v2
+      - uses: subosito/flutter-action@dbf1fa04f4d2e52c33185153d06cdb5443aa189d
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: ${{ env.FLUTTER_CHANNEL }}
@@ -124,7 +124,7 @@ jobs:
       - name: Set Flutter version from FVM config file to environment variables
         uses: kuhnroyal/flutter-fvm-config-action@e91317131a2da710b9cd9b7a24f2c0ade9eeb61d
 
-      - uses: subosito/flutter-action@v2
+      - uses: subosito/flutter-action@dbf1fa04f4d2e52c33185153d06cdb5443aa189d
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: ${{ env.FLUTTER_CHANNEL }}
@@ -268,7 +268,7 @@ jobs:
       - name: Set Flutter version from FVM config file to environment variables
         uses: kuhnroyal/flutter-fvm-config-action@e91317131a2da710b9cd9b7a24f2c0ade9eeb61d
 
-      - uses: subosito/flutter-action@v2
+      - uses: subosito/flutter-action@dbf1fa04f4d2e52c33185153d06cdb5443aa189d
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: ${{ env.FLUTTER_CHANNEL }}
@@ -337,7 +337,7 @@ jobs:
       - name: Set Flutter version from FVM config file to environment variables
         uses: kuhnroyal/flutter-fvm-config-action@e91317131a2da710b9cd9b7a24f2c0ade9eeb61d
 
-      - uses: subosito/flutter-action@v2
+      - uses: subosito/flutter-action@dbf1fa04f4d2e52c33185153d06cdb5443aa189d
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: ${{ env.FLUTTER_CHANNEL }}

--- a/.github/workflows/app_ci.yml
+++ b/.github/workflows/app_ci.yml
@@ -211,7 +211,7 @@ jobs:
         run: flutter build apk --target=integration_test/app_test.dart --flavor dev --dart-define USER_1_EMAIL=$USER_1_EMAIL --dart-define USER_1_PASSWORD=$USER_1_PASSWORD
       
       - name: Run integration tests
-        uses: reactivecircus/android-emulator-runner@6fd58f95fca234f6afffa070854b8c4c520b2d81
+        uses: reactivecircus/android-emulator-runner@50986b1464923454c95e261820bc626f38490ec0
         env:
           USER_1_EMAIL: ${{ secrets.INTEGRATION_TEST_USER_1_EMAIL }}
           USER_1_PASSWORD: ${{ secrets.INTEGRATION_TEST_USER_1_PASSWORD }}

--- a/.github/workflows/app_ci.yml
+++ b/.github/workflows/app_ci.yml
@@ -211,7 +211,7 @@ jobs:
         run: flutter build apk --target=integration_test/app_test.dart --flavor dev --dart-define USER_1_EMAIL=$USER_1_EMAIL --dart-define USER_1_PASSWORD=$USER_1_PASSWORD
       
       - name: Run integration tests
-        uses: reactivecircus/android-emulator-runner@e1248ae048e31ec2e171adc06be585d06c1f936e
+        uses: reactivecircus/android-emulator-runner@6fd58f95fca234f6afffa070854b8c4c520b2d81
         env:
           USER_1_EMAIL: ${{ secrets.INTEGRATION_TEST_USER_1_EMAIL }}
           USER_1_PASSWORD: ${{ secrets.INTEGRATION_TEST_USER_1_PASSWORD }}

--- a/.github/workflows/app_ci.yml
+++ b/.github/workflows/app_ci.yml
@@ -179,7 +179,7 @@ jobs:
 
       # Java is needed for building the APK, see
       # https://github.com/marketplace/actions/flutter-action.
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@888b4006f39f9718dc69efb685c48e14340507b6
         with:
           distribution: 'temurin'
           java-version: '11'

--- a/.github/workflows/app_ci.yml
+++ b/.github/workflows/app_ci.yml
@@ -153,7 +153,7 @@ jobs:
       # this workflows finished.
       - name: Upload failed golden tests
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@65d862660abb392b8c4a3d1195a2108db131dd05
         with:
           name: failed-golden-tests
           # When a golden test failed, are the results stored in the "failures"

--- a/.github/workflows/app_ci.yml
+++ b/.github/workflows/app_ci.yml
@@ -49,7 +49,7 @@ jobs:
   # * https://github.com/github/docs/commit/4364076e0fb56c2579ae90cd048939eaa2c18954
   #   (workaround for required checks with path filters)
   changes:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       changesFound: ${{ steps.filter.outputs.changesFound }}
     steps:
@@ -81,7 +81,7 @@ jobs:
 
   analyze:
     needs: changes
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # In draft PRs we might use TODOs temporarily.
     # In this case the analyze pipeline would fail, thus we won't run it.
     if: ${{ github.event.pull_request.draft == false && needs.changes.outputs.changesFound == 'true' }}
@@ -117,7 +117,7 @@ jobs:
   test:
     needs: changes
     if: ${{ needs.changes.outputs.changesFound == 'true' }}
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@27135e314dd1818f797af1db9dae03a9f045786b
 
@@ -171,7 +171,7 @@ jobs:
     # hardware acceleration support provided by HAXM. See more details in the
     # README.md of the Android emulator action:
     # https://github.com/ReactiveCircus/android-emulator-runner#usage
-    runs-on: macos-latest
+    runs-on: macos-12
     if: ${{ github.event.pull_request.draft == false && needs.changes.outputs.changesFound == 'true' }}
     timeout-minutes: 60
     steps:
@@ -259,7 +259,7 @@ jobs:
   
   ios-integration-test:
     needs: changes
-    runs-on: macos-latest
+    runs-on: macos-12
     if: ${{ github.event.pull_request.draft == false && needs.changes.outputs.changesFound == 'true' }}
     timeout-minutes: 45
     steps:
@@ -327,7 +327,7 @@ jobs:
     #
     # Otherwise this will be triggered inside a merge-queue.
     if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.changesFound == 'true'}}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       pull-requests: write # for FirebaseExtended/action-hosting-deploy to comment on PRs
       checks: write # for FirebaseExtended/action-hosting-deploy to comment on PRs (without write permissions for checks the action doesn't post a comment to the PR, we don't know why)

--- a/.github/workflows/app_ci.yml
+++ b/.github/workflows/app_ci.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Install FVM
         run: |
-          flutter pub global activate fvm
+          flutter pub global activate fvm 2.4.1
           fvm config --cache-path '${{ runner.tool_cache }}/flutter'
 
       - name: Activate sz_repo_cli package
@@ -135,7 +135,7 @@ jobs:
 
       - name: Install FVM
         run: |
-          flutter pub global activate fvm
+          flutter pub global activate fvm 2.4.1
           fvm config --cache-path '${{ runner.tool_cache }}/flutter'
 
       - name: Activate sz_repo_cli package
@@ -279,7 +279,7 @@ jobs:
 
       - name: Install FVM
         run: |
-          flutter pub global activate fvm
+          flutter pub global activate fvm 2.4.1
           fvm config --cache-path '${{ runner.tool_cache }}/flutter'
 
       - uses: futureware-tech/simulator-action@v1
@@ -348,7 +348,7 @@ jobs:
 
       - name: Install FVM
         run: |
-          flutter pub global activate fvm
+          flutter pub global activate fvm 2.4.1
           fvm config --cache-path '${{ runner.tool_cache }}/flutter'
 
       - name: Build web app

--- a/.github/workflows/app_ci.yml
+++ b/.github/workflows/app_ci.yml
@@ -282,7 +282,7 @@ jobs:
           flutter pub global activate fvm 2.4.1
           fvm config --cache-path '${{ runner.tool_cache }}/flutter'
 
-      - uses: futureware-tech/simulator-action@v1
+      - uses: futureware-tech/simulator-action@ae8f725abebda0c4c62629c7a2a5b826e161c9f1
         id: simulator
         with:
           model: "iPhone 13"

--- a/.github/workflows/cli_ci.yml
+++ b/.github/workflows/cli_ci.yml
@@ -38,7 +38,7 @@ jobs:
   # * https://github.com/github/docs/commit/4364076e0fb56c2579ae90cd048939eaa2c18954
   #   (workaround for required checks with path filters)
   changes:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       changesFound: ${{ steps.filter.outputs.changesFound }}
     steps:
@@ -68,7 +68,7 @@ jobs:
 
   analyze:
     needs: changes
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # In draft PRs we might use TODOs temporarily.
     # In this case the analyze pipeline would fail, thus we won't run it.
     if: ${{ github.event.pull_request.draft == false && needs.changes.outputs.changesFound == 'true' }}
@@ -109,7 +109,7 @@ jobs:
     #
     # When the Sharezone CLI supports filters for the test command (like
     # `--only="tools/sz_repo_cli"`), we can change this to a Linux runner.
-    runs-on: macos-latest
+    runs-on: macos-12
     if: ${{ needs.changes.outputs.changesFound == 'true' }}
     steps:
       - uses: actions/checkout@27135e314dd1818f797af1db9dae03a9f045786b

--- a/.github/workflows/cli_ci.yml
+++ b/.github/workflows/cli_ci.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Install FVM
         run: |
-          flutter pub global activate fvm
+          flutter pub global activate fvm 2.4.1
           fvm config --cache-path '${{ runner.tool_cache }}/flutter'
 
       - name: Activate sz_repo_cli package
@@ -128,7 +128,7 @@ jobs:
 
       - name: Install FVM
         run: |
-          flutter pub global activate fvm
+          flutter pub global activate fvm 2.4.1
           fvm config --cache-path '${{ runner.tool_cache }}/flutter'
 
       - name: Activate sz_repo_cli package

--- a/.github/workflows/cli_ci.yml
+++ b/.github/workflows/cli_ci.yml
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@27135e314dd1818f797af1db9dae03a9f045786b
 
       - name: Set Flutter version from FVM config file to environment variables
-        uses: kuhnroyal/flutter-fvm-config-action@v1
+        uses: kuhnroyal/flutter-fvm-config-action@e91317131a2da710b9cd9b7a24f2c0ade9eeb61d
 
       - uses: subosito/flutter-action@v2
         with:
@@ -115,7 +115,7 @@ jobs:
       - uses: actions/checkout@27135e314dd1818f797af1db9dae03a9f045786b
 
       - name: Set Flutter version from FVM config file to environment variables
-        uses: kuhnroyal/flutter-fvm-config-action@v1
+        uses: kuhnroyal/flutter-fvm-config-action@e91317131a2da710b9cd9b7a24f2c0ade9eeb61d
 
       - uses: subosito/flutter-action@v2
         with:

--- a/.github/workflows/cli_ci.yml
+++ b/.github/workflows/cli_ci.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Set Flutter version from FVM config file to environment variables
         uses: kuhnroyal/flutter-fvm-config-action@e91317131a2da710b9cd9b7a24f2c0ade9eeb61d
 
-      - uses: subosito/flutter-action@v2
+      - uses: subosito/flutter-action@dbf1fa04f4d2e52c33185153d06cdb5443aa189d
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: ${{ env.FLUTTER_CHANNEL }}
@@ -117,7 +117,7 @@ jobs:
       - name: Set Flutter version from FVM config file to environment variables
         uses: kuhnroyal/flutter-fvm-config-action@e91317131a2da710b9cd9b7a24f2c0ade9eeb61d
 
-      - uses: subosito/flutter-action@v2
+      - uses: subosito/flutter-action@dbf1fa04f4d2e52c33185153d06cdb5443aa189d
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: ${{ env.FLUTTER_CHANNEL }}

--- a/.github/workflows/cli_ci.yml
+++ b/.github/workflows/cli_ci.yml
@@ -42,7 +42,7 @@ jobs:
     outputs:
       changesFound: ${{ steps.filter.outputs.changesFound }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@27135e314dd1818f797af1db9dae03a9f045786b
       - uses: AurorNZ/paths-filter@v3
         id: filter
         with:
@@ -73,7 +73,7 @@ jobs:
     # In this case the analyze pipeline would fail, thus we won't run it.
     if: ${{ github.event.pull_request.draft == false && needs.changes.outputs.changesFound == 'true' }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@27135e314dd1818f797af1db9dae03a9f045786b
 
       - name: Set Flutter version from FVM config file to environment variables
         uses: kuhnroyal/flutter-fvm-config-action@v1
@@ -112,7 +112,7 @@ jobs:
     runs-on: macos-latest
     if: ${{ needs.changes.outputs.changesFound == 'true' }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@27135e314dd1818f797af1db9dae03a9f045786b
 
       - name: Set Flutter version from FVM config file to environment variables
         uses: kuhnroyal/flutter-fvm-config-action@v1

--- a/.github/workflows/cli_ci.yml
+++ b/.github/workflows/cli_ci.yml
@@ -43,7 +43,7 @@ jobs:
       changesFound: ${{ steps.filter.outputs.changesFound }}
     steps:
       - uses: actions/checkout@27135e314dd1818f797af1db9dae03a9f045786b
-      - uses: AurorNZ/paths-filter@v3
+      - uses: AurorNZ/paths-filter@1497c53e78ed46e4d9fcb735b3870e1a504bdb10
         id: filter
         with:
           filters: |

--- a/.github/workflows/label_app_preview.yaml
+++ b/.github/workflows/label_app_preview.yaml
@@ -28,7 +28,7 @@ jobs:
     # list of labels. For example, if the PR is labeled with "build-app-preview"
     # and "bug", the job will be triggered when the label "bug" is removed.
     if: contains(github.event.pull_request.labels.*.name, 'build-app-preview')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       CODEMAGIC_TOKEN: ${{ secrets.CODEMAGIC_TOKEN }}
       # From https://codemagic.io/app/62d2f58c726fce097e34c0b4/

--- a/.github/workflows/licence.yml
+++ b/.github/workflows/licence.yml
@@ -27,7 +27,7 @@ permissions: {}
 
 jobs:
   check-files-licence-headers:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@27135e314dd1818f797af1db9dae03a9f045786b
       - uses: actions/setup-go@v2

--- a/.github/workflows/licence.yml
+++ b/.github/workflows/licence.yml
@@ -29,7 +29,7 @@ jobs:
   check-files-licence-headers:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@27135e314dd1818f797af1db9dae03a9f045786b
       - uses: actions/setup-go@v2
         with:
           go-version: '^1.13.1'

--- a/.github/workflows/licence.yml
+++ b/.github/workflows/licence.yml
@@ -33,5 +33,5 @@ jobs:
       - uses: actions/setup-go@c51a7207680f1bee06f4a751214aab70667f9e25
         with:
           go-version: '^1.13.1'
-      - run: go install github.com/google/addlicense@latest 
+      - run: go install github.com/google/addlicense@v1.1.1 
       - run: ./bin/check_license_headers.sh

--- a/.github/workflows/licence.yml
+++ b/.github/workflows/licence.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@27135e314dd1818f797af1db9dae03a9f045786b
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@c51a7207680f1bee06f4a751214aab70667f9e25
         with:
           go-version: '^1.13.1'
       - run: go install github.com/google/addlicense@latest 

--- a/.github/workflows/pull_request_label.yml
+++ b/.github/workflows/pull_request_label.yml
@@ -36,7 +36,7 @@ jobs:
   label:
     permissions:
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
       - uses: actions/labeler@a96e5aec3e3d5caaefde174986c02d40560a0b91

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -29,7 +29,7 @@ workflows:
     name: App Preview
     max_build_duration: 75
     environment:
-      xcode: latest
+      xcode: 14.3
       groups:
         - github
         - ios-publishing
@@ -50,7 +50,7 @@ workflows:
         # there is our .fvm folder with all the FVM configurations.
         working_directory: .
         script: |
-          dart pub global activate fvm
+          dart pub global activate fvm 2.4.1
           fvm install
       - name: iOS code signing
         script: |
@@ -87,5 +87,5 @@ workflows:
       scripts:
         - name: Post App Preview
           script: |
-            dart pub global activate codemagic_app_preview
+            dart pub global activate codemagic_app_preview 0.0.3
             app_preview post --gh_token $GITHUB_PAT --message "_Note_: Only Sharezone team members are able to install the iOS app."


### PR DESCRIPTION
To follow [security best practices](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) and to have a deterministic setup, we fix our version for tools and Actions that we are using in our CI. 

This PR updates also some Actions because some Actions haven't published an update for months but committed new changes.