### PR TITLE
Hide "Daten werden nach Frankfurt gesendet" Snackbar when adding an homework / information sheet.

### DIFF
--- a/app/lib/blackboard/blackboard_dialog.dart
+++ b/app/lib/blackboard/blackboard_dialog.dart
@@ -187,6 +187,7 @@ class _SaveButton extends StatelessWidget {
             bloc.submit(oldBlackboardItem: oldBlackboardItem);
 
           logBlackboardEditEvent(context);
+          hideSendDataToFrankfurtSnackBar(context);
           if (popTwice) Navigator.pop(context);
           Navigator.pop(context, BlackboardPopOption.edited);
         } else {
@@ -196,6 +197,7 @@ class _SaveButton extends StatelessWidget {
             bloc.submit();
 
           logBlackboardAddEvent(context);
+          hideSendDataToFrankfurtSnackBar(context);
           Navigator.pop(context, BlackboardPopOption.added);
         }
       }
@@ -206,6 +208,10 @@ class _SaveButton extends StatelessWidget {
         seconds: 5,
       );
     }
+  }
+
+  void hideSendDataToFrankfurtSnackBar(BuildContext context) {
+    ScaffoldMessenger.of(context).hideCurrentSnackBar();
   }
 
   @override

--- a/app/lib/pages/homework/homework_dialog.dart
+++ b/app/lib/pages/homework/homework_dialog.dart
@@ -175,10 +175,12 @@ class _SaveButton extends StatelessWidget {
             bloc.submit(oldHomework: oldHomework);
           }
           logHomeworkEditEvent(context);
+          hideSendDataToFrankfurtSnackBar(context);
           Navigator.pop(context, true);
         } else {
           hasAttachments ? await bloc.submit() : bloc.submit();
           logHomeworkAddEvent(context);
+          hideSendDataToFrankfurtSnackBar(context);
           Navigator.pop(context, true);
         }
       }
@@ -203,6 +205,10 @@ class _SaveButton extends StatelessWidget {
         seconds: 5,
       );
     }
+  }
+
+  void hideSendDataToFrankfurtSnackBar(BuildContext context) {
+    ScaffoldMessenger.of(context).hideCurrentSnackBar();
   }
 
   void logHomeworkEditEvent(BuildContext context) {


### PR DESCRIPTION
There was a problem that sometimes the "Daten werden nach Frankfurt gesendet" snackbar was still displayed after adding a homework / information sheet (see #281) successfully.

To fix this, we just hide this snackbar after successfully adding a homework / information sheet.

Fixes #281