### PR TITLE
Update version to 1.7.1

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -13,7 +13,7 @@ description: Der digitale Schulplaner &quot;Sharezone&quot; für Android und iOS
 # (https://appstoreconnect.apple.com/apps/1434868489/testflight/ios) or use
 # "app-store-connect get-latest-build-number 1434868489" to get the latest build
 # number.
-version: 1.7.0+318
+version: 1.7.1+318
 publish_to: none
 
 environment:


### PR DESCRIPTION
I need to publish a new version for iOS because I used an alpha version to publish to production but I forgot that we have a "Alpha" banner at the top ._.