### PR TITLE
Add `sharezone_lints` to `remote_configuration` package

### DIFF
--- a/lib/remote_configuration/analysis_options.yaml
+++ b/lib/remote_configuration/analysis_options.yaml
@@ -1,0 +1,9 @@
+# Copyright (c) 2023 Sharezone UG (haftungsbeschränkt)
+# Licensed under the EUPL-1.2-or-later.
+#
+# You may obtain a copy of the Licence at:
+# https://joinup.ec.europa.eu/software/page/eupl
+#
+# SPDX-License-Identifier: EUPL-1.2
+
+include: package:sharezone_lints/analysis_options.yaml

--- a/lib/remote_configuration/lib/src/implementation/firebase_remote_configuration.dart
+++ b/lib/remote_configuration/lib/src/implementation/firebase_remote_configuration.dart
@@ -6,6 +6,8 @@
 //
 // SPDX-License-Identifier: EUPL-1.2
 
+import 'dart:developer';
+
 import 'package:firebase_remote_config/firebase_remote_config.dart';
 
 import '../remote_configuration.dart';
@@ -37,7 +39,7 @@ class FirebaseRemoteConfiguration extends RemoteConfiguration {
           minimumFetchInterval: const Duration(hours: 3)));
       await _remoteConfig.fetchAndActivate();
     } catch (e) {
-      print("Error fetch remote config: $e");
+      log("Error fetch remote config: $e");
     }
   }
 }

--- a/lib/remote_configuration/lib/src/implementation/stub_remote_configuration.dart
+++ b/lib/remote_configuration/lib/src/implementation/stub_remote_configuration.dart
@@ -11,6 +11,7 @@ import '../remote_configuration.dart';
 class StubRemoteConfiguration extends RemoteConfiguration {
   Map<String, dynamic> _defaultValues = {};
 
+  @override
   String getString(String key) {
     return _defaultValues[key] ?? '';
   }

--- a/lib/remote_configuration/pubspec.lock
+++ b/lib/remote_configuration/pubspec.lock
@@ -142,6 +142,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_lints:
+    dependency: transitive
+    description:
+      name: flutter_lints
+      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -160,6 +168,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.5"
+  lints:
+    dependency: transitive
+    description:
+      name: lints
+      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   matcher:
     dependency: transitive
     description:
@@ -208,6 +224,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.27.7"
+  sharezone_lints:
+    dependency: "direct dev"
+    description:
+      path: "../sharezone_lints"
+      relative: true
+    source: path
+    version: "1.0.0"
   sharezone_utils:
     dependency: "direct main"
     description:

--- a/lib/remote_configuration/pubspec.yaml
+++ b/lib/remote_configuration/pubspec.yaml
@@ -24,5 +24,5 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-
-flutter: null
+  sharezone_lints:
+    path: ../sharezone_lints


### PR DESCRIPTION
This PR adds `sharezone_lints` to the `remote_configuration` package and fixes the following lint warnings:

```
Analyzing remote_configuration...                                       

   info • Don't invoke 'print' in production code • lib/src/implementation/firebase_remote_configuration.dart:40:7 •
          avoid_print
   info • The member 'getString' overrides an inherited member but isn't annotated with '@override' •
          lib/src/implementation/stub_remote_configuration.dart:14:10 • annotate_overrides

2 issues found. (ran in 1.1s)
```

Part of #37