### PR TITLE
Use `sz deploy ios` command in `alpha.yml` workflow

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -250,36 +250,8 @@ jobs:
       run: |
         flutter pub global activate fvm 2.4.1
         fvm config --cache-path '${{ runner.tool_cache }}/flutter'
-    
-    - name: Build iOS app
-      env:
-        # From https://appstoreconnect.apple.com/apps/1434868489/
-        IOS_APP_ID: 1434868489
-        # The following secrets are used by the Codemagic CLI tool. It's important
-        # to use the same names as the CLI tool expects.
-        APP_STORE_CONNECT_KEY_IDENTIFIER: ${{ secrets.SHAREZONE_APP_STORE_CONNECT_KEY_IDENTIFIER }}
-        APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.SHAREZONE_APP_STORE_CONNECT_ISSUER_ID }}
-        APP_STORE_CONNECT_PRIVATE_KEY: ${{ secrets.SHAREZONE_APP_STORE_CONNECT_PRIVATE_KEY }}
-      run: |
-        # Because TestFlight requires a build number that is higher than the
-        # latest build number, we need to get the latest build number and
-        # increment it by one.
-        #
-        # The "| head -2 | tail -1" part is to get the second line of the output
-        # of the "app-store-connect get-latest-build-number" command because the
-        # second line includes the build number.
-        LATEST_BUILD_NUMBER=$(app-store-connect get-latest-build-number $IOS_APP_ID --platform IOS | head -2 | tail -1)
-        BUMPED_BUILD_NUMBER=$(expr $LATEST_BUILD_NUMBER + 1)
 
-        fvm flutter build ipa \
-          --release \
-          --flavor prod \
-          --target lib/main_prod.dart \
-          --dart-define DEVELOPMENT_STAGE=ALPHA \
-          --export-options-plist=$HOME/export_options.plist \
-          --build-number $BUMPED_BUILD_NUMBER
-
-    - name: Publish to App Store Connect
+    - name: Deploy iOS alpha to TestFlight
       env:
         # The following secrets are used by the Codemagic CLI tool. It's important
         # to use the same names as the CLI tool expects.
@@ -301,9 +273,6 @@ jobs:
         # longer than 4000 characters.
         export SHORT_LAST_COMMIT_MESSAGE=${LAST_COMMIT_MESSAGE:0:4000}
 
-        app-store-connect publish \
-          --path build/ios/ipa/*.ipa \
-          --beta-group=alpha \
-          --testflight \
-          --release-type=AFTER_APPROVAL \
+        sz deploy ios \
+          --stage alpha \
           --whats-new="$SHORT_LAST_COMMIT_MESSAGE"


### PR DESCRIPTION
With this PR we make use of the new `sz deploy ios` command (#695) to remove code duplication.