### PR TITLE
Format `group_domain_models` package

### DIFF
--- a/lib/group_domain_models/lib/src/models/member_role.dart
+++ b/lib/group_domain_models/lib/src/models/member_role.dart
@@ -15,6 +15,7 @@ enum MemberRole {
   standard,
   none,
 }
+
 MemberRole memberRoleEnumFromString(String data) =>
     enumFromString(MemberRole.values, data);
 String memberRoleEnumToString(MemberRole memberRole) =>

--- a/lib/group_domain_models/lib/src/models/write_permissions.dart
+++ b/lib/group_domain_models/lib/src/models/write_permissions.dart
@@ -9,6 +9,7 @@
 import 'package:sharezone_common/helper_functions.dart';
 
 enum WritePermission { everyone, onlyAdmins }
+
 WritePermission writePermissionEnumFromString(String data) =>
     enumFromString(WritePermission.values, data);
 String writePermissionEnumToString(WritePermission writePermissions) =>
@@ -16,8 +17,11 @@ String writePermissionEnumToString(WritePermission writePermissions) =>
 
 String writePermissionAsUiString(WritePermission writePermission) {
   switch (writePermission) {
-    case WritePermission.everyone: return 'Alle';
-    case WritePermission.onlyAdmins: return 'Nur Admins';
-    default: return 'Einstellung konnte nicht gefunden werden';
+    case WritePermission.everyone:
+      return 'Alle';
+    case WritePermission.onlyAdmins:
+      return 'Nur Admins';
+    default:
+      return 'Einstellung konnte nicht gefunden werden';
   }
 }


### PR DESCRIPTION
Used `dart format .` to format the package. Preparation for #588.