### PR TITLE
Update `remove-safe-to-test-label` and `verify-safe-to-test` label to skip action in merge queues

### DIFF
--- a/.github/workflows/unsafe_app_ci.yml
+++ b/.github/workflows/unsafe_app_ci.yml
@@ -62,7 +62,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Remove "safe to test" label, if PR is from a fork
-        uses: SharezoneApp/remove-safe-to-test-label@cd6d4f2a213ca202359a4518e926fe7ead243b67
+        uses: SharezoneApp/remove-safe-to-test-label@228977e0ec39c61eef543d130927065940d56907
 
   # We can't use the official "paths" filter because it has no support for merge
   # groups and we would need some kind of fallback CI when a check is required

--- a/.github/workflows/unsafe_app_ci.yml
+++ b/.github/workflows/unsafe_app_ci.yml
@@ -121,7 +121,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Ensure PR has "safe to test" label, if PR is from a fork
-        uses: SharezoneApp/verify-safe-to-test-label@0af9e3bf0c90e54f3e488ea787c092124d697348
+        uses: SharezoneApp/verify-safe-to-test-label@c1059d43fc918756660a700ca6d08e445ff314a2
 
       - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
         with:
@@ -216,7 +216,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Ensure PR has "safe to test" label, if PR is from a fork
-        uses: SharezoneApp/verify-safe-to-test-label@0af9e3bf0c90e54f3e488ea787c092124d697348
+        uses: SharezoneApp/verify-safe-to-test-label@c1059d43fc918756660a700ca6d08e445ff314a2
 
       - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
         with:
@@ -281,7 +281,7 @@ jobs:
         working-directory: app
     steps:
       - name: Ensure PR has "safe to test" label, if PR is from a fork
-        uses: SharezoneApp/verify-safe-to-test-label@0af9e3bf0c90e54f3e488ea787c092124d697348
+        uses: SharezoneApp/verify-safe-to-test-label@c1059d43fc918756660a700ca6d08e445ff314a2
 
       - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
         with:
@@ -358,7 +358,7 @@ jobs:
       checks: write # for FirebaseExtended/action-hosting-deploy to comment on PRs (without write permissions for checks the action doesn't post a comment to the PR, we don't know why)
     steps:
       - name: Ensure PR has "safe to test" label, if PR is from a fork
-        uses: SharezoneApp/verify-safe-to-test-label@0af9e3bf0c90e54f3e488ea787c092124d697348
+        uses: SharezoneApp/verify-safe-to-test-label@c1059d43fc918756660a700ca6d08e445ff314a2
 
       - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
         with:


### PR DESCRIPTION
Uses the new update that skips the action when the action is executed not with `pull_request` or `pull_request_target` event.