### PR TITLE
Upgrade dio to 5.3.2 to resolve CVE-2020-35669

### DIFF
--- a/app/lib/blocs/sharezone_bloc_providers.dart
+++ b/app/lib/blocs/sharezone_bloc_providers.dart
@@ -289,7 +289,7 @@ class _SharezoneBlocProvidersState extends State<SharezoneBlocProviders> {
       baseUrl: abgabenServiceBaseUrl,
 
       /// Cold-Start kann manchmal dauern
-      connectTimeout: 45000,
+      connectTimeout: const Duration(seconds: 45),
     );
     abgabeHttpApi.dio = Dio(baseOptions);
     var firebaseAuthTokenRetreiver = FirebaseAuthTokenRetreiverImpl(

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -480,10 +480,10 @@ packages:
     dependency: "direct main"
     description:
       name: dio
-      sha256: "7d328c4d898a61efc3cd93655a0955858e29a0aa647f0f9e02d59b3bb275e2e8"
+      sha256: ce75a1b40947fea0a0e16ce73337122a86762e38b982e1ccb909daa3b9bc4197
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.6"
+    version: "5.3.2"
   dynamic_links:
     dependency: "direct main"
     description:
@@ -913,7 +913,7 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/flutter_markdown"
-      ref: HEAD
+      ref: a12da208dff84bc9c77453a1e8a392bb7f40fc4a
       resolved-ref: a12da208dff84bc9c77453a1e8a392bb7f40fc4a
       url: "https://github.com/SharezoneApp/packages"
     source: git

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -58,7 +58,7 @@ dependencies:
     path: ../lib/date
   design:
     path: ../lib/design
-  dio: ^4.0.0
+  dio: ^5.3.2
   dynamic_links:
     path: ../lib/dynamic_links
   fast_immutable_collections: ^7.4.1

--- a/lib/abgabe/abgabe_http_api/lib/api.dart
+++ b/lib/abgabe/abgabe_http_api/lib/api.dart
@@ -25,8 +25,8 @@ class AbgabeHttpApi {
         Dio(
           BaseOptions(
             baseUrl: basePath,
-            connectTimeout: 5000,
-            receiveTimeout: 3000,
+            connectTimeout: const Duration(seconds: 5),
+            receiveTimeout: const Duration(seconds: 3),
           ),
         );
     this.serializers = serializers ?? standardSerializers;

--- a/lib/abgabe/abgabe_http_api/pubspec.lock
+++ b/lib/abgabe/abgabe_http_api/pubspec.lock
@@ -173,10 +173,10 @@ packages:
     dependency: "direct main"
     description:
       name: dio
-      sha256: "7d328c4d898a61efc3cd93655a0955858e29a0aa647f0f9e02d59b3bb275e2e8"
+      sha256: ce75a1b40947fea0a0e16ce73337122a86762e38b982e1ccb909daa3b9bc4197
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.6"
+    version: "5.3.2"
   file:
     dependency: transitive
     description:

--- a/lib/abgabe/abgabe_http_api/pubspec.yaml
+++ b/lib/abgabe/abgabe_http_api/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
 dependencies:
   built_collection: ^5.1.0
   built_value: ^8.1.1
-  dio: ^4.0.0
+  dio: ^5.3.2
 
 dev_dependencies:
   build_runner: ^2.3.3


### PR DESCRIPTION
Tested manually that homework submissions are still working.

Fixes https://github.com/SharezoneApp/sharezone-app/security/dependabot/19
Fixes https://github.com/SharezoneApp/sharezone-app/security/dependabot/18
Fixes https://github.com/SharezoneApp/sharezone-app/security/dependabot/17
Fixes https://github.com/SharezoneApp/sharezone-app/security/dependabot/16
Fixes https://github.com/SharezoneApp/sharezone-app/security/dependabot/15
Fixes https://github.com/SharezoneApp/sharezone-app/security/dependabot/14