### PR TITLE
Add "build android" command to Sharezone CLI

### DIFF
--- a/tools/sz_repo_cli/lib/src/commands/src/build_android_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/build_android_command.dart
@@ -59,18 +59,12 @@ When none is specified, the value from pubspec.yaml is used.''',
         help:
             'The flavor to build for. At the moment only "prod" is supported.',
         defaultsTo: 'prod',
-      )
-      ..addOption(
-        googleApplicationCredentialsOptionName,
-        help:
-            'Google Cloud service account credentials with `JSON` key type to access Google Play Developer API. If not given, the value will be checked from the environment variable `GCLOUD_SERVICE_ACCOUNT_CREDENTIALS`.',
       );
   }
 
   static const releaseStageOptionName = 'stage';
   static const flavorOptionName = 'flavor';
   static const buildNumberOptionName = 'build-number';
-  static const googleApplicationCredentialsOptionName = 'credentials';
   static const outputTypeName = 'output-type';
 
   @override

--- a/tools/sz_repo_cli/lib/src/commands/src/build_android_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/build_android_command.dart
@@ -82,7 +82,7 @@ When none is specified, the value from pubspec.yaml is used.''',
     isVerbose = true;
 
     await _buildApp();
-    stdout.writeln('Build finished 🎉 ');
+    print('Build finished 🎉 ');
   }
 
   Future<void> _buildApp() async {

--- a/tools/sz_repo_cli/lib/src/commands/src/build_android_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/build_android_command.dart
@@ -6,8 +6,6 @@
 //
 // SPDX-License-Identifier: EUPL-1.2
 
-import 'dart:io';
-
 import 'package:args/command_runner.dart';
 import 'package:sz_repo_cli/src/common/common.dart';
 

--- a/tools/sz_repo_cli/lib/src/commands/src/build_android_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/build_android_command.dart
@@ -1,0 +1,122 @@
+// Copyright (c) 2022 Sharezone UG (haftungsbeschränkt)
+// Licensed under the EUPL-1.2-or-later.
+//
+// You may obtain a copy of the Licence at:
+// https://joinup.ec.europa.eu/software/page/eupl
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+import 'package:sz_repo_cli/src/common/common.dart';
+
+final _androidStages = [
+  'stable',
+  'alpha',
+];
+
+/// The different flavors of the Android app.
+final _androidFlavors = [
+  'prod',
+  'dev',
+];
+
+/// The different output types of the Android app.
+final _androidOutputType = [
+  'appbundle',
+  'apk',
+];
+
+class BuildAndroidCommand extends Command {
+  final SharezoneRepo _repo;
+
+  BuildAndroidCommand(this._repo) {
+    argParser
+      ..addOption(
+        releaseStageOptionName,
+        abbr: 's',
+        allowed: _androidStages,
+        defaultsTo: 'stable',
+      )
+      ..addOption(
+        outputTypeName,
+        help: 'The type of output type, either "appbundle" or "apk".',
+        allowed: _androidOutputType,
+        defaultsTo: 'appbundle',
+      )
+      ..addOption(
+        buildNumberOptionName,
+        help: '''An identifier used as an internal version number.
+Each build must have a unique identifier to differentiate it from previous builds.
+It is used to determine whether one build is more recent than
+another, with higher numbers indicating more recent build.
+When none is specified, the value from pubspec.yaml is used.''',
+      )
+      ..addOption(
+        flavorOptionName,
+        allowed: _androidFlavors,
+        help:
+            'The flavor to build for. At the moment only "prod" is supported.',
+        defaultsTo: 'prod',
+      )
+      ..addOption(
+        googleApplicationCredentialsOptionName,
+        help:
+            'Google Cloud service account credentials with `JSON` key type to access Google Play Developer API. If not given, the value will be checked from the environment variable `GCLOUD_SERVICE_ACCOUNT_CREDENTIALS`.',
+      );
+  }
+
+  static const releaseStageOptionName = 'stage';
+  static const flavorOptionName = 'flavor';
+  static const buildNumberOptionName = 'build-number';
+  static const googleApplicationCredentialsOptionName = 'credentials';
+  static const outputTypeName = 'output-type';
+
+  @override
+  String get description =>
+      'Build the Sharezone Android app in release mode. Codemagic CLI tools must be installed.';
+
+  @override
+  String get name => 'android';
+
+  @override
+  Future<void> run() async {
+    // Its less work to just print everything right now instead of selectively
+    // print and add custom print statements for non-verboes output.
+    // One might add non-verbose output in the future but right now this is
+    // easier.
+    isVerbose = true;
+
+    await _buildApp();
+    stdout.writeln('Build finished 🎉 ');
+  }
+
+  Future<void> _buildApp() async {
+    try {
+      final flavor = argResults[flavorOptionName] as String;
+      final stage = argResults[releaseStageOptionName] as String;
+      final outputType = argResults[outputTypeName] as String;
+      final buildNumber = argResults[buildNumberOptionName] as String;
+      await runProcessSucessfullyOrThrow(
+        'fvm',
+        [
+          'flutter',
+          'build',
+          outputType,
+          '--target',
+          'lib/main_$flavor.dart',
+          '--flavor',
+          flavor,
+          '--release',
+          '--dart-define',
+          'DEVELOPMENT_STAGE=${stage.toUpperCase()}',
+          if (buildNumber != null) ...['--build-number', '$buildNumber'],
+        ],
+        workingDirectory: _repo.sharezoneFlutterApp.location.path,
+      );
+    } catch (e) {
+      throw Exception('Failed to build Android app: $e');
+    }
+  }
+}

--- a/tools/sz_repo_cli/lib/src/commands/src/build_android_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/build_android_command.dart
@@ -75,10 +75,10 @@ When none is specified, the value from pubspec.yaml is used.''',
 
   @override
   Future<void> run() async {
-    // Its less work to just print everything right now instead of selectively
-    // print and add custom print statements for non-verboes output.
-    // One might add non-verbose output in the future but right now this is
-    // easier.
+    // Is used so that runProcess commands print the command that was run. Right
+    // now this can't be done via an argument.
+    //
+    // This workaround should be addressed in the future.
     isVerbose = true;
 
     await _buildApp();

--- a/tools/sz_repo_cli/lib/src/commands/src/build_android_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/build_android_command.dart
@@ -56,8 +56,7 @@ When none is specified, the value from pubspec.yaml is used.''',
       ..addOption(
         flavorOptionName,
         allowed: _androidFlavors,
-        help:
-            'The flavor to build for. At the moment only "prod" is supported.',
+        help: 'The flavor to build for.',
         defaultsTo: 'prod',
       );
   }

--- a/tools/sz_repo_cli/lib/src/commands/src/build_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/build_command.dart
@@ -1,0 +1,18 @@
+// Copyright (c) 2022 Sharezone UG (haftungsbeschränkt)
+// Licensed under the EUPL-1.2-or-later.
+//
+// You may obtain a copy of the Licence at:
+// https://joinup.ec.europa.eu/software/page/eupl
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+import 'package:args/command_runner.dart';
+
+class BuildCommand extends Command {
+  @override
+  String get description =>
+      'Build Sharezone app for a specific platform (e.g. web app)';
+
+  @override
+  String get name => 'build';
+}

--- a/tools/sz_repo_cli/lib/src/main.dart
+++ b/tools/sz_repo_cli/lib/src/main.dart
@@ -12,6 +12,8 @@ import 'dart:io';
 import 'package:args/command_runner.dart';
 import 'package:path/path.dart' as p;
 import 'package:sz_repo_cli/src/commands/src/add_license_headers_command.dart';
+import 'package:sz_repo_cli/src/commands/src/build_android_command.dart';
+import 'package:sz_repo_cli/src/commands/src/build_command.dart';
 import 'package:sz_repo_cli/src/commands/src/check_license_headers_command.dart';
 import 'package:sz_repo_cli/src/commands/src/format_command.dart';
 import 'package:sz_repo_cli/src/commands/src/license_headers_command.dart';
@@ -42,7 +44,8 @@ Future<void> main(List<String> args) async {
     ..addCommand(LicenseHeadersCommand()
       ..addSubcommand(CheckLicenseHeadersCommand(repo))
       ..addSubcommand(AddLicenseHeadersCommand(repo)))
-    ..addCommand(DeployCommand()..addSubcommand(DeployWebAppCommand(repo)));
+    ..addCommand(DeployCommand()..addSubcommand(DeployWebAppCommand(repo)))
+    ..addCommand(BuildCommand()..addSubcommand(BuildAndroidCommand(repo)));
 
   await commandRunner.run(args).catchError((Object e) {
     final ToolExit toolExit = e;


### PR DESCRIPTION
Adds the `sz build android` command to the Sharezone CLI. It's part of a `sz deploy` command that should come in the future.

Running `sz build android --help`

```
NilsMBP13M14:sz_repo_cli nils$ fvm dart run sz_repo_cli build android --help
Build the Sharezone Android app in release mode. Codemagic CLI tools must be installed.

Usage: pub global run sz_repo_cli build android [arguments]
-h, --help            Print this usage information.
-s, --stage           [stable (default), alpha]
    --output-type     The type of output type, either "appbundle" or "apk".
                      [appbundle (default), apk]
    --build-number    An identifier used as an internal version number.
                      Each build must have a unique identifier to differentiate it from previous builds.
                      It is used to determine whether one build is more recent than
                      another, with higher numbers indicating more recent build.
                      When none is specified, the value from pubspec.yaml is used.
    --flavor          The flavor to build for. At the moment only "prod" is supported.
                      [prod (default), dev]

Run "pub global run sz_repo_cli help" to see global options.
```

Running `sz build android`

```
NilsMBP13M14:sz_repo_cli nils$ fvm dart run sz_repo_cli build android
Starting fvm flutter build appbundle --target lib/main_prod.dart --flavor prod --release --dart-define DEVELOPMENT_STAGE=STABLE...
Waiting for exit code...

Building without sound null safety ⚠️
Dart 3 will only support sound null safety, see https://dart.dev/null-safety

Running Gradle task 'bundleProdRelease'...                      
Removed unused resources: Binary resource data reduced from 609KB to 550KB: Removed 9%
Running Gradle task 'bundleProdRelease'...                         30.2s
✓ Built build/app/outputs/bundle/prodRelease/app-prod-release.aab (43.5MB).
Got exit code 0...
Build finished 🎉 
```