### PR TITLE
Fix getting latest build number when publishing iOS alpha

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -168,7 +168,7 @@ jobs:
         #
         # Bumping the build number for Firebase Distribution has no effect on
         # the PlayStore build number.
-        LATEST_BUILD_NUMBER=$(app-store-connect get-latest-build-number $IOS_APP_ID | head -2 | tail -1)
+        LATEST_BUILD_NUMBER=$(app-store-connect get-latest-build-number $IOS_APP_ID --platform IOS | head -2 | tail -1)
         BUMPED_BUILD_NUMBER=$(expr $LATEST_BUILD_NUMBER + 1)
 
         # We are publishing APKs instead of App Bundles to Firebase Distribution
@@ -268,7 +268,7 @@ jobs:
         # The "| head -2 | tail -1" part is to get the second line of the output
         # of the "app-store-connect get-latest-build-number" command because the
         # second line includes the build number.
-        LATEST_BUILD_NUMBER=$(app-store-connect get-latest-build-number $IOS_APP_ID | head -2 | tail -1)
+        LATEST_BUILD_NUMBER=$(app-store-connect get-latest-build-number $IOS_APP_ID --platform IOS | head -2 | tail -1)
         BUMPED_BUILD_NUMBER=$(expr $LATEST_BUILD_NUMBER + 1)
 
         fvm flutter build ipa \


### PR DESCRIPTION
The issue was that by default `app-store-connect get-latest-build-number` used `--platform MACOS` and because we haven't set up Testflight for macOS the build number never increases.