### PR TITLE
Update macOS runner to `macos-13`

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -206,7 +206,7 @@ jobs:
           --release-notes "$LAST_COMMIT_MESSAGE"
 
   deploy-alpha-ios-app:
-    runs-on: macos-12
+    runs-on: macos-13
     timeout-minutes: 120
     defaults:
       run:

--- a/.github/workflows/integration_tests_app_ci.yml
+++ b/.github/workflows/integration_tests_app_ci.yml
@@ -75,7 +75,7 @@ jobs:
     # hardware acceleration support provided by HAXM. See more details in the
     # README.md of the Android emulator action:
     # https://github.com/ReactiveCircus/android-emulator-runner#usage
-    runs-on: macos-12
+    runs-on: macos-13
     if: ${{ needs.changes.outputs.changesFound == 'true' }}
     # Don't use less than 90 minutes. Often 40 minutes are enough but sometimes
     # (~5% of the time) build takes longer and then is a long timeout needed.
@@ -165,7 +165,7 @@ jobs:
 
   ios-integration-test:
     needs: changes
-    runs-on: macos-12
+    runs-on: macos-13
     if: ${{ needs.changes.outputs.changesFound == 'true' }}
     timeout-minutes: 45
     steps:
@@ -220,7 +220,7 @@ jobs:
   # macOS app.
   macos-build-test:
     needs: changes
-    runs-on: macos-12
+    runs-on: macos-13
     if: ${{ needs.changes.outputs.changesFound == 'true' }}
     timeout-minutes: 60
     defaults:

--- a/.github/workflows/integration_tests_app_ci.yml
+++ b/.github/workflows/integration_tests_app_ci.yml
@@ -191,7 +191,7 @@ jobs:
       - uses: futureware-tech/simulator-action@ae8f725abebda0c4c62629c7a2a5b826e161c9f1
         id: simulator
         with:
-          model: "iPhone 13"
+          model: "iPhone 14"
 
       - name: Run integration tests
         working-directory: app

--- a/.github/workflows/safe_app_ci.yml
+++ b/.github/workflows/safe_app_ci.yml
@@ -173,7 +173,7 @@ jobs:
   test-only-goldens:
     needs: changes
     if: ${{ needs.changes.outputs.changesFound == 'true' }}
-    runs-on: macos-12
+    runs-on: macos-13
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3


### PR DESCRIPTION
`macos-13` runner are now available since today, see: https://github.blog/changelog/2023-04-24-github-actions-macos-13-is-now-available/. `macos-13` runner seems to fix the issue Flutter 3.7 and macOS integration tests (see https://github.com/flutter/flutter/issues/118469).