### PR TITLE
Remove link to markdown help page

### DIFF
--- a/app/lib/markdown/markdown_support.dart
+++ b/app/lib/markdown/markdown_support.dart
@@ -8,7 +8,6 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
-import 'package:sharezone/util/launch_link.dart';
 import 'package:sharezone_widgets/sharezone_widgets.dart';
 
 class MarkdownSupport extends StatelessWidget {
@@ -17,11 +16,9 @@ class MarkdownSupport extends StatelessWidget {
     const style =
         TextStyle(color: Colors.grey, fontSize: 14, fontFamily: rubik);
     return MarkdownBody(
-      data:
-          "[Markdown](https://sharezone.net/markdown): \*\***fett**\\*\*, \**kursiv*\\*",
+      data: "Markdown: \*\***fett**\\*\*, \**kursiv*\\*",
       styleSheet: MarkdownStyleSheet(p: style, a: linkStyle(context, 14)),
       selectable: true,
-      onTapLink: (link, _, __) => launchURL(link),
     );
   }
 }


### PR DESCRIPTION
## Description

Because we don't use ZenDesk anymore, the link to the Markdown help page hasn't worked anymore. Because our [docs](https://docs.sharezone.net) are in the creation process, we don't have a Markdown help.

## Demo

<img width="453" alt="image" src="https://user-images.githubusercontent.com/24459435/236462136-87529337-fe03-4c91-be00-16958517a8ca.png">

## Related Tickets

Fixes #362