### PR TITLE
Replace `package:tuneup` with the Dart analyzer.

### DIFF
--- a/tools/sz_repo_cli/lib/src/commands/src/analyze_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/analyze_command.dart
@@ -24,14 +24,6 @@ class AnalyzeCommand extends ConcurrentCommand {
   Duration get defaultPackageTimeout => Duration(minutes: 5);
 
   @override
-  Future<void> runSetup() async {
-    print('Activating tuneup package...');
-    await runProcessSucessfullyOrThrow(
-        'fvm', ['dart', 'pub', 'global', 'activate', 'tuneup'],
-        workingDirectory: repo.sharezoneFlutterApp.location.path);
-  }
-
-  @override
   Future<void> runTaskForPackage(Package package) {
     return package.analyzePackage();
   }

--- a/tools/sz_repo_cli/lib/src/common/src/package.dart
+++ b/tools/sz_repo_cli/lib/src/common/src/package.dart
@@ -74,16 +74,14 @@ abstract class Package {
 
   Future<void> analyzePackage() async {
     await getPackages();
-    await _runTuneup();
+    await _runDartAnalyze();
     await _checkForCommentsWithBadSpacing();
   }
 
-  Future<void> _runTuneup() async {
-    await runProcessSucessfullyOrThrow(
-      'fvm',
-      ['dart', 'pub', 'global', 'run', 'tuneup', 'check', '--fail-on-todos'],
-      workingDirectory: location.path,
-    );
+  Future<void> _runDartAnalyze() {
+    return runProcessSucessfullyOrThrow(
+        'fvm', ['dart', 'analyze', '--fatal-infos', '--fatal-warnings'],
+        workingDirectory: location.path);
   }
 
   Future<void> _checkForCommentsWithBadSpacing() async {


### PR DESCRIPTION
Replace the deprecated `package:tuneup` with the Dart analyzer to check for analyzer errors/warnings/infos when running `sz analyze`. See: https://github.com/SharezoneApp/sharezone-app/issues/480

Closes #480.