### PR TITLE
Fix freeze when signing out on web

### DIFF
--- a/lib/user/lib/src/models/user.dart
+++ b/lib/user/lib/src/models/user.dart
@@ -103,7 +103,7 @@ class AppUser {
       name: data['name'],
       abbreviation: generateAbbreviation(data['name']),
       typeOfUser: enumFromString(TypeOfUser.values, data['typeOfUser']) ??
-          TypeOfUser.unknown,
+          TypeOfUser.student,
       notificationTokens: decodeList(data['notificationTokens'], (it) => it),
       reminderTime: data['reminderTime'],
       referralLink: data['referralLink'],


### PR DESCRIPTION
Through Git binary search, I found out that the issue #497 was caused by #469. I don't why the web app crashes when the `AppUser` is `TypeOfUser.unknown`. We are never using the `TypeOfUser.unknown` state. However, using `TypeOfUser.student` works and I think should be okay as a fallback value, because `typeOfUser` should never be null.

https://user-images.githubusercontent.com/24459435/230229074-9adc6da4-e6e7-43b8-a7df-4302bbbd67d5.mov

Closes #497 