### PR TITLE
Add `sharezone_lints` to `date` package

### DIFF
--- a/lib/date/analysis_options.yaml
+++ b/lib/date/analysis_options.yaml
@@ -1,0 +1,9 @@
+# Copyright (c) 2023 Sharezone UG (haftungsbeschränkt)
+# Licensed under the EUPL-1.2-or-later.
+#
+# You may obtain a copy of the Licence at:
+# https://joinup.ec.europa.eu/software/page/eupl
+#
+# SPDX-License-Identifier: EUPL-1.2
+
+include: package:sharezone_lints/analysis_options.yaml

--- a/lib/date/lib/src/fuzzy_date_time_string.dart
+++ b/lib/date/lib/src/fuzzy_date_time_string.dart
@@ -17,13 +17,14 @@ String getFuzzyDateTimeString(BuildContext context, DateTime dateTime) {
     return TimeOfDay.fromDateTime(dateTime).format(context);
   } else {
     final dateYesterday = dateToday.addDays(-1);
-    if (dateOfDateTime.isSameDay(dateYesterday))
+    if (dateOfDateTime.isSameDay(dateYesterday)) {
       return 'Gestern';
-    else {
-      if (dateOfDateTime.year == dateToday.year)
+    } else {
+      if (dateOfDateTime.year == dateToday.year) {
         return dateOfDateTime.parser.toMMMEd;
-      else
+      } else {
         return dateOfDateTime.parser.toYMMMd;
+      }
     }
   }
 }

--- a/lib/date/pubspec.lock
+++ b/lib/date/pubspec.lock
@@ -220,6 +220,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_lints:
+    dependency: transitive
+    description:
+      name: flutter_lints
+      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   flutter_test:
     dependency: transitive
     description: flutter
@@ -254,6 +262,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.5"
+  lints:
+    dependency: transitive
+    description:
+      name: lints
+      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   matcher:
     dependency: transitive
     description:
@@ -317,6 +333,13 @@ packages:
       relative: true
     source: path
     version: "0.0.1"
+  sharezone_lints:
+    dependency: "direct dev"
+    description:
+      path: "../sharezone_lints"
+      relative: true
+    source: path
+    version: "1.0.0"
   sharezone_utils:
     dependency: transitive
     description:

--- a/lib/date/pubspec.yaml
+++ b/lib/date/pubspec.yaml
@@ -12,7 +12,7 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   sharezone_common:
@@ -22,39 +22,6 @@ dependencies:
   flutter:
     sdk: flutter
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter.
-flutter:
-
-  # To add assets to your package, add an assets section, like this:
-  # assets:
-  #  - images/a_dot_burr.jpeg
-  #  - images/a_dot_ham.jpeg
-  #
-  # For details regarding assets in packages, see
-  # https://flutter.dev/assets-and-images/#from-packages
-  #
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/assets-and-images/#resolution-aware.
-
-  # To add custom fonts to your package, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts in packages, see
-  # https://flutter.dev/custom-fonts/#from-packages
+dev_dependencies:
+  sharezone_lints:
+    path: ../sharezone_lints


### PR DESCRIPTION
This PR adds `sharezone_lints` to the `date` package and fixes the following lint warnings:

```
Analyzing date...                                                       

   info • Statements in an if should be enclosed in a block • lib/src/fuzzy_date_time_string.dart:21:7 •
          curly_braces_in_flow_control_structures
   info • Statements in an if should be enclosed in a block • lib/src/fuzzy_date_time_string.dart:24:9 •
          curly_braces_in_flow_control_structures
   info • Statements in an if should be enclosed in a block • lib/src/fuzzy_date_time_string.dart:26:9 •
          curly_braces_in_flow_control_structures

3 issues found. (ran in 1.5s)
```

Part of #37