### PR TITLE
Rename concurrency group for alpha deployments

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -13,7 +13,7 @@ concurrency:
   # build a new version while a build is already running. This is why we use the
   # branch name as a concurrency group. This way, we can only build one version
   # per branch at the same time.
-  group: alpha
+  group: app-release
 
 on:
   push:


### PR DESCRIPTION
Since we also have a workflow to deploy stable versions (#699) we need to use the same name for the concurrency group because in these workflows we access the latest build number from App Store Connect.