### PR TITLE
Remove `repo-token` attribute for labeler

### DIFF
--- a/.github/workflows/pull_request_label.yml
+++ b/.github/workflows/pull_request_label.yml
@@ -35,10 +35,11 @@ jobs:
   # For more information, see: https://github.com/actions/labeler
   label:
     permissions:
+      # Required by the labeler action, see:
+      # https://github.com/actions/labeler#inputs
+      contents: read
       pull-requests: write
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
       - uses: actions/labeler@59036c7b951d5b450848fd1b2b014c036cf91f46
-        with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
`GITHUB.TOKEN` is now the default `repo-token`. Therefore, we don't need to explicitly provide the `GITHUB.TOKEN`. See https://github.com/actions/labeler/pull/227 for more information. 