### PR TITLE
Fix view PDF files on Web & Android

### DIFF
--- a/app/web/index.html
+++ b/app/web/index.html
@@ -54,11 +54,15 @@
         <div class="double-bounce2"></div>
     </div>
 
-    <script src="//cdnjs.cloudflare.com/ajax/libs/pdf.js/2.4.456/pdf.min.js"></script>
+    <!-- Required for the pdfx package -->
+    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@2.12.313/build/pdf.js" type="text/javascript"></script>
     <script type="text/javascript">
-        pdfjsLib.GlobalWorkerOptions.workerSrc = "//cdnjs.cloudflare.com/ajax/libs/pdf.js/2.4.456/pdf.worker.min.js";
+      pdfjsLib.GlobalWorkerOptions.workerSrc = "https://cdn.jsdelivr.net/npm/pdfjs-dist@2.12.313/build/pdf.worker.min.js";
+      pdfRenderOptions = {
+        cMapUrl: 'https://cdn.jsdelivr.net/npm/pdfjs-dist@2.12.313/cmaps/',
+        cMapPacked: true,
+      }
     </script>
-
 
     <script src="main.dart.js?version=283" type="application/javascript"></script>
 

--- a/lib/filesharing/files_usecases/lib/src/file_viewer/pages/pdf_file_page.dart
+++ b/lib/filesharing/files_usecases/lib/src/file_viewer/pages/pdf_file_page.dart
@@ -53,7 +53,7 @@ class PdfFilePage extends StatelessWidget {
                   controller:
                       PdfController(document: getPdfDocument(localFile)),
                   scrollDirection: Axis.vertical,
-                  builders: PdfViewBuilders(
+                  builders: PdfViewBuilders<DefaultBuilderOptions>(
                     options: const DefaultBuilderOptions(),
                     errorBuilder: (context, exception) {
                       return const Center(


### PR DESCRIPTION
## Description

The issue was that the type `DefaultBuilderOptions` was missing as generic. For web, I also need to update the scripts in `index.html`.

<img width="1552" alt="image" src="https://user-images.githubusercontent.com/24459435/230802795-903600be-0d02-445f-a7a7-07788f1b3caf.png">

## Related Tickets

Closes #620 