### PR TITLE
Add `sharezone_lints` to `bloc_provider` package

### DIFF
--- a/lib/bloc_provider/analysis_options.yaml
+++ b/lib/bloc_provider/analysis_options.yaml
@@ -1,0 +1,9 @@
+# Copyright (c) 2023 Sharezone UG (haftungsbeschränkt)
+# Licensed under the EUPL-1.2-or-later.
+#
+# You may obtain a copy of the Licence at:
+# https://joinup.ec.europa.eu/software/page/eupl
+#
+# SPDX-License-Identifier: EUPL-1.2
+
+include: package:sharezone_lints/analysis_options.yaml

--- a/lib/bloc_provider/lib/src/bloc_provider.dart
+++ b/lib/bloc_provider/lib/src/bloc_provider.dart
@@ -22,7 +22,7 @@ class BlocProvider<T extends BlocBase> extends StatefulWidget {
   final Widget? child;
 
   @override
-  _BlocProviderState<T> createState() => _BlocProviderState<T>();
+  State createState() => _BlocProviderState<T>();
 
   static T of<T extends BlocBase>(BuildContext context) {
     final type = _typeOf<BlocProvider<T>>();

--- a/lib/bloc_provider/pubspec.lock
+++ b/lib/bloc_provider/pubspec.lock
@@ -61,6 +61,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_lints:
+    dependency: transitive
+    description:
+      name: flutter_lints
+      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -74,6 +82,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.5"
+  lints:
+    dependency: transitive
+    description:
+      name: lints
+      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   matcher:
     dependency: transitive
     description:
@@ -106,6 +122,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.8.2"
+  sharezone_lints:
+    dependency: "direct dev"
+    description:
+      path: "../sharezone_lints"
+      relative: true
+    source: path
+    version: "1.0.0"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/lib/bloc_provider/pubspec.yaml
+++ b/lib/bloc_provider/pubspec.yaml
@@ -9,11 +9,10 @@
 name: bloc_provider
 description: A new Flutter package project.
 version: 0.0.1
-homepage:
 publish_to: none
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:
@@ -24,40 +23,5 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter.
-flutter:
-
-  # To add assets to your package, add an assets section, like this:
-  # assets:
-  #  - images/a_dot_burr.jpeg
-  #  - images/a_dot_ham.jpeg
-  #
-  # For details regarding assets in packages, see
-  # https://flutter.dev/assets-and-images/#from-packages
-  #
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/assets-and-images/#resolution-aware.
-
-  # To add custom fonts to your package, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts in packages, see
-  # https://flutter.dev/custom-fonts/#from-packages
+  sharezone_lints:
+    path: ../sharezone_lints


### PR DESCRIPTION
This PR adds `sharezone_lints` to the `bloc_provider` package and fixes the following lint warnings:

```
Analyzing bloc_provider...                                              

   info • Invalid use of a private type in a public API • lib/src/bloc_provider.dart:25:3 •
          library_private_types_in_public_api

1 issue found. (ran in 1.4s)
```

Part of #37