### PR TITLE
Cancel CI for outdated commits in a PR

### DIFF
--- a/.github/workflows/app_ci.yml
+++ b/.github/workflows/app_ci.yml
@@ -11,6 +11,14 @@
 
 name: app-ci
 
+concurrency:
+  group: app-ci-${{ github.head_ref }}
+  # In order to conserve the use of GitHub Actions, we cancel the running action
+  # of the previous commit. This means that if you first commit "A" and then
+  # commit "B" to the pull request a few minutes later, the workflow for commit
+  # "A" will be cancelled.
+  cancel-in-progress: true
+
 on:
   # Triggers the workflow on pull request events
   pull_request:

--- a/.github/workflows/cli_ci.yml
+++ b/.github/workflows/cli_ci.yml
@@ -8,6 +8,14 @@
 
 name: cli-ci
 
+concurrency:
+  group: app-ci-${{ github.head_ref }}
+  # In order to conserve the use of GitHub Actions, we cancel the running action
+  # of the previous commit. This means that if you first commit "A" and then
+  # commit "B" to the pull request a few minutes later, the workflow for commit
+  # "A" will be cancelled.
+  cancel-in-progress: true
+
 on:
   pull_request:
     types:

--- a/.github/workflows/cli_ci.yml
+++ b/.github/workflows/cli_ci.yml
@@ -9,7 +9,7 @@
 name: cli-ci
 
 concurrency:
-  group: app-ci-${{ github.head_ref }}
+  group: cli-ci-${{ github.head_ref }}
   # In order to conserve the use of GitHub Actions, we cancel the running action
   # of the previous commit. This means that if you first commit "A" and then
   # commit "B" to the pull request a few minutes later, the workflow for commit


### PR DESCRIPTION
Because we had set the concurrency for the merge queue to 1 (because setting the value to > 1 has no effect because we only have 5 macOS machines), we are never running two 2 PRs at the same time. The reason why we removed this feature was that when 2 PRs were actively in the merge queue (running, not waiting) at the same time, the PRs were cancelled. So I think we add again the cancel-in-progress feature (I'm not 100% sure if it's going to work but I think it should).

<img width="430" alt="image" src="https://user-images.githubusercontent.com/24459435/229933740-9b0c75d7-f0f9-4ec1-a83a-8bf8ae088697.png">
