### PR TITLE
Remove `**/**file**` wildcard for "feature: universal file features" label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -234,7 +234,6 @@
 
 "feature: universal file features":
   - "**/filesharing/**"
-  - "**/**file**"
 
 "user: parent":
   - "**/parent/**"


### PR DESCRIPTION
This wildcard had too many false positives like `Podfile.lock`.