### PR TITLE
Fix launching Sharezone when using Dynamic Link on Android

### DIFF
--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -39,6 +39,24 @@
                 <action android:name="FLUTTER_NOTIFICATION_CLICK" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
+
+            <!-- Intent for receiving Firebase Dynammic Links
+                 See:
+                     * https://github.com/firebase/flutterfire/blob/6ae57735289cfa82322ee2259816a49cd605b784/packages/firebase_dynamic_links/firebase_dynamic_links/example/android/app/src/main/AndroidManifest.xml#L35
+                     * https://firebase.google.com/docs/dynamic-links/android/receive#add-an-intent-filter-for-deep-links
+            -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:host="sharez.one" android:scheme="https"/>
+            </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:host="sharezone.net" android:scheme="https"/>
+            </intent-filter>
         </activity>
 
         <provider android:name="androidx.core.content.FileProvider" android:authorities="${applicationId}.fileProvider" android:exported="false" android:grantUriPermissions="true" tools:replace="android:authorities">


### PR DESCRIPTION
Reason for this issue was that `intent-filter` was missing.

For some reason, I also needed to add `sharezone.net` to get the Dynamic Links working, which is a bit weird. I think `sharezone.net` is coming from

https://github.com/SharezoneApp/backend-mono/blob/1d402c3a1817c24e04d4f781405fdcc3af350209/infrastructure/google_cloud_platform/firebase/cloud_functions/functions/src/dynamic_links/dynamic_links.ts#L14

Fixes #661 