### PR TITLE
Remove "opened" pull request trigger for "label_app_preview"

### DIFF
--- a/.github/workflows/label_app_preview.yaml
+++ b/.github/workflows/label_app_preview.yaml
@@ -16,7 +16,6 @@ on:
   pull_request:
     types:
       - labeled
-      - opened
       - synchronize
 
 jobs:


### PR DESCRIPTION
The pull request type `opened` only makes sense when you skip workflows because they should only be executed for non-draft pull requests. But because we don't have this check in this workflow, we don't need "opened" as a type.