### PR TITLE
Add git diff checks for integration tests

### DIFF
--- a/.github/workflows/cli_ci.yml
+++ b/.github/workflows/cli_ci.yml
@@ -113,7 +113,7 @@ jobs:
       # updated. Or other cases where files are changed during a build.
       # Therefore, fails this check if there are Git changes.
       - name: Fail if there are Git diffs
-        run: git diff --exit-code
+        run: git diff --exit-code --name-status
 
   test:
     needs: changes

--- a/.github/workflows/integration_tests_app_ci.yml
+++ b/.github/workflows/integration_tests_app_ci.yml
@@ -154,6 +154,12 @@ jobs:
             --test ../build/app/outputs/apk/androidTest/prod/debug/app-prod-debug-androidTest.apk \
             --device model=Pixel2,version=30,locale=en,orientation=portrait \
             --timeout 3m
+    
+      # It can easily happen that a dependency changed but the .lock file is not
+      # updated. Or other cases where files are changed during a build.
+      # Therefore, fails this check if there are Git changes.
+      - name: Fail if there are Git diffs
+        run: git diff --exit-code
 
   ios-integration-test:
     needs: changes
@@ -208,6 +214,12 @@ jobs:
             --dart-define=USER_1_EMAIL=$USER_1_EMAIL \
             --dart-define=USER_1_PASSWORD=$USER_1_PASSWORD \
             -d $SIMULATOR_UDID
+
+      # It can easily happen that a dependency changed but the .lock file is not
+      # updated. Or other cases where files are changed during a build.
+      # Therefore, fails this check if there are Git changes.
+      - name: Fail if there are Git diffs
+        run: git diff --exit-code
 
   # At the moment, Flutter Integration Tests are not working with GitHub Actions
   # and Flutter +3.7 (see https://github.com/flutter/flutter/issues/118469).
@@ -267,3 +279,9 @@ jobs:
         run: |
           flutter build macos \
             -t lib/main_prod.dart
+
+      # It can easily happen that a dependency changed but the .lock file is not
+      # updated. Or other cases where files are changed during a build.
+      # Therefore, fails this check if there are Git changes.
+      - name: Fail if there are Git diffs
+        run: git diff --exit-code

--- a/.github/workflows/integration_tests_app_ci.yml
+++ b/.github/workflows/integration_tests_app_ci.yml
@@ -159,7 +159,7 @@ jobs:
       # updated. Or other cases where files are changed during a build.
       # Therefore, fails this check if there are Git changes.
       - name: Fail if there are Git diffs
-        run: git diff --exit-code
+        run: git diff --exit-code --name-status
 
   ios-integration-test:
     needs: changes
@@ -219,7 +219,7 @@ jobs:
       # updated. Or other cases where files are changed during a build.
       # Therefore, fails this check if there are Git changes.
       - name: Fail if there are Git diffs
-        run: git diff --exit-code
+        run: git diff --exit-code --name-status
 
   # At the moment, Flutter Integration Tests are not working with GitHub Actions
   # and Flutter +3.7 (see https://github.com/flutter/flutter/issues/118469).
@@ -284,4 +284,4 @@ jobs:
       # updated. Or other cases where files are changed during a build.
       # Therefore, fails this check if there are Git changes.
       - name: Fail if there are Git diffs
-        run: git diff --exit-code
+        run: git diff --exit-code --name-status

--- a/.github/workflows/integration_tests_app_ci.yml
+++ b/.github/workflows/integration_tests_app_ci.yml
@@ -215,12 +215,6 @@ jobs:
             --dart-define=USER_1_PASSWORD=$USER_1_PASSWORD \
             -d $SIMULATOR_UDID
 
-      # It can easily happen that a dependency changed but the .lock file is not
-      # updated. Or other cases where files are changed during a build.
-      # Therefore, fails this check if there are Git changes.
-      - name: Fail if there are Git diffs
-        run: git diff --exit-code --name-status
-
   # At the moment, Flutter Integration Tests are not working with GitHub Actions
   # and Flutter +3.7 (see https://github.com/flutter/flutter/issues/118469).
   #
@@ -279,9 +273,3 @@ jobs:
         run: |
           flutter build macos \
             -t lib/main_prod.dart
-
-      # It can easily happen that a dependency changed but the .lock file is not
-      # updated. Or other cases where files are changed during a build.
-      # Therefore, fails this check if there are Git changes.
-      - name: Fail if there are Git diffs
-        run: git diff --exit-code --name-status

--- a/.github/workflows/safe_app_ci.yml
+++ b/.github/workflows/safe_app_ci.yml
@@ -129,7 +129,7 @@ jobs:
       # updated. Or other cases where files are changed during a build.
       # Therefore, fails this check if there are Git changes.
       - name: Fail if there are Git diffs
-        run: git diff --exit-code
+        run: git diff --exit-code --name-status
 
   # We split the tests into two jobs, because we want to run the golden tests on
   # a macOS runner, because the golden tests were generated on macOS. To reduce


### PR DESCRIPTION
We're already catching Flutter dependency changes in the `analyze` check. However, to catch platform-specific file changes, I added the git diff check to the integration test checks.