### PR TITLE
Treat TODOs as warnings.

### DIFF
--- a/app/analysis_options.yaml
+++ b/app/analysis_options.yaml
@@ -14,8 +14,8 @@ analyzer:
     missing_required_param: warning
     # treat missing returns as a warning (not a hint)
     missing_return: warning
-    # allow having TODOs in the code
-    todo: true
+    # Disallow TODOs
+    todo: warning
     # treat unrealated == as a warning (not a hint)
     unrelated_type_equality_checks: warning
   exclude:

--- a/lib/sharezone_lints/lib/analysis_options.yaml
+++ b/lib/sharezone_lints/lib/analysis_options.yaml
@@ -9,6 +9,8 @@
 include: package:flutter_lints/flutter.yaml
 
 analyzer:
+  errors:
+    todo: warning
   exclude:
     # Generated files with build_runner
     - "**/*.g.dart"

--- a/tools/sz_repo_cli/analysis_options.yaml
+++ b/tools/sz_repo_cli/analysis_options.yaml
@@ -18,5 +18,5 @@ include: package:pedantic/analysis_options.yaml
 #     - camel_case_types
 
 analyzer:
-#   exclude:
-#     - path/to/excluded/files/**
+  errors:
+    todo: warning


### PR DESCRIPTION
By treating TODOs as warnings we can use the normal Dart analyzer instead of using the deprecated `package:tuneup` to run `sz analyze` and fail if TODOs are found (see https://github.com/SharezoneApp/sharezone-app/issues/480).