### PR TITLE
Bump the min. Dart Version of our Sharezone CLI to 2.19.6

### DIFF
--- a/tools/sz_repo_cli/pubspec.lock
+++ b/tools/sz_repo_cli/pubspec.lock
@@ -497,4 +497,4 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.19.0 <3.0.0"
+  dart: ">=2.19.6 <3.0.0"

--- a/tools/sz_repo_cli/pubspec.yaml
+++ b/tools/sz_repo_cli/pubspec.yaml
@@ -11,7 +11,7 @@ version: 0.0.1
 publish_to: none
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.19.6 <3.0.0'
 
 dependencies:
   args: ^2.3.1


### PR DESCRIPTION
I need some of the "new" Dart features in other pull requests. 
