### PR TITLE
Add `sharezone_lints` to `sharezone_about_page_addon` package

### DIFF
--- a/lib/sharezone_about_page_addon/analysis_options.yaml
+++ b/lib/sharezone_about_page_addon/analysis_options.yaml
@@ -1,0 +1,9 @@
+# Copyright (c) 2023 Sharezone UG (haftungsbeschränkt)
+# Licensed under the EUPL-1.2-or-later.
+#
+# You may obtain a copy of the Licence at:
+# https://joinup.ec.europa.eu/software/page/eupl
+#
+# SPDX-License-Identifier: EUPL-1.2
+
+include: package:sharezone_lints/analysis_options.yaml

--- a/lib/sharezone_about_page_addon/lib/game/custom/util.dart
+++ b/lib/sharezone_about_page_addon/lib/game/custom/util.dart
@@ -8,7 +8,7 @@
 
 import 'dart:math';
 
-late Random rnd = Random();
+Random rnd = Random();
 
 double getRandomNum(double min, double max) =>
     (rnd.nextDouble() * (max - min + 1)).floor() + min;

--- a/lib/sharezone_about_page_addon/lib/sharezone_about_page_addon.dart
+++ b/lib/sharezone_about_page_addon/lib/sharezone_about_page_addon.dart
@@ -37,7 +37,7 @@ class TrexPage extends StatelessWidget {
         children: <Widget>[
           Container(
             decoration: const BoxDecoration(color: Colors.white),
-            child: TRexGameWrapper(),
+            child: const TRexGameWrapper(),
           ),
           Padding(
             padding: const EdgeInsets.all(8.0),
@@ -68,8 +68,10 @@ class TrexPage extends StatelessWidget {
 }
 
 class TRexGameWrapper extends StatefulWidget {
+  const TRexGameWrapper({Key? key}) : super(key: key);
+
   @override
-  _TRexGameWrapperState createState() => _TRexGameWrapperState();
+  State createState() => _TRexGameWrapperState();
 }
 
 TRexGame? _game;

--- a/lib/sharezone_about_page_addon/pubspec.lock
+++ b/lib/sharezone_about_page_addon/pubspec.lock
@@ -110,6 +110,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.5"
+  flutter_lints:
+    dependency: transitive
+    description:
+      name: flutter_lints
+      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -131,6 +139,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.5"
+  lints:
+    dependency: transitive
+    description:
+      name: lints
+      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   matcher:
     dependency: transitive
     description:
@@ -179,6 +195,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
+  sharezone_lints:
+    dependency: "direct dev"
+    description:
+      path: "../sharezone_lints"
+      relative: true
+    source: path
+    version: "1.0.0"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/lib/sharezone_about_page_addon/pubspec.yaml
+++ b/lib/sharezone_about_page_addon/pubspec.yaml
@@ -19,8 +19,9 @@ dependencies:
     sdk: flutter
   flame: 1.0.0-rc9
 
-
 dev_dependencies:
   flutter_launcher_icons: ^0.7.3
   flutter_test:
     sdk: flutter
+  sharezone_lints:
+    path: ../sharezone_lints


### PR DESCRIPTION
This PR adds `sharezone_lints` to the `sharezone_about_page_addon` package and fixes the following lint warnings:

```
Analyzing sharezone_about_page_addon...                                 

   info • Unnecessary 'late' modifier • lib/game/custom/util.dart:11:13 • unnecessary_late
   info • Constructors for public widgets should have a named 'key' parameter • lib/sharezone_about_page_addon.dart:70:7
          • use_key_in_widget_constructors
   info • Invalid use of a private type in a public API • lib/sharezone_about_page_addon.dart:72:3 •
          library_private_types_in_public_api

3 issues found. (ran in 1.0s)
```

Part of #37