### PR TITLE
Optimize App Startup by Background Loading of Firebase Remote Config

### DIFF
--- a/app/lib/main/plugin_initializations.dart
+++ b/app/lib/main/plugin_initializations.dart
@@ -65,7 +65,7 @@ class PluginInitializations {
   static Future<RemoteConfiguration> initializeRemoteConfiguration() async {
     final remoteConfiguration = getRemoteConfiguration();
 
-    await remoteConfiguration.initialize({
+    await remoteConfiguration.initializeAndFetchInBackground({
       'meeting_server_url': 'https://meet.sharezone.net',
       'abgaben_bucket_name': 'sharezone-c2bd8-submissions',
       'abgaben_service_base_url': 'https://api.sharezone.net',

--- a/lib/remote_configuration/lib/src/implementation/stub_remote_configuration.dart
+++ b/lib/remote_configuration/lib/src/implementation/stub_remote_configuration.dart
@@ -22,7 +22,9 @@ class StubRemoteConfiguration extends RemoteConfiguration {
   }
 
   @override
-  Future<void> initialize(Map<String, dynamic> defaultValues) async {
+  Future<void> initializeAndFetchInBackground(
+    Map<String, dynamic> defaultValues,
+  ) async {
     _defaultValues = defaultValues;
   }
 }

--- a/lib/remote_configuration/lib/src/remote_configuration.dart
+++ b/lib/remote_configuration/lib/src/remote_configuration.dart
@@ -7,7 +7,8 @@
 // SPDX-License-Identifier: EUPL-1.2
 
 abstract class RemoteConfiguration {
-  Future<void> initialize(Map<String, dynamic> defaultValues);
+  Future<void> initializeAndFetchInBackground(
+      Map<String, dynamic> defaultValues);
   String getString(String key);
   bool getBool(String key);
 }


### PR DESCRIPTION
## Description

In this pull request, we made significant changes to the way our application fetches and activates the Firebase Remote Config data to improve app start-up times.

Previously, our app fetched Firebase Remote Config data during its start-up sequence. This fetch-and-activate approach was a major contributor to the 11 seconds startup time our app was experiencing.

We have now moved the Firebase Remote Config fetch process to execute in the background after the application has started. This ensures that the app is not blocked waiting for these config values during startup. The fetched config values are activated on the next app launch. 

This change has led to a considerable improvement in app startup times. Initial tests show startup times have dropped to just 2 seconds, down from 11 seconds - a more than 5x improvement.

### Disadvantages in this strategy

The disadvantage in this strategy is that the values activated on the next launch. When there is a critical change, the user doesn't receive the values immediately. However, since we started Sharezone, 5 years ago, we never had this case. Therefore, I think it's overkill to trade bad app start times against the possibility to update critical values maybe someday.

## Benchmarks

| Name | Time |
|-|-|
| Before the changes | 11 seconds |
| After the changes | 2 seconds |

The app start is now 5,5x faster than before when using an EDGE connection.

### Demo

(In the benchmarks table, I removed the time I needed to open the emulator and click the "stop" button)

#### Before 

https://github.com/SharezoneApp/sharezone-app/assets/24459435/f2c512ac-0a4c-45df-8f22-afff05611d87

#### After

https://github.com/SharezoneApp/sharezone-app/assets/24459435/de172d53-1147-43b5-b1df-f228ce5b51ec

#### Using the values for the next start

https://github.com/SharezoneApp/sharezone-app/assets/24459435/198add26-2da3-4fb2-94ac-59e8f3defe0e

## Related Ticktes

Fixes #696 