### PR TITLE
Increase test timeout to 15 minutes.

### DIFF
--- a/.github/workflows/app_ci.yml
+++ b/.github/workflows/app_ci.yml
@@ -145,8 +145,7 @@ jobs:
       - run: echo $(pwd)/bin >> $GITHUB_PATH
       
       - name: Run tests via "sz test"
-        run: sz test -c 4
-      
+        run: sz test -c 4 --package-timeout-minutes 15      
       # Uploads the results of failed tests as .zip to GitHub.
       #
       # You can find the file under the "Summary" Tab on GitHub when all jobs of

--- a/.github/workflows/cli_ci.yml
+++ b/.github/workflows/cli_ci.yml
@@ -138,4 +138,4 @@ jobs:
       - run: echo $(pwd)/bin >> $GITHUB_PATH
 
       - name: Run tests via "sz test"
-        run: sz test -c 4
+        run: sz test -c 4 --package-timeout-minutes 15


### PR DESCRIPTION
In #504 running `sz test` timed out for the `sharezone` package. From what I can see it doesn't have something to do with the PR in #504 itself, so I increase the timeout from 10 to 15 minutes.