### PR TITLE
Add `sharezone_lints` to `build_context` package

### DIFF
--- a/lib/build_context/analysis_options.yaml
+++ b/lib/build_context/analysis_options.yaml
@@ -1,0 +1,9 @@
+# Copyright (c) 2023 Sharezone UG (haftungsbeschränkt)
+# Licensed under the EUPL-1.2-or-later.
+#
+# You may obtain a copy of the Licence at:
+# https://joinup.ec.europa.eu/software/page/eupl
+#
+# SPDX-License-Identifier: EUPL-1.2
+
+include: package:sharezone_lints/analysis_options.yaml

--- a/lib/build_context/lib/src/build_context_impl.dart
+++ b/lib/build_context/lib/src/build_context_impl.dart
@@ -19,10 +19,11 @@ extension MediaQueryExt on BuildContext {
     if (mediaQuerySize.width < 700) {
       return false;
     } else if (mediaQuerySize.width >= 700 && mediaQuerySize.width <= 700) {
-      if (mediaQuerySize.height > 500)
+      if (mediaQuerySize.height > 500) {
         return true;
-      else
+      } else {
         return false;
+      }
     } else {
       return true;
     }

--- a/lib/build_context/pubspec.lock
+++ b/lib/build_context/pubspec.lock
@@ -54,6 +54,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_lints:
+    dependency: transitive
+    description:
+      name: flutter_lints
+      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -67,6 +75,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.5"
+  lints:
+    dependency: transitive
+    description:
+      name: lints
+      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   matcher:
     dependency: transitive
     description:
@@ -99,6 +115,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.8.2"
+  sharezone_lints:
+    dependency: "direct dev"
+    description:
+      path: "../sharezone_lints"
+      relative: true
+    source: path
+    version: "1.0.0"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/lib/build_context/pubspec.yaml
+++ b/lib/build_context/pubspec.yaml
@@ -12,7 +12,7 @@ version: 0.0.1
 publish_to: none
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:
@@ -21,5 +21,5 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-
-flutter:
+  sharezone_lints:
+    path: ../sharezone_lints


### PR DESCRIPTION
This PR adds `sharezone_lints` to the `build_context` package and fixes the following lint warnings:

```
Analyzing build_context...                                              

   info • Statements in an if should be enclosed in a block • lib/src/build_context_impl.dart:23:9 •
          curly_braces_in_flow_control_structures
   info • Statements in an if should be enclosed in a block • lib/src/build_context_impl.dart:25:9 •
          curly_braces_in_flow_control_structures

2 issues found. (ran in 1.3s)
```

Part of #37