### PR TITLE
Fix incorrect `sz build android` description

### DIFF
--- a/tools/sz_repo_cli/lib/src/commands/src/build_android_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/build_android_command.dart
@@ -65,8 +65,7 @@ When none is specified, the value from pubspec.yaml is used.''',
   static const outputTypeName = 'output-type';
 
   @override
-  String get description =>
-      'Build the Sharezone Android app in release mode. Codemagic CLI tools must be installed.';
+  String get description => 'Build the Sharezone Android app in release mode.';
 
   @override
   String get name => 'android';


### PR DESCRIPTION
Codemagic CLI Tools are not required for building Android. They are later required when deploying.