### PR TITLE
Format `design` package

### DIFF
--- a/lib/design/lib/src/color_parser.dart
+++ b/lib/design/lib/src/color_parser.dart
@@ -18,6 +18,7 @@ class ColorParser {
   static Color fromHex(String? hex) {
     if (hex == null) return Colors.blue;
     final rgbColor = colorlib.HexColor(hex).toRgbColor();
-    return Color.fromARGB(255, rgbColor.r as int, rgbColor.g as int, rgbColor.b as int);
+    return Color.fromARGB(
+        255, rgbColor.r as int, rgbColor.g as int, rgbColor.b as int);
   }
 }


### PR DESCRIPTION
Used `dart format .` to format the package. Preparation for #588.