### PR TITLE
Add `ProcessResult` as return type to `runProcessSucessfullyOrThrow`

### DIFF
--- a/tools/sz_repo_cli/lib/src/common/src/run_process.dart
+++ b/tools/sz_repo_cli/lib/src/common/src/run_process.dart
@@ -12,7 +12,7 @@ import '../common.dart';
 
 /// Helper method that automatically throws if [Process.exitCode] is non-zero
 /// (unsucessfull).
-Future<void> runProcessSucessfullyOrThrow(
+Future<ProcessResult> runProcessSucessfullyOrThrow(
   String executable,
   List<String> arguments, {
   String? workingDirectory,
@@ -34,6 +34,8 @@ Future<void> runProcessSucessfullyOrThrow(
     throw Exception(
         'Process ended with non-zero exit code: $displayableCommand (exit code ${result.exitCode}): ${result.stderr}\n\n stdout:${result.stdout}');
   }
+
+  return ProcessResult(result.pid, exitCode, result.stdout, result.stderr);
 }
 
 /// Helper method with automatic (verbose) logging and workarounds for some


### PR DESCRIPTION
In #695 I need to work with the attributes of `ProcessResult` but it would be helpful to still use `runProcessSucessfullyOrThrow` since this method checks if the command execution was successful (https://github.com/SharezoneApp/sharezone-app/pull/695#discussion_r1274675748).