### PR TITLE
Remove `app/lib/generated_plugin_registrant.dart` from `gitignore`

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -31,9 +31,6 @@
 .pub/
 /build/
 
-# Web related
-lib/generated_plugin_registrant.dart
-
 # Symbolication related
 app.*.symbols
 


### PR DESCRIPTION
The Flutter CLI removes the `app/lib/generated_plugin_registrant.dart` automatically from `.gitignore` because it does not exist anymore, see https://github.com/flutter/flutter/pull/102185.

```
$ flutter build web
Running "flutter pub get" in flutter_example...                  1,041ms

💪 Building with sound null safety 💪

generated_plugin_registrant.dart found. Deleted.
Upgrading .gitignore
Compiling lib/main.dart for the Web...                             8.5s
```

This PR removes the `lib/generated_plugin_registrant.dart` from `.gitignore` as the Flutter CLI does when building for web.