### PR TITLE
Add `sharezone_lints` to `crash_analytics` package

### DIFF
--- a/lib/crash_analytics/analysis_options.yaml
+++ b/lib/crash_analytics/analysis_options.yaml
@@ -1,0 +1,9 @@
+# Copyright (c) 2023 Sharezone UG (haftungsbeschränkt)
+# Licensed under the EUPL-1.2-or-later.
+#
+# You may obtain a copy of the Licence at:
+# https://joinup.ec.europa.eu/software/page/eupl
+#
+# SPDX-License-Identifier: EUPL-1.2
+
+include: package:sharezone_lints/analysis_options.yaml

--- a/lib/crash_analytics/lib/src/implementation/stub_crash_analytics.dart
+++ b/lib/crash_analytics/lib/src/implementation/stub_crash_analytics.dart
@@ -19,17 +19,17 @@ class StubCrashAnalytics extends CrashAnalytics {
 
   @override
   Future<void> recordError(exception, StackTrace stack) async {
-    return null;
+    return;
   }
 
   @override
   Future<void> recordFlutterError(FlutterErrorDetails details) async {
-    return null;
+    return;
   }
 
   @override
   Future<void> setUserIdentifier(String identifier) async {
-    return null;
+    return;
   }
 
   @override

--- a/lib/crash_analytics/pubspec.lock
+++ b/lib/crash_analytics/pubspec.lock
@@ -102,6 +102,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_lints:
+    dependency: transitive
+    description:
+      name: flutter_lints
+      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -120,6 +128,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.5"
+  lints:
+    dependency: transitive
+    description:
+      name: lints
+      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   matcher:
     dependency: transitive
     description:
@@ -160,6 +176,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  sharezone_lints:
+    dependency: "direct dev"
+    description:
+      path: "../sharezone_lints"
+      relative: true
+    source: path
+    version: "1.0.0"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/lib/crash_analytics/pubspec.yaml
+++ b/lib/crash_analytics/pubspec.yaml
@@ -12,7 +12,7 @@ version: 0.0.1
 publish_to: none
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:
@@ -22,5 +22,5 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-
-flutter: null
+  sharezone_lints:
+    path: ../sharezone_lints


### PR DESCRIPTION
This PR adds `sharezone_lints` to the `crash_analytics` package and fixes the following lint warnings:

```
Analyzing crash_analytics...                                            

   info • Don't return 'null' from a method with a return type of 'void' •
          lib/src/implementation/stub_crash_analytics.dart:22:5 • avoid_returning_null_for_void
   info • Don't return 'null' from a method with a return type of 'void' •
          lib/src/implementation/stub_crash_analytics.dart:27:5 • avoid_returning_null_for_void
   info • Don't return 'null' from a method with a return type of 'void' •
          lib/src/implementation/stub_crash_analytics.dart:32:5 • avoid_returning_null_for_void

3 issues found. (ran in 1.4s)
```

Part of #37