### PR TITLE
Add `sharezone_lints` to `key_value_store` package

### DIFF
--- a/lib/key_value_store/analysis_options.yaml
+++ b/lib/key_value_store/analysis_options.yaml
@@ -1,0 +1,9 @@
+# Copyright (c) 2023 Sharezone UG (haftungsbeschränkt)
+# Licensed under the EUPL-1.2-or-later.
+#
+# You may obtain a copy of the Licence at:
+# https://joinup.ec.europa.eu/software/page/eupl
+#
+# SPDX-License-Identifier: EUPL-1.2
+
+include: package:sharezone_lints/analysis_options.yaml

--- a/lib/key_value_store/pubspec.lock
+++ b/lib/key_value_store/pubspec.lock
@@ -81,6 +81,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.4"
+  flutter_lints:
+    dependency: transitive
+    description:
+      name: flutter_lints
+      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   frontend_server_client:
     dependency: transitive
     description:
@@ -129,6 +137,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.7"
+  lints:
+    dependency: transitive
+    description:
+      name: lints
+      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   logging:
     dependency: transitive
     description:
@@ -201,6 +217,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
+  sharezone_lints:
+    dependency: "direct dev"
+    description:
+      path: "../sharezone_lints"
+      relative: true
+    source: path
+    version: "1.0.0"
   shelf:
     dependency: transitive
     description:

--- a/lib/key_value_store/pubspec.yaml
+++ b/lib/key_value_store/pubspec.yaml
@@ -9,7 +9,6 @@
 name: key_value_store
 description: A key-value-store.
 version: 0.0.1
-homepage:
 publish_to: none
 
 environment:
@@ -17,3 +16,5 @@ environment:
 
 dev_dependencies:
   test: ^1.23.1
+  sharezone_lints:
+    path: ../sharezone_lints


### PR DESCRIPTION
This PR adds `sharezone_lints` to the `key_value_store` package. There were no warnings to fix.

Part of #37 
