### PR TITLE
Fix "Null check operator used on a null value" when when closing the video player

### DIFF
--- a/lib/filesharing/files_usecases/lib/src/file_viewer/widgets/video_viewer.dart
+++ b/lib/filesharing/files_usecases/lib/src/file_viewer/widgets/video_viewer.dart
@@ -17,10 +17,10 @@ class VideoViewer extends StatefulWidget {
   final String downloadURL;
 
   @override
-  State createState() => __VideoViewerState();
+  State createState() => _VideoViewerState();
 }
 
-class __VideoViewerState extends State<VideoViewer> {
+class _VideoViewerState extends State<VideoViewer> {
   ChewieController? _controller;
   late VideoPlayerController _videoPlayerController;
 
@@ -45,7 +45,7 @@ class __VideoViewerState extends State<VideoViewer> {
   @override
   void dispose() {
     super.dispose();
-    _controller!.dispose();
+    _controller?.dispose();
     _videoPlayerController.dispose();
   }
 


### PR DESCRIPTION
Related to #762