### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,11 @@
+# Copyright (c) 2022 Sharezone UG (haftungsbeschränkt)
+# Licensed under the EUPL-1.2-or-later.
+#
+# You may obtain a copy of the Licence at:
+# https://joinup.ec.europa.eu/software/page/eupl
+#
+# SPDX-License-Identifier: EUPL-1.2
+
 # To keep our dependencies up to date, we use Dependabot.
 #
 # This file configures the Dependabot. See

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To keep our dependencies up to date, we use Dependabot.
+#
+# This file configures the Dependabot. See
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates
+
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -9,6 +9,7 @@
 "ci/cd":
 - .github/workflows/**
 - .github/labeler.yml
+- .github/dependabot.yml
 - codemagic.yaml
 
 "documentation":


### PR DESCRIPTION
Dependabot allows us to automatically keep our dependencies up to date. For now, we are only using the Dependabot for our GitHub Actions.

Copied from https://github.com/firebase/flutterfire/blob/master/.github/dependabot.yml

(This PR should be merged after #478)