### PR TITLE
Allow new line when adding the event description while adding a new event

### DIFF
--- a/app/lib/timetable/timetable_add_event/tabs/optional_tab.dart
+++ b/app/lib/timetable/timetable_add_event/tabs/optional_tab.dart
@@ -94,8 +94,9 @@ class _DescriptionField extends StatelessWidget {
                       : "z.B. Sportsachen mitbringen!",
                 ),
                 onChanged: bloc.changeDetail,
+                maxLines: null,
                 onEditingComplete: () => _submit(context),
-                textInputAction: TextInputAction.done,
+                textInputAction: TextInputAction.newline,
               ),
               const SizedBox(height: 10),
               Padding(


### PR DESCRIPTION
## Description

Before the PR you could only add a new line by adding the event and then editing the event. Now it's possible to add a new line while adding a new event.

## Demo

Normal use case:

https://user-images.githubusercontent.com/24459435/230377687-bcddce0d-55a1-47e7-900c-458b61232dfa.mov

Edge case:

https://user-images.githubusercontent.com/24459435/230378216-d08ba414-46a5-4213-b1dc-66d0db2ec346.mov

## Related Tickets

Fixes #585