### PR TITLE
Hide debug login credentials for production flavor

### DIFF
--- a/app/integration_test/app_test.dart
+++ b/app/integration_test/app_test.dart
@@ -42,6 +42,7 @@ void main() {
         beitrittsversuche: dependencies.beitrittsversuche,
         blocDependencies: dependencies.blocDependencies,
         dynamicLinkBloc: dependencies.dynamicLinkBloc,
+        flavor: Flavor.dev,
       ),
     );
   }

--- a/app/lib/auth/login_page.dart
+++ b/app/lib/auth/login_page.dart
@@ -14,9 +14,11 @@ import 'package:authentification_base/authentification_analytics.dart';
 import 'package:bloc_provider/bloc_provider.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:sharezone/download_app_tip/widgets/download_app_tip_card.dart';
 import 'package:sharezone/groups/src/widgets/contact_support.dart';
 import 'package:sharezone/onboarding/sign_up/sign_up_page.dart';
+import 'package:sharezone/util/flavor.dart';
 import 'package:sharezone/widgets/apple_sign_in_button.dart';
 import 'package:sharezone_common/api_errors.dart';
 import 'package:sharezone_widgets/sharezone_widgets.dart';
@@ -100,6 +102,8 @@ class _LoginPageState extends State<LoginPage> {
 
   @override
   Widget build(BuildContext context) {
+    final flavor = context.read<Flavor>();
+    final showDebugLogins = kDebugMode && flavor == Flavor.dev;
     return BlocProvider(
       bloc: bloc,
       child: Scaffold(
@@ -161,7 +165,7 @@ class _LoginPageState extends State<LoginPage> {
                 ),
               ),
               if (widget.withBackIcon) BackIcon(),
-              if (kDebugMode) _DebugLoginButtons(),
+              if (showDebugLogins) _DebugLoginButtons(),
             ],
           ),
         ),

--- a/app/lib/main/run_app.dart
+++ b/app/lib/main/run_app.dart
@@ -68,7 +68,7 @@ Future<void> runFlutterApp({@required Flavor flavor}) async {
       beitrittsversuche: dependencies.beitrittsversuche,
       blocDependencies: dependencies.blocDependencies,
       dynamicLinkBloc: dependencies.dynamicLinkBloc,
-      flavor: Flavor.dev,
+      flavor: flavor,
     )),
     (error, stackTrace) async {
       debugPrint(error.toString());

--- a/app/lib/main/run_app.dart
+++ b/app/lib/main/run_app.dart
@@ -68,6 +68,7 @@ Future<void> runFlutterApp({@required Flavor flavor}) async {
       beitrittsversuche: dependencies.beitrittsversuche,
       blocDependencies: dependencies.blocDependencies,
       dynamicLinkBloc: dependencies.dynamicLinkBloc,
+      flavor: Flavor.dev,
     )),
     (error, stackTrace) async {
       debugPrint(error.toString());

--- a/app/lib/main/sharezone.dart
+++ b/app/lib/main/sharezone.dart
@@ -7,8 +7,8 @@
 // SPDX-License-Identifier: EUPL-1.2
 
 import 'package:analytics/analytics.dart';
-import 'package:authentification_base/authentification.dart';
-import 'package:authentification_base/authentification_base.dart';
+import 'package:authentification_base/authentification.dart' hide Provider;
+import 'package:authentification_base/authentification_base.dart' hide Provider;
 import 'package:bloc_provider/bloc_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:overlay_support/overlay_support.dart';
@@ -21,6 +21,7 @@ import 'package:sharezone/main/auth_app.dart';
 import 'package:sharezone/main/dynamic_links.dart';
 import 'package:sharezone/main/sharezone_app.dart';
 import 'package:sharezone/onboarding/group_onboarding/logic/signed_up_bloc.dart';
+import 'package:sharezone/util/flavor.dart';
 import 'package:sharezone/widgets/alpha_version_banner.dart';
 import 'package:sharezone/widgets/animation/color_fade_in.dart';
 import 'package:sharezone_utils/platform.dart';
@@ -33,13 +34,15 @@ class Sharezone extends StatefulWidget {
   final BlocDependencies blocDependencies;
   final DynamicLinkBloc dynamicLinkBloc;
   final Stream<Beitrittsversuch> beitrittsversuche;
+  final Flavor flavor;
 
-  const Sharezone(
-      {Key key,
-      @required this.blocDependencies,
-      @required this.dynamicLinkBloc,
-      @required this.beitrittsversuche})
-      : super(key: key);
+  const Sharezone({
+    Key key,
+    @required this.blocDependencies,
+    @required this.dynamicLinkBloc,
+    @required this.beitrittsversuche,
+    @required this.flavor,
+  }) : super(key: key);
 
   static Analytics analytics = Analytics(getBackend());
 
@@ -95,19 +98,27 @@ class _SharezoneState extends State<Sharezone> with WidgetsBindingObserver {
                   children: [
                     BlocProvider(
                       bloc: signUpBloc,
-                      child: StreamBuilder<AuthUser>(
-                        stream: listenToAuthStateChanged(),
-                        builder: (context, snapshot) {
-                          if (snapshot.hasData) {
-                            widget.blocDependencies.authUser = snapshot.data;
-                            return SharezoneApp(widget.blocDependencies,
-                                Sharezone.analytics, widget.beitrittsversuche);
-                          }
-                          return AuthApp(
-                            blocDependencies: widget.blocDependencies,
-                            analytics: Sharezone.analytics,
-                          );
-                        },
+                      child: MultiProvider(
+                        providers: [
+                          Provider<Flavor>(create: (context) => widget.flavor)
+                        ],
+                        child: StreamBuilder<AuthUser>(
+                          stream: listenToAuthStateChanged(),
+                          builder: (context, snapshot) {
+                            if (snapshot.hasData) {
+                              widget.blocDependencies.authUser = snapshot.data;
+                              return SharezoneApp(
+                                widget.blocDependencies,
+                                Sharezone.analytics,
+                                widget.beitrittsversuche,
+                              );
+                            }
+                            return AuthApp(
+                              blocDependencies: widget.blocDependencies,
+                              analytics: Sharezone.analytics,
+                            );
+                          },
+                        ),
                       ),
                     ),
                   ],


### PR DESCRIPTION
## Description

Our debug login credentials are only working in our development environment. Therefore, makes it sense to hide them in our production environment (when `kDebugMode` is `true`).

We just put the `Flavor` enum into a `Provider` so that it's accessible across the app.

## Demo

| Prod | Dev |
|-|-|
| <img width="1312" alt="image" src="https://user-images.githubusercontent.com/24459435/230362642-3bf85f8f-903f-4e15-b087-e8d6cc8b1421.png"> | <img width="1312" alt="image" src="https://user-images.githubusercontent.com/24459435/230362708-75724347-93f2-4469-bb05-598a97cb7c64.png"> |

