### PR TITLE
Fix using `ScaffoldMessengerKey` to show Snack Bars without a context

### DIFF
--- a/app/lib/account/account_page.dart
+++ b/app/lib/account/account_page.dart
@@ -41,8 +41,8 @@ class _AccountPageState extends State<AccountPage> {
   @override
   void initState() {
     super.initState();
-    final blocFatory = BlocProvider.of<AccountPageBlocFactory>(context);
-    bloc = blocFatory.create(scaffoldKey);
+    final blocFactory = BlocProvider.of<AccountPageBlocFactory>(context);
+    bloc = blocFactory.create(scaffoldKey);
   }
 
   @override

--- a/app/lib/navigation/scaffold/desktop/desktop_main_scaffold.dart
+++ b/app/lib/navigation/scaffold/desktop/desktop_main_scaffold.dart
@@ -35,18 +35,20 @@ class DesktopMainScaffold extends StatelessWidget {
   Widget build(BuildContext context) {
     return DesktopAlignment(
       drawer: SharezoneDrawer(isDesktopModus: true),
-      scaffold: Scaffold(
+      scaffold: ScaffoldMessenger(
         key: scaffoldKey,
-        appBar: AppBar(
-          title: Text(appBarConfiguration?.title ?? navigationItem.getName()),
-          centerTitle: true,
-          actions: appBarConfiguration?.actions,
-          bottom: appBarConfiguration?.bottom,
-          elevation: appBarConfiguration?.elevation,
+        child: Scaffold(
+          appBar: AppBar(
+            title: Text(appBarConfiguration?.title ?? navigationItem.getName()),
+            centerTitle: true,
+            actions: appBarConfiguration?.actions,
+            bottom: appBarConfiguration?.bottom,
+            elevation: appBarConfiguration?.elevation,
+          ),
+          body: body,
+          floatingActionButton: floatingActionButton,
+          bottomNavigationBar: bottomBarConfiguration?.bottomBar,
         ),
-        body: body,
-        floatingActionButton: floatingActionButton,
-        bottomNavigationBar: bottomBarConfiguration?.bottomBar,
       ),
     );
   }

--- a/app/lib/navigation/scaffold/portable/portable_main_scaffold.dart
+++ b/app/lib/navigation/scaffold/portable/portable_main_scaffold.dart
@@ -66,22 +66,24 @@ class _PortableMainScaffoldState extends State<PortableMainScaffold> {
             currentNavigationItem: widget.navigationItem,
             colorBehindBNB: widget.colorBehindBNB,
             option: option,
-            page: Scaffold(
+            page: ScaffoldMessenger(
               key: widget.scaffoldKey,
-              drawer: isOldNav ? SharezoneDrawer() : null,
-              appBar: AppBar(
-                title: Text(widget.appBarConfiguration?.title ??
-                    widget.navigationItem.getName()),
-                centerTitle: isOldNav,
-                elevation: widget.appBarConfiguration?.elevation,
-                leading: isOldNav ? DrawerIcon() : null,
-                automaticallyImplyLeading: isOldNav,
-                bottom: widget.appBarConfiguration?.bottom,
-                actions: widget.appBarConfiguration?.actions,
+              child: Scaffold(
+                drawer: isOldNav ? SharezoneDrawer() : null,
+                appBar: AppBar(
+                  title: Text(widget.appBarConfiguration?.title ??
+                      widget.navigationItem.getName()),
+                  centerTitle: isOldNav,
+                  elevation: widget.appBarConfiguration?.elevation,
+                  leading: isOldNav ? DrawerIcon() : null,
+                  automaticallyImplyLeading: isOldNav,
+                  bottom: widget.appBarConfiguration?.bottom,
+                  actions: widget.appBarConfiguration?.actions,
+                ),
+                bottomNavigationBar: bottomBar(option),
+                body: widget.body,
+                floatingActionButton: widget.floatingActionButton,
               ),
-              bottomNavigationBar: bottomBar(option),
-              body: widget.body,
-              floatingActionButton: widget.floatingActionButton,
             ),
           ),
         );


### PR DESCRIPTION
The problem was an incomplete migration for `ScaffoldMessenger`: https://docs.flutter.dev/release/breaking-changes/scaffold-messenger#migration-guide

Fixes #772 