### PR TITLE
Force loading remote config values for dev flavor

### DIFF
--- a/app/lib/main/plugin_initializations.dart
+++ b/app/lib/main/plugin_initializations.dart
@@ -15,17 +15,18 @@ import 'package:flutter/foundation.dart';
 import 'package:purchases_flutter/purchases_flutter.dart';
 import 'package:remote_configuration/remote_configuration.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:sharezone/main/sharezone.dart';
+import 'package:sharezone/util/flavor.dart';
 import 'package:sharezone_utils/platform.dart';
 import 'package:streaming_shared_preferences/streaming_shared_preferences.dart';
 
 class PluginInitializations {
-  const PluginInitializations(
-      {this.remoteConfiguration,
-      this.crashAnalytics,
-      this.dynamicLinks,
-      this.sharedPreferences,
-      this.streamingSharedPreferences});
+  const PluginInitializations({
+    this.remoteConfiguration,
+    this.crashAnalytics,
+    this.dynamicLinks,
+    this.sharedPreferences,
+    this.streamingSharedPreferences,
+  });
 
   final RemoteConfiguration remoteConfiguration;
   final CrashAnalytics crashAnalytics;
@@ -64,7 +65,9 @@ class PluginInitializations {
     return dynamicLinks;
   }
 
-  static Future<RemoteConfiguration> initializeRemoteConfiguration() async {
+  static Future<RemoteConfiguration> initializeRemoteConfiguration({
+    @required Flavor flavor,
+  }) async {
     final remoteConfiguration = getRemoteConfiguration();
 
     remoteConfiguration.initialize({
@@ -77,15 +80,23 @@ class PluginInitializations {
           'BNT7Da6B6wi-mUBcGrt-9HxeIJZsPTsPpmR8cae_LhgJPcSFb5j0T8o-r-oFV1xAtXVXfRPIZlgUJR3tx8mLbbA',
     });
 
-    // We follow the "Load new values for next startup" strategy (see
-    // https://firebase.google.com/docs/remote-config/loading) to reduce the
-    // startup time of the app.
-    //
-    // First, we activate the fetched remote config from the last fetch. Then we
-    // fetch the remote config in the background. The next time the app starts,
-    // the fetched remote config will be available.
-    await remoteConfiguration.activate();
-    unawaited(remoteConfiguration.fetch());
+    if (flavor == Flavor.dev) {
+      // Since we depend on some values from our Remote Config in the dev
+      // environment, we can't use the "Load new values for next startup"
+      // strategy.
+      await remoteConfiguration.fetch();
+      await remoteConfiguration.activate();
+    } else {
+      await remoteConfiguration.activate();
+      // We follow the "Load new values for next startup" strategy (see
+      // https://firebase.google.com/docs/remote-config/loading) to reduce the
+      // startup time of the app.
+      //
+      // First, we activate the fetched remote config from the last fetch. Then we
+      // fetch the remote config in the background. The next time the app starts,
+      // the fetched remote config will be available.
+      unawaited(remoteConfiguration.fetch());
+    }
 
     return remoteConfiguration;
   }
@@ -102,9 +113,11 @@ class PluginInitializations {
   }
 }
 
-Future<PluginInitializations> runPluginInitializations() async {
+Future<PluginInitializations> runPluginInitializations({
+  @required Flavor flavor,
+}) async {
   final futureRemoteConfiguration =
-      PluginInitializations.initializeRemoteConfiguration();
+      PluginInitializations.initializeRemoteConfiguration(flavor: flavor);
   final futureSharedPrefs = PluginInitializations.initializeSharedPreferences();
   final futureStreamingSharedPrefs =
       PluginInitializations.initializeStreamingSharedPreferences();

--- a/app/lib/main/plugin_initializations.dart
+++ b/app/lib/main/plugin_initializations.dart
@@ -85,7 +85,7 @@ class PluginInitializations {
     // fetch the remote config in the background. The next time the app starts,
     // the fetched remote config will be available.
     await remoteConfiguration.activate();
-    unawaited(_fetchRemoteConfig(remoteConfiguration));
+    unawaited(remoteConfiguration.fetch());
 
     return remoteConfiguration;
   }
@@ -99,24 +99,6 @@ class PluginInitializations {
       initializeStreamingSharedPreferences() async {
     final prefs = await StreamingSharedPreferences.instance;
     return prefs;
-  }
-}
-
-Future<void> _fetchRemoteConfig(RemoteConfiguration remoteConfiguration) async {
-  try {
-    await remoteConfiguration.fetch();
-  } catch (e) {
-    if (isIntegrationTest && PlatformCheck.isAndroid) {
-      if ('$e'.contains(
-          '[firebase_remote_config/internal] internal remote config fetch error')) {
-        log("Catched '$e'. Ignoring because we're running an integration test.");
-        // Sometimes the remote config fetch fails on Android integration tests,
-        // see https://github.com/SharezoneApp/sharezone-app/issues/725.
-        return;
-      }
-    }
-
-    rethrow;
   }
 }
 

--- a/app/lib/main/plugin_initializations.dart
+++ b/app/lib/main/plugin_initializations.dart
@@ -92,9 +92,9 @@ class PluginInitializations {
       // https://firebase.google.com/docs/remote-config/loading) to reduce the
       // startup time of the app.
       //
-      // First, we activate the fetched remote config from the last fetch. Then we
-      // fetch the remote config in the background. The next time the app starts,
-      // the fetched remote config will be available.
+      // First, we activate the fetched remote config from the last fetch. Then
+      // we fetch the remote config in the background. The next time the app
+      // starts, the fetched remote config will be available.
       unawaited(remoteConfiguration.fetch());
     }
 

--- a/app/lib/main/run_app.dart
+++ b/app/lib/main/run_app.dart
@@ -93,7 +93,7 @@ Future<AppDependencies> initializeDependencies({
 
   await _initializeFirebase(flavor);
 
-  final pluginInitializations = await runPluginInitializations();
+  final pluginInitializations = await runPluginInitializations(flavor: flavor);
 
   final firebaseDependencies = FirebaseDependencies.get();
   final firebaseFunctions =


### PR DESCRIPTION
As in #751 described, we sometimes depend on the values in the Remote Config in our dev environment. For that reason, we force fetching the newest values when running the app in our dev environment.

Closes #751