### PR TITLE
Improve design for event details page to view long event titles

### DIFF
--- a/app/lib/timetable/timetable_page/timetable_event_details.dart
+++ b/app/lib/timetable/timetable_page/timetable_event_details.dart
@@ -23,7 +23,6 @@ import 'package:sharezone/timetable/timetable_edit/event/timetable_event_edit_pa
 import 'package:sharezone/timetable/timetable_permissions.dart';
 import 'package:sharezone/util/launch_link.dart';
 import 'package:sharezone/util/navigation_service.dart';
-import 'package:sharezone_utils/dimensions.dart';
 import 'package:sharezone_utils/platform.dart';
 import 'package:sharezone_widgets/sharezone_widgets.dart';
 

--- a/app/lib/timetable/timetable_page/timetable_event_details.dart
+++ b/app/lib/timetable/timetable_page/timetable_event_details.dart
@@ -134,12 +134,8 @@ class _TimetableEventDetailsPage extends StatelessWidget {
     final isExam = event.eventType == Exam();
     final theme = Theme.of(context);
 
-    final dimensions = Dimensions.fromMediaQuery(context);
-
     return Scaffold(
       appBar: AppBar(
-        title: Text(event.title),
-        centerTitle: dimensions.isDesktopModus,
         actions: [
           ReportIcon(
             item: ReportItemReference.event(event.eventID),
@@ -158,6 +154,11 @@ class _TimetableEventDetailsPage extends StatelessWidget {
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: <Widget>[
+                const SizedBox(height: 12),
+                _TitleAndDate(
+                  design: design,
+                  event: event,
+                ),
                 ListTile(
                   leading: const Icon(Icons.group),
                   title: Text.rich(
@@ -175,14 +176,6 @@ class _TimetableEventDetailsPage extends StatelessWidget {
                       ],
                     ),
                   ),
-                ),
-                ListTile(
-                  leading: const Icon(Icons.event),
-                  title: Text("Datum: ${event.date.parser.toYMMMMEEEEd}"),
-                ),
-                ListTile(
-                  leading: const Icon(Icons.access_time),
-                  title: Text("${event.startTime} - ${event.endTime}"),
                 ),
                 if (event.eventType is OtherEventType == false)
                   ListTile(
@@ -220,6 +213,61 @@ class _TimetableEventDetailsPage extends StatelessWidget {
               ],
             ),
           ),
+        ),
+      ),
+    );
+  }
+}
+
+class _TitleAndDate extends StatelessWidget {
+  const _TitleAndDate({
+    Key key,
+    @required this.design,
+    @required this.event,
+  }) : super(key: key);
+
+  final Design design;
+  final CalendricalEvent event;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      leading: _Square(color: design.color),
+      title: Text(
+        event.title,
+        style: TextStyle(
+          fontSize: 26,
+        ),
+      ),
+      subtitle: Padding(
+        padding: const EdgeInsets.only(top: 6),
+        child: Text(
+          "${event.date.parser.toYMMMMEEEEd} • ${event.startTime} - ${event.endTime}",
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
+      ),
+    );
+  }
+}
+
+class _Square extends StatelessWidget {
+  const _Square({
+    Key key,
+    @required this.color,
+  }) : super(key: key);
+
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 24),
+      child: Container(
+        height: 20,
+        width: 20,
+        decoration: BoxDecoration(
+          color: color,
+          borderRadius: BorderRadius.circular(4),
         ),
       ),
     );
@@ -282,7 +330,8 @@ class _AddToMyCalendarButton extends StatelessWidget {
                   icon: const Icon(Icons.add_circle),
                   label: Text("Zu meinem Kalender hinzufügen".toUpperCase()),
                   style: ElevatedButton.styleFrom(
-                    foregroundColor: Colors.white, backgroundColor: Theme.of(context).primaryColor,
+                    foregroundColor: Colors.white,
+                    backgroundColor: Theme.of(context).primaryColor,
                   ),
                   onPressed: () async {
                     final timezone = await _getTimezoneForMobile();


### PR DESCRIPTION
## Description

As in #577 described, it was not possible to read longer event titles:

<img width="816" alt="image" src="https://user-images.githubusercontent.com/24459435/230374065-8da82bb3-ee4a-4943-8277-7d6b23f5cee7.png">

With this PR, the title of the event moved out of the `AppBar`. Also, the date has been moved as subtitle under the title. The design is inspired by the Google Calendar app.

Skipped writing a golden test for this because a refactoring the code to not use things like `SharezoneContext` would make it easier.

## Demo

| Light Mode | Dark Mode |
|-|-|
| <img width="532" alt="image" src="https://user-images.githubusercontent.com/24459435/230373831-409a02d2-59e2-482c-9bdb-ecf4bca74360.png"> | <img width="532" alt="image" src="https://user-images.githubusercontent.com/24459435/230374691-930c4492-1eb5-4472-9bc7-d52d8242000e.png"> |

https://user-images.githubusercontent.com/24459435/230373924-89fc7463-b1bc-4715-b138-0fbb8d16fa3d.mov

## Related Tickets

Fixes #577
