### PR TITLE
Update `remove-safe-to-test-label` GitHub Action

### DIFF
--- a/.github/workflows/unsafe_app_ci.yml
+++ b/.github/workflows/unsafe_app_ci.yml
@@ -62,7 +62,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Remove "safe to test" label, if PR is from a fork
-        uses: SharezoneApp/remove-safe-to-test-label@0a166fb9eef390fa6fee111ce7457b06cc26b74c
+        uses: SharezoneApp/remove-safe-to-test-label@cd6d4f2a213ca202359a4518e926fe7ead243b67
 
   # We can't use the official "paths" filter because it has no support for merge
   # groups and we would need some kind of fallback CI when a check is required


### PR DESCRIPTION
Update allows running the action in `merge_group`. Fixes https://github.com/SharezoneApp/sharezone-app/actions/runs/4627242358/jobs/8184930675

(Not sure if we need to skip this action in `merge_group`. We need to test this in the next weeks)