### PR TITLE
Fix picking the homework reminder minutes.

### DIFF
--- a/app/lib/timetable/src/edit_time.dart
+++ b/app/lib/timetable/src/edit_time.dart
@@ -8,7 +8,8 @@
 
 import 'package:bloc_provider/bloc_provider.dart';
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide TimePickerEntryMode;
+import 'package:interval_time_picker/interval_time_picker.dart';
 import 'package:sharezone/pages/settings/timetable_settings/time_picker_settings_cache.dart';
 import 'package:sharezone_common/helper_functions.dart';
 import 'package:sharezone_utils/platform.dart';
@@ -110,10 +111,11 @@ Future<Time> selectTime(BuildContext context,
     });
   }
 
-  return showTimePicker(
+  return showIntervalTimePicker(
     context: context,
     initialTime: initialTime?.toTimeOfDay() ?? TimeOfDay(hour: 9, minute: 10),
-    cancelText: 'Abbrechen'.toUpperCase(),
+    interval: 30,
+    visibleStep: VisibleStep.thirtieths,
     builder: (BuildContext context, Widget child) {
       return MediaQuery(
         data: MediaQuery.of(context).copyWith(alwaysUse24HourFormat: true),

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -1213,6 +1213,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  interval_time_picker:
+    dependency: "direct main"
+    description:
+      name: interval_time_picker
+      sha256: "5088b4d7bea298207cf92302fccf95bbbe0f51a902ac8736646d00da989c53ac"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0+5"
   intl:
     dependency: "direct main"
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -75,9 +75,6 @@ dependencies:
   firebase_messaging: ^14.4.0
   firebase_performance: ^0.9.1
   firebase_storage: ^11.1.0
-  # Used so that we can select a minute interval (only either XX:00 or XX:30)
-  # for the homework reminder time picker.
-  interval_time_picker: ^2.0.0+5
   flare_flutter: ^3.0.2
   flutter:
     sdk: flutter
@@ -99,6 +96,9 @@ dependencies:
     path: ../lib/hausaufgabenheft_logik
   holidays:
     path: ../lib/holidays
+  # Used so that we can select a minute interval (only either XX:00 or XX:30)
+  # for the homework reminder time picker.
+  interval_time_picker: ^2.0.0+5
   intl: ^0.17.0
   key_value_store:
     path: ../lib/key_value_store

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -75,6 +75,9 @@ dependencies:
   firebase_messaging: ^14.4.0
   firebase_performance: ^0.9.1
   firebase_storage: ^11.1.0
+  # Used so that we can select a minute interval (only either XX:00 or XX:30)
+  # for the homework reminder time picker.
+  interval_time_picker: ^2.0.0+5
   flare_flutter: ^3.0.2
   flutter:
     sdk: flutter


### PR DESCRIPTION
On Android picking only reminder times in an half-hour interval was broken. Instead a user could pick any time. By using `package:interval_time_picker` this issue is now fixed an users can again only pick reminder times in an half-hour interval.

![grafik](https://user-images.githubusercontent.com/29028262/230206469-858d222c-414f-4c09-95f1-19285d501c32.png)

Fixes #565