### PR TITLE
`sz` CLI: Move logic out of `package.dart`.

### DIFF
--- a/tools/sz_repo_cli/lib/src/commands/src/format_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/format_command.dart
@@ -24,7 +24,22 @@ class FormatCommand extends ConcurrentCommand {
   Duration get defaultPackageTimeout => Duration(minutes: 3);
 
   @override
-  Future<void> runTaskForPackage(Package package) {
-    return package.formatCode();
-  }
+  Future<void> runTaskForPackage(Package package) => formatCode(package);
+}
+
+Future<void> formatCode(
+  Package package, {
+  /// Throws if code is not already formatted properly.
+  /// Useful for code analysis in CI.
+  bool throwIfCodeChanged = false,
+}) {
+  return runProcessSucessfullyOrThrow(
+      'fvm',
+      [
+        'dart',
+        'format',
+        if (throwIfCodeChanged) '--set-exit-if-changed',
+        '.',
+      ],
+      workingDirectory: package.path);
 }

--- a/tools/sz_repo_cli/lib/src/commands/src/pub_get_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/pub_get_command.dart
@@ -31,7 +31,7 @@ class PubGetCommand extends ConcurrentCommand {
 }
 
 Future<void> getPackage(Package package) async {
-  if (package.type == PackageType.flutter) {
+  if (package.isFlutterPackage) {
     await getPackagesFlutter(package);
   } else {
     await getPackagesDart(package);

--- a/tools/sz_repo_cli/lib/src/commands/src/pub_get_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/pub_get_command.dart
@@ -27,7 +27,26 @@ class PubGetCommand extends ConcurrentCommand {
   Duration get defaultPackageTimeout => Duration(minutes: 5);
 
   @override
-  Future<void> runTaskForPackage(Package package) {
-    return package.getPackages();
+  Future<void> runTaskForPackage(Package package) => getPackage(package);
+}
+
+Future<void> getPackage(Package package) async {
+  if (package.type == PackageType.flutter) {
+    await getPackagesFlutter(package);
+  } else {
+    await getPackagesDart(package);
   }
+}
+
+Future<void> getPackagesDart(Package package) async {
+  await runProcessSucessfullyOrThrow('fvm', ['dart', 'pub', 'get'],
+      workingDirectory: package.path);
+}
+
+Future<void> getPackagesFlutter(Package package) async {
+  await runProcessSucessfullyOrThrow(
+    'fvm',
+    ['flutter', 'pub', 'get'],
+    workingDirectory: package.path,
+  );
 }

--- a/tools/sz_repo_cli/lib/src/commands/src/test_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/test_command.dart
@@ -47,8 +47,7 @@ class TestCommand extends ConcurrentCommand {
     if (argResults['only-goldens'] as bool) {
       return repo.streamPackages().where(
             (package) =>
-                package.type == PackageType.flutter &&
-                package.hasGoldenTestsDirectory,
+                package.isFlutterPackage && package.hasGoldenTestsDirectory,
           );
     }
 
@@ -70,7 +69,7 @@ Future<void> runTests(
   @required bool excludeGoldens,
   @required bool onlyGoldens,
 }) {
-  if (package.type == PackageType.flutter) {
+  if (package.isFlutterPackage) {
     return _runTestsFlutter(
       package,
       excludeGoldens: excludeGoldens,

--- a/tools/sz_repo_cli/lib/src/common/src/package.dart
+++ b/tools/sz_repo_cli/lib/src/common/src/package.dart
@@ -8,14 +8,57 @@
 
 import 'dart:io';
 
-import 'package:sz_repo_cli/src/commands/src/fix_comment_spacing_command.dart';
 import 'package:meta/meta.dart';
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as p;
 import 'package:yaml/yaml.dart';
 
-import '../common.dart';
-
 enum PackageType { pureDart, flutter }
+
+class Package {
+  final Directory location;
+  String get path => location.path;
+  final String name;
+  final PackageType type;
+  final bool hasTestDirectory;
+  final bool hasGoldenTestsDirectory;
+
+  Package({
+    @required this.location,
+    @required this.name,
+    @required this.type,
+    @required this.hasTestDirectory,
+    @required this.hasGoldenTestsDirectory,
+  });
+
+  factory Package.fromDirectory(Directory directory) {
+    final pubspecFile = File(p.join(directory.path, 'pubspec.yaml'));
+    final YamlMap pubspecYaml = loadYaml(pubspecFile.readAsStringSync());
+    final YamlMap dependencies = pubspecYaml['dependencies'] ?? YamlMap();
+    final YamlMap devDependencies =
+        pubspecYaml['dev_dependencies'] ?? YamlMap();
+    final containsFlutter = dependencies.containsKey('flutter') ||
+            devDependencies.containsKey('flutter') ??
+        false;
+    final name = pubspecYaml['name'] as String;
+    final hasTestDirectory =
+        Directory(p.join(directory.path, 'test')).existsSync();
+    final hasTestGoldensDirectory =
+        Directory(p.join(directory.path, 'test_goldens')).existsSync();
+
+    return Package(
+      location: directory,
+      name: name,
+      hasTestDirectory: hasTestDirectory,
+      hasGoldenTestsDirectory: hasTestGoldensDirectory,
+      type: containsFlutter ? PackageType.flutter : PackageType.pureDart,
+    );
+  }
+
+  @override
+  String toString() {
+    return '$runtimeType(name: $name)';
+  }
+}
 
 extension PackageTypeToReadableString on PackageType {
   String toReadableString() {
@@ -26,205 +69,5 @@ extension PackageTypeToReadableString on PackageType {
         return 'Dart';
     }
     throw UnimplementedError();
-  }
-}
-
-abstract class Package {
-  final Directory location;
-  final String name;
-  final PackageType type;
-  final bool hasTestDirectory;
-
-  Package({
-    @required this.location,
-    @required this.name,
-    @required this.type,
-    @required this.hasTestDirectory,
-  });
-
-  factory Package.fromDirectory(Directory directory) {
-    final pubspecFile = File(path.join(directory.path, 'pubspec.yaml'));
-    final YamlMap pubspecYaml = loadYaml(pubspecFile.readAsStringSync());
-    final YamlMap dependencies = pubspecYaml['dependencies'] ?? YamlMap();
-    final YamlMap devDependencies =
-        pubspecYaml['dev_dependencies'] ?? YamlMap();
-    final containsFlutter = dependencies.containsKey('flutter') ||
-            devDependencies.containsKey('flutter') ??
-        false;
-    final name = pubspecYaml['name'] as String;
-    final hasTestDirectory =
-        Directory(path.join(directory.path, 'test')).existsSync();
-    final hasTestGoldensDirectory =
-        Directory(path.join(directory.path, 'test_goldens')).existsSync();
-
-    return containsFlutter
-        ? FlutterPackage(
-            location: directory,
-            name: name,
-            hasTestDirectory: hasTestDirectory,
-            hasGoldenTestsDirectory: hasTestGoldensDirectory,
-          )
-        : DartPackage(
-            location: directory,
-            name: name,
-            hasTestDirectory: hasTestDirectory,
-          );
-  }
-
-  Future<void> getPackages();
-
-  Future<void> runTests({
-    @required bool excludeGoldens,
-    @required bool onlyGoldens,
-  });
-
-  Future<void> analyzePackage() async {
-    await getPackages();
-    await _runDartAnalyze();
-    await _runDartFormat();
-    await _checkForCommentsWithBadSpacing();
-  }
-
-  Future<void> _runDartAnalyze() {
-    return runProcessSucessfullyOrThrow(
-        'fvm', ['dart', 'analyze', '--fatal-infos', '--fatal-warnings'],
-        workingDirectory: location.path);
-  }
-
-  Future<void> _runDartFormat() {
-    return runProcessSucessfullyOrThrow(
-        'fvm', ['dart', 'format', '--set-exit-if-changed', '.'],
-        workingDirectory: location.path);
-  }
-
-  Future<void> _checkForCommentsWithBadSpacing() async {
-    if (doesPackageIncludeFilesWithBadCommentSpacing(location.path)) {
-      throw Exception(
-          'Package $name has comments with bad spacing. Fix them by running the `sz fix-comment-spacing` command.');
-    }
-    return;
-  }
-
-  @override
-  String toString() {
-    return '$runtimeType(name: $name)';
-  }
-
-  Future<void> formatCode() {
-    return runProcessSucessfullyOrThrow('fvm', ['dart', 'format', '.'],
-        workingDirectory: location.path);
-  }
-}
-
-class DartPackage extends Package {
-  DartPackage({
-    @required Directory location,
-    @required String name,
-    @required bool hasTestDirectory,
-  }) : super(
-          name: name,
-          location: location,
-          type: PackageType.pureDart,
-          hasTestDirectory: hasTestDirectory,
-        );
-
-  @override
-  Future<void> getPackages() async {
-    await runProcessSucessfullyOrThrow('fvm', ['dart', 'pub', 'get'],
-        workingDirectory: location.path);
-  }
-
-  @override
-  Future<void> runTests({
-    // We can ignore the "excludeGoldens" parameter here because Dart packages
-    // don't have golden tests.
-    @required bool excludeGoldens,
-    @required bool onlyGoldens,
-  }) async {
-    if (onlyGoldens) {
-      // Golden tests are only run in the flutter package.
-      return;
-    }
-
-    await getPackages();
-
-    await runProcessSucessfullyOrThrow(
-      'fvm',
-      ['dart', 'test'],
-      workingDirectory: location.path,
-    );
-  }
-}
-
-class FlutterPackage extends Package {
-  /// Whether the package has a "test_goldens" directory.
-  final bool hasGoldenTestsDirectory;
-
-  FlutterPackage({
-    @required Directory location,
-    @required String name,
-    @required bool hasTestDirectory,
-    @required this.hasGoldenTestsDirectory,
-  }) : super(
-          name: name,
-          location: location,
-          type: PackageType.flutter,
-          hasTestDirectory: hasTestDirectory,
-        );
-
-  @override
-  Future<void> getPackages() async {
-    await runProcessSucessfullyOrThrow(
-      'fvm',
-      ['flutter', 'pub', 'get'],
-      workingDirectory: location.path,
-    );
-  }
-
-  @override
-  Future<void> runTests({
-    @required bool excludeGoldens,
-    @required bool onlyGoldens,
-  }) async {
-    if (onlyGoldens) {
-      if (!hasGoldenTestsDirectory) {
-        return;
-      }
-
-      await runProcessSucessfullyOrThrow(
-        'fvm',
-        ['flutter', 'test', 'test_goldens'],
-        workingDirectory: location.path,
-      );
-      return;
-    }
-
-    // If the package has no golden tests, we need to use the normal test
-    // command. Otherwise the throws the Flutter tool throws an error that it
-    // couldn't find the "test_goldens" directory.
-    if (excludeGoldens || !hasGoldenTestsDirectory) {
-      await runProcessSucessfullyOrThrow(
-        'fvm',
-        ['flutter', 'test'],
-        workingDirectory: location.path,
-      );
-      return;
-    }
-
-    /// Flutter test lässt automatisch flutter pub get laufen.
-    /// Deswegen muss nicht erst noch [getPackages] aufgerufen werden.
-
-    await runProcessSucessfullyOrThrow(
-      'fvm',
-      [
-        'flutter',
-        'test',
-        // Directory for golden tests.
-        'test_goldens',
-        // Directory for unit and widget tests.
-        'test',
-      ],
-      workingDirectory: location.path,
-    );
   }
 }

--- a/tools/sz_repo_cli/lib/src/common/src/package.dart
+++ b/tools/sz_repo_cli/lib/src/common/src/package.dart
@@ -19,6 +19,8 @@ class Package {
   String get path => location.path;
   final String name;
   final PackageType type;
+  bool get isFlutterPackage => type == PackageType.flutter;
+  bool get isPureDartPackage => type == PackageType.pureDart;
   final bool hasTestDirectory;
   final bool hasGoldenTestsDirectory;
 


### PR DESCRIPTION
Instead of letting `package.dart` grow and grow, I moved all of the logic out to the `xxx_command.dart` classes.   
Additionally I removed the `DartPackage` and `FlutterPackage` subclasses as they are unnecessary with the logic moved elsewhere.