### PR TITLE
Remove link to FAQ

### DIFF
--- a/app/lib/pages/settings_page.dart
+++ b/app/lib/pages/settings_page.dart
@@ -172,11 +172,6 @@ class _MoreSection extends StatelessWidget {
             tag: WebAppSettingsPage.tag,
           ),
         _SettingsOption(
-          title: "Häufige Fragen",
-          icon: Icons.live_help,
-          onTap: () => launchURL("https://sharezone.net/faq"),
-        ),
-        _SettingsOption(
           title: "Support",
           icon: Icons.question_answer,
           tag: SupportPage.tag,

--- a/app/lib/pages/settings_page.dart
+++ b/app/lib/pages/settings_page.dart
@@ -21,7 +21,6 @@ import 'package:sharezone/pages/settings/src/subpages/theme/theme_page.dart';
 import 'package:sharezone/pages/settings/support_page.dart';
 import 'package:sharezone/pages/settings/timetable_settings/timetable_settings_page.dart';
 import 'package:sharezone/pages/settings/web_app.dart';
-import 'package:sharezone/util/launch_link.dart';
 import 'package:sharezone_utils/platform.dart';
 import 'package:sharezone_widgets/sharezone_widgets.dart';
 


### PR DESCRIPTION
Because we don't have a FAQ at the moment, we are going to remove the "Häufige Fragen" button in our app.

![image](https://user-images.githubusercontent.com/24459435/230230829-dd785b0d-61fa-4da2-9cdd-29da423f0f16.png)

Closes #572 