### PR TITLE
Using the Flutter version from the `fvm_config.json` for `codemagic.yaml`

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -38,12 +38,8 @@ workflows:
         - codemagic
       vars:
         BUNDLE_ID: de.codingbrain.sharezone.app.dev
-      # We won't use this Flutter version because we are going to download FVM
-      # later and use the specified Flutter version in our repository.
-      #
-      # As predefined Flutter version we are using here the newest stable
-      # version because this version is preinstalled on Codemagic VMs.
-      flutter: stable
+      # Sets the Flutter version to the version from fvm_config.json.
+      flutter: fvm
     working_directory: app
     scripts:
       - name: Install FVM


### PR DESCRIPTION
Uses the new version to automatically set the Flutter version to the version from the `fvm_config.json` file (see https://docs.codemagic.io/yaml-quick-start/building-a-flutter-app/#setting-the-flutter-version).

(I still leave the "Install FVM" step in the file because I will later replace the "flutter build" commands with our "sz build" commands, which require FVM.)