### PR TITLE
Run `flutter pub get` in `abgabe_client_lib` to resolve CVE-2020-35669

### DIFF
--- a/lib/abgabe/abgabe_client_lib/pubspec.lock
+++ b/lib/abgabe/abgabe_client_lib/pubspec.lock
@@ -295,10 +295,10 @@ packages:
     dependency: transitive
     description:
       name: dio
-      sha256: "7d328c4d898a61efc3cd93655a0955858e29a0aa647f0f9e02d59b3bb275e2e8"
+      sha256: ce75a1b40947fea0a0e16ce73337122a86762e38b982e1ccb909daa3b9bc4197
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.6"
+    version: "5.3.2"
   encrypt:
     dependency: transitive
     description:


### PR DESCRIPTION
Fix from #710 

Fixes https://github.com/SharezoneApp/sharezone-app/security/dependabot/15
Fixes https://github.com/SharezoneApp/sharezone-app/security/dependabot/18