### PR TITLE
Split our CI test job into `test-without-goldens` and `test-only-goldens` 

### DIFF
--- a/.github/workflows/cli_ci.yml
+++ b/.github/workflows/cli_ci.yml
@@ -117,7 +117,7 @@ jobs:
     #
     # When the Sharezone CLI supports filters for the test command (like
     # `--only="tools/sz_repo_cli"`), we can change this to a Linux runner.
-    runs-on: macos-12
+    runs-on: ubuntu-22.04
     if: ${{ needs.changes.outputs.changesFound == 'true' }}
     steps:
       - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
@@ -145,5 +145,13 @@ jobs:
       # So we can just use "sz COMMAND" instead of "dart ../path/to/script.dart ..."
       - run: echo $(pwd)/bin >> $GITHUB_PATH
 
+      # Currently, we run the tests for all packages because we don't have a
+      # filter for the test command yet.
+      #
+      # Because of this, we need to exclude the golden tests because they
+      # require a macOS runner.
       - name: Run tests via "sz test"
-        run: sz test -c 4 --package-timeout-minutes 15
+        run: sz test \
+          -c 4 \
+          --package-timeout-minutes 15 \
+          --exclude-goldens

--- a/.github/workflows/safe_app_ci.yml
+++ b/.github/workflows/safe_app_ci.yml
@@ -125,10 +125,14 @@ jobs:
       - name: Run code analysis via "sz analyze" (formatting, issues, spacing ...)
         run: sz analyze --max-concurrent-packages 3 --package-timeout-minutes 15
 
-  test:
+  # We split out the tests into two jobs, because we want to run the golden
+  # tests on a macOS runner, because the golden tests were generated on macOS.
+  # To reduce the time that macOS runner are used, we run the other tests on a
+  # Linux runner.
+  test-without-goldens:
     needs: changes
     if: ${{ needs.changes.outputs.changesFound == 'true' }}
-    runs-on: macos-12
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
 
@@ -156,7 +160,52 @@ jobs:
       - run: echo $(pwd)/bin >> $GITHUB_PATH
 
       - name: Run tests via "sz test"
-        run: sz test -c 4 --package-timeout-minutes 15
+        run: sz test \
+          -c 4 \
+          --package-timeout-minutes 15 \
+          --exclude-goldens
+
+  # We split out the tests into two jobs, because we want to run the golden
+  # tests on a macOS runner, because the golden tests were generated on macOS.
+  # To reduce the time that macOS runner are used, we run the other tests on a
+  # Linux runner.
+  test-only-goldens:
+    needs: changes
+    if: ${{ needs.changes.outputs.changesFound == 'true' }}
+    runs-on: macos-12
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
+
+      - name: Set Flutter version from FVM config file to environment variables
+        uses: kuhnroyal/flutter-fvm-config-action@e91317131a2da710b9cd9b7a24f2c0ade9eeb61d
+
+      - uses: subosito/flutter-action@dbf1fa04f4d2e52c33185153d06cdb5443aa189d
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: ${{ env.FLUTTER_CHANNEL }}
+          # Use format expected by FVM.
+          # Else this won't be recognized as an installed version when setting
+          # '.../flutter' as the FVM Flutter version cache folder.
+          cache-path: "${{ runner.tool_cache }}/flutter/:version:"
+
+      - name: Install FVM
+        run: |
+          flutter pub global activate fvm 2.4.1
+          fvm config --cache-path '${{ runner.tool_cache }}/flutter'
+
+      - name: Activate sz_repo_cli package
+        run: fvm flutter pub global activate --source path "$CI_CD_DART_SCRIPTS_PACKAGE_PATH"
+
+      # So we can just use "sz COMMAND" instead of "dart ../path/to/script.dart ..."
+      - run: echo $(pwd)/bin >> $GITHUB_PATH
+
+      - name: Run tests via "sz test"
+        run: sz test \
+          -c 4 \
+          --package-timeout-minutes 15 \
+          --only-goldens
+      
       # Uploads the results of failed tests as .zip to GitHub.
       #
       # You can find the file under the "Summary" Tab on GitHub when all jobs of

--- a/.github/workflows/safe_app_ci.yml
+++ b/.github/workflows/safe_app_ci.yml
@@ -125,10 +125,10 @@ jobs:
       - name: Run code analysis via "sz analyze" (formatting, issues, spacing ...)
         run: sz analyze --max-concurrent-packages 3 --package-timeout-minutes 15
 
-  # We split out the tests into two jobs, because we want to run the golden
-  # tests on a macOS runner, because the golden tests were generated on macOS.
-  # To reduce the time that macOS runner are used, we run the other tests on a
-  # Linux runner.
+  # We split the tests into two jobs, because we want to run the golden tests on
+  # a macOS runner, because the golden tests were generated on macOS. To reduce
+  # the time that macOS runner are used, we run the other tests on a Linux
+  # runner.
   test-without-goldens:
     needs: changes
     if: ${{ needs.changes.outputs.changesFound == 'true' }}
@@ -165,10 +165,10 @@ jobs:
           --package-timeout-minutes 15 \
           --exclude-goldens
 
-  # We split out the tests into two jobs, because we want to run the golden
-  # tests on a macOS runner, because the golden tests were generated on macOS.
-  # To reduce the time that macOS runner are used, we run the other tests on a
-  # Linux runner.
+  # We split the tests into two jobs, because we want to run the golden tests on
+  # a macOS runner, because the golden tests were generated on macOS. To reduce
+  # the time that macOS runner are used, we run the other tests on a Linux
+  # runner.
   test-only-goldens:
     needs: changes
     if: ${{ needs.changes.outputs.changesFound == 'true' }}


### PR DESCRIPTION
The only reason why used a macOS runner to run our tests was that we have few golden tests which require a macOS runner. Since we have `--exclude-goldens` and `--only-goldens` arguments for the `sz test` command (see #614), we can split the test jobs into a job that runs only the golden tests (uses a macOS runner) and a job that excludes the golden tests (uses an Ubuntu runner).

This PR also uses the `--exclude-goldens` argument for the CLI CI because the CLI has no golden tests.