### PR TITLE
Remove deprecated Android `SplashScreenDrawable`.

### DIFF
--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -28,7 +28,6 @@
         <meta-data android:name="flutterEmbedding" android:value="2" />
 
         <activity android:name=".MainActivity" android:launchMode="singleTop" android:theme="@style/LaunchTheme" android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density" android:hardwareAccelerated="true" android:windowSoftInputMode="adjustResize">
-            <meta-data android:name="io.flutter.embedding.android.SplashScreenDrawable" android:resource="@drawable/launch_background" />
             <meta-data android:name="io.flutter.embedding.android.LaunchTheme" android:resource="@style/LaunchTheme" />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>


### PR DESCRIPTION
We still used an deprecated way to declare a splash screen, which caused the following warning to be printed on Android start-up: `W/FlutterActivityAndFragmentDelegate( 6179): A splash screen was provided to Flutter, but this is deprecated. See flutter.dev/go/android-splash-migration for migration steps.`

Since we also already use the recommand way to declare a splash screen additionally, we just had to remove the old way. There are no behavior / splash screen changes, everything works as it used to.