### PR TITLE
Don't explicitly pass `CERTIFICATE_PRIVATE_KEY` to Codemagic CLI Tools for `deploy-alpha-ios-app`

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -219,9 +219,9 @@ jobs:
 
     - name: Setup signing
       env:
-        CERTIFICATE_PRIVATE_KEY: ${{ secrets.SHAREZONE_CERTIFICATE_PRIVATE_KEY }}
         # The following secrets are used by the Codemagic CLI tool. It's important
         # to use the same names as the CLI tool expects.
+        CERTIFICATE_PRIVATE_KEY: ${{ secrets.SHAREZONE_CERTIFICATE_PRIVATE_KEY }}
         APP_STORE_CONNECT_KEY_IDENTIFIER: ${{ secrets.SHAREZONE_APP_STORE_CONNECT_KEY_IDENTIFIER }}
         APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.SHAREZONE_APP_STORE_CONNECT_ISSUER_ID }}
         APP_STORE_CONNECT_PRIVATE_KEY: ${{ secrets.SHAREZONE_APP_STORE_CONNECT_PRIVATE_KEY }}
@@ -230,7 +230,6 @@ jobs:
         app-store-connect fetch-signing-files $(xcode-project detect-bundle-id) \
           --platform IOS \
           --type IOS_APP_STORE \
-          --certificate-key=@env:CERTIFICATE_PRIVATE_KEY \
           --create
         keychain add-certificates
         xcode-project use-profiles


### PR DESCRIPTION
Passing `CERTIFICATE_PRIVATE_KEY` with `--certificate-key=@env:CERTIFICATE_PRIVATE_KEY` is useless because the CLI uses as default `CERTIFICATE_PRIVATE_KEY`, see https://github.com/codemagic-ci-cd/cli-tools/blob/master/docs/app-store-connect/list-certificates.md#--certificate-keyprivate_key.