### PR TITLE
Update Version to 1.7.2

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -13,7 +13,7 @@ description: Der digitale Schulplaner &quot;Sharezone&quot; für Android und iOS
 # (https://appstoreconnect.apple.com/apps/1434868489/testflight/ios) or use
 # "app-store-connect get-latest-build-number 1434868489" to get the latest build
 # number.
-version: 1.7.1+318
+version: 1.7.2+318
 publish_to: none
 
 environment:


### PR DESCRIPTION
Because we released 1.7.1, new updates for TestFlight must have a higher version otherwise publishing fails. See https://github.com/SharezoneApp/sharezone-app/actions/runs/4927171386/jobs/8803767801