### PR TITLE
Remove making the extension lower case for Android when downloading a file

### DIFF
--- a/app/lib/filesharing/widgets/download_unknown_file_type_dialog_content.dart
+++ b/app/lib/filesharing/widgets/download_unknown_file_type_dialog_content.dart
@@ -77,21 +77,8 @@ class DownloadUnknownFileTypeDialogContent extends StatelessWidget {
       builder: (context, future) {
         // Finished Downloading
         if (future.hasData) {
-          // Für Android ist es besser, wenn die Extension der File lowerCase
-          // gemacht wird, damit Android die korrekte App nutzt, um die Datei
-          // zu öffnen. Ist die Endung PNG z. B. großgeschrieben, weiß Android
-          // nicht, wie es geöffnet werden soll.
-          // iOS öffnet jedoch auch die richtige App, wenn die Endung großgeschrieben
-          // ist. Jedoch muss der Path zur File case-sensitive, wodurch die Endung
-          // nicht bearbeitet werden darf. Deswegen gibt es die Unterscheidung
-          // zwischen iOS und Android
-          if (PlatformCheck.isIOS) {
-            OpenFile.open(future.data.getPath());
-          } else {
-            OpenFile.open(
-                    _getFilePathWithLowerCaseExtension(future.data.getPath()))
-                .then((result) => log('open file result: ${result.message}'));
-          }
+          OpenFile.open(future.data.getPath())
+              .then((value) => log(value.message));
 
           _closeDialogAfter1500Milliseconds(context);
           return _FinishDialog();


### PR DESCRIPTION
We couldn't reproduce the behavior that was mentioned in the comment.
