### PR TITLE
Add CD workflow to deploy new iOS stable versions

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -37,9 +37,6 @@ jobs:
     if: github.event.inputs.ios-changelog != ''
     runs-on: macos-13
     timeout-minutes: 120
-    defaults:
-      run:
-        working-directory: app
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
 
@@ -47,6 +44,7 @@ jobs:
         run: pip3 install codemagic-cli-tools==0.39.1
 
       - name: Setup signing
+        working-directory: app
         env:
           # The following secrets are used by the Codemagic CLI tool. It's important
           # to use the same names as the CLI tool expects.
@@ -80,6 +78,12 @@ jobs:
           flutter pub global activate fvm 2.4.1
           fvm config --cache-path '${{ runner.tool_cache }}/flutter'
 
+      - name: Activate sz_repo_cli package
+        run: fvm flutter pub global activate --source path "$CI_CD_DART_SCRIPTS_PACKAGE_PATH"
+
+      # So we can just use "sz COMMAND" instead of "dart ../path/to/script.dart ..."
+      - run: echo $(pwd)/bin >> $GITHUB_PATH
+
       - name: Deploy
         env:
           # The following secrets are used by the Codemagic CLI tool. It's important
@@ -90,4 +94,5 @@ jobs:
         run: |
           sz deploy ios \
             --stage stable \
-            --whats-new "${{ github.event.inputs.ios-changelog }}"
+            --whats-new "${{ github.event.inputs.ios-changelog }}" \
+            --export-options-plist=$HOME/export_options.plist

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -21,9 +21,8 @@ on:
       ios-changelog:
         type: string
         description: |
-          The changelog for the iOS release. This will be used as the release
-          notes in the App Store release.
-        required: true
+          iOS changelog: Used for the App Store release notes. If the changelog 
+          is not provided, the deployment for iOS will be skipped.
 
 # Set permissions to none.
 #
@@ -33,6 +32,9 @@ permissions: {}
 
 jobs:
   deploy-ios:
+    # We skip the deployment if no changelog is provided because we assume that
+    # nothing has changed in the iOS app and therefore no new version is needed.
+    if: github.event.inputs.ios-changelog != ''
     runs-on: macos-13
     timeout-minutes: 120
     defaults:

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -82,7 +82,6 @@ jobs:
         env:
           # The following secrets are used by the Codemagic CLI tool. It's important
           # to use the same names as the CLI tool expects.
-          CERTIFICATE_PRIVATE_KEY: ${{ secrets.SHAREZONE_CERTIFICATE_PRIVATE_KEY }}
           APP_STORE_CONNECT_KEY_IDENTIFIER: ${{ secrets.SHAREZONE_APP_STORE_CONNECT_KEY_IDENTIFIER }}
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.SHAREZONE_APP_STORE_CONNECT_ISSUER_ID }}
           APP_STORE_CONNECT_PRIVATE_KEY: ${{ secrets.SHAREZONE_APP_STORE_CONNECT_PRIVATE_KEY }}

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -79,6 +79,13 @@ jobs:
           fvm config --cache-path '${{ runner.tool_cache }}/flutter'
 
       - name: Deploy
+        env:
+          # The following secrets are used by the Codemagic CLI tool. It's important
+          # to use the same names as the CLI tool expects.
+          CERTIFICATE_PRIVATE_KEY: ${{ secrets.SHAREZONE_CERTIFICATE_PRIVATE_KEY }}
+          APP_STORE_CONNECT_KEY_IDENTIFIER: ${{ secrets.SHAREZONE_APP_STORE_CONNECT_KEY_IDENTIFIER }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.SHAREZONE_APP_STORE_CONNECT_ISSUER_ID }}
+          APP_STORE_CONNECT_PRIVATE_KEY: ${{ secrets.SHAREZONE_APP_STORE_CONNECT_PRIVATE_KEY }}
         run: |
           sz deploy ios \
             --stage stable \

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -1,0 +1,85 @@
+# Copyright (c) 2022 Sharezone UG (haftungsbeschränkt)
+# Licensed under the EUPL-1.2-or-later.
+#
+# You may obtain a copy of the Licence at:
+# https://joinup.ec.europa.eu/software/page/eupl
+#
+# SPDX-License-Identifier: EUPL-1.2
+
+name: stable
+
+concurrency:
+  # Our iOS builds require unique build numbers. Therefore, we should never
+  # build a new version while a build is already running. This is why we use the
+  # branch name as a concurrency group. This way, we can only build one version
+  # per branch at the same time.
+  group: app-release
+
+on:
+  workflow_dispatch:
+    inputs:
+      ios-changelog:
+        type: string
+        description: |
+          The changelog for the iOS release. This will be used as the release
+          notes in the App Store release.
+        required: true
+
+# Set permissions to none.
+#
+# Using the broad default permissions is considered a bad security practice
+# and would cause alerts from our scanning tools.
+permissions: {}
+
+jobs:
+  deploy-ios:
+    runs-on: macos-13
+    timeout-minutes: 120
+    defaults:
+      run:
+        working-directory: app
+    steps:
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+
+      - name: Install Codemagic CLI Tools
+        run: pip3 install codemagic-cli-tools==0.39.1
+
+      - name: Setup signing
+        env:
+          # The following secrets are used by the Codemagic CLI tool. It's important
+          # to use the same names as the CLI tool expects.
+          CERTIFICATE_PRIVATE_KEY: ${{ secrets.SHAREZONE_CERTIFICATE_PRIVATE_KEY }}
+          APP_STORE_CONNECT_KEY_IDENTIFIER: ${{ secrets.SHAREZONE_APP_STORE_CONNECT_KEY_IDENTIFIER }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.SHAREZONE_APP_STORE_CONNECT_ISSUER_ID }}
+          APP_STORE_CONNECT_PRIVATE_KEY: ${{ secrets.SHAREZONE_APP_STORE_CONNECT_PRIVATE_KEY }}
+        run: |
+          keychain initialize
+          app-store-connect fetch-signing-files $(xcode-project detect-bundle-id) \
+            --platform IOS \
+            --type IOS_APP_STORE \
+            --create
+          keychain add-certificates
+          xcode-project use-profiles
+
+      - name: Set Flutter version from FVM config file to environment variables
+        uses: kuhnroyal/flutter-fvm-config-action@e91317131a2da710b9cd9b7a24f2c0ade9eeb61d
+
+      - uses: subosito/flutter-action@48cafc24713cca54bbe03cdc3a423187d413aafa
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: ${{ env.FLUTTER_CHANNEL }}
+          # Use format expected by FVM.
+          # Else this won't be recognized as an installed version when setting
+          # '.../flutter' as the FVM Flutter version cache folder.
+          cache-path: "${{ runner.tool_cache }}/flutter/:version:"
+
+      - name: Install FVM
+        run: |
+          flutter pub global activate fvm 2.4.1
+          fvm config --cache-path '${{ runner.tool_cache }}/flutter'
+
+      - name: Deploy
+        run: |
+          sz deploy ios \
+            --stage stable \
+            --whats-new "${{ github.event.inputs.ios-changelog }}"


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for deploying new stable versions of our application.

The workflow, named 'stable', ensures that our iOS builds are built sequentially to maintain unique build numbers, a requirement of iOS builds. The concurrency group, 'app-release', enforces that only one version is built per branch at a time.

A manual trigger has been implemented via the workflow_dispatch event. This requires the input of a changelog for the iOS release. This changelog is subsequently used as the release notes in the App Store release.