### PR TITLE
Skip image compressing for macOS

### DIFF
--- a/lib/filesharing/files_usecases/lib/src/file_compression/implementation/mobile_native_image_compressor.dart
+++ b/lib/filesharing/files_usecases/lib/src/file_compression/implementation/mobile_native_image_compressor.dart
@@ -11,11 +11,19 @@ import 'package:files_basics/local_file.dart';
 import 'package:files_basics/local_file_io.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:flutter_image_compress/flutter_image_compress.dart';
+import 'package:sharezone_utils/platform.dart';
 import '../image_compressor.dart';
 
 class FlutterNativeImageCompressor extends ImageCompressor {
   @override
   Future<LocalFile> compressImage(LocalFile file) async {
+    if (PlatformCheck.isMacOS) {
+      // Currently, the image compressor does not work on macOS.
+      //
+      // https://github.com/fluttercandies/flutter_image_compress/issues/255
+      return file;
+    }
+
     final File ioFile = file.getFile();
     final dir = await getTemporaryDirectory();
     final targetPath = "${dir.absolute.path}/compressed-${file.getName()}";


### PR DESCRIPTION
## Summary

This PR addresses a limitation with the `flutter_image_compress` library on macOS. Due to a known issue, the image compressor does not work on macOS, leading to potential runtime errors or unexpected behavior.

## Changes:

- If the platform is macOS, the image compression step is skipped and the original file is returned unchanged.

## Reason for Change:

The `flutter_image_compress` library has a known issue on macOS which causes the compression functionality to fail. Refer to the following issue for more details: [fluttercandies/flutter_image_compress#255](https://github.com/fluttercandies/flutter_image_compress/issues/255).

By skipping the image compression step on macOS, we ensure that our users do not encounter unexpected errors or issues while using the app on this platform. The changes are a temporary measure until a fix or alternative solution is found for the underlying library issue.

## Testing:

- Manual testing on macOS confirms that images are not compressed and the app behaves as expected.

## Related Tickets

Fixes #713 
