### PR TITLE
Do not store an event when start and end time is equal or end is before start time

### DIFF
--- a/app/lib/timetable/timetable_add_event/bloc/timetable_add_event_bloc.dart
+++ b/app/lib/timetable/timetable_add_event/bloc/timetable_add_event_bloc.dart
@@ -111,22 +111,28 @@ class TimetableAddEventBloc extends BlocBase {
   }
   */
 
-  bool isStartTimeValid() {
-    if (!isStartTimeEmpty()) {
-      if (isStartBeforeEnd()) {
-        return true;
-      }
+  void throwIfEndTimeHasIncorrectValues() {
+    if (isEndTimeEmpty()) {
+      throw InvalidEndTimeException();
     }
-    return false;
+
+    _throwIfStartAndEndTimeIsEqual();
+
+    if (!isStartTimeEmpty() && !_isStartBeforeEnd()) {
+      throw EndTimeIsBeforeStartTimeException();
+    }
   }
 
-  bool isEndTimeValid() {
-    if (!isEndTimeEmpty()) {
-      if (isStartBeforeEnd()) {
-        return true;
-      }
+  void throwIfStartTimeHasIncorrectValues() {
+    if (isStartTimeEmpty()) {
+      throw InvalidStartTimeException();
     }
-    return false;
+
+    _throwIfStartAndEndTimeIsEqual();
+
+    if (!isEndTimeEmpty() && !_isStartBeforeEnd()) {
+      throw EndTimeIsBeforeStartTimeException();
+    }
   }
 
   /*
@@ -148,9 +154,9 @@ Time _calculateEndTime(Time startTime, int lessonsLength) {
         _isCourseValid(controller) &&
         _isDateValid(controller) &&
         _isStartTimeValid(controller) &&
-        _isEndTimeValid(controller) &&
-        isStartBeforeEnd() &&
-        _isStartAndEndTimeNotEqual(controller)) {
+        _isEndTimeValid(controller)) {
+      _throwIfStartAndEndTimeIsEqual(controller);
+      _throwIfStartIsBeforeEnd(controller);
       return true;
     }
     return false;
@@ -261,7 +267,7 @@ Time _calculateEndTime(Time startTime, int lessonsLength) {
     return true;
   }
 
-  bool isStartBeforeEnd() {
+  bool _isStartBeforeEnd() {
     final startTime = _startTimeSubject.valueOrNull;
     final endTime = _endTimeSubject.valueOrNull;
     if (startTime != null && endTime != null) {
@@ -270,16 +276,28 @@ Time _calculateEndTime(Time startTime, int lessonsLength) {
     return false;
   }
 
-  bool _isStartAndEndTimeNotEqual([TabController controller]) {
+  void _throwIfStartIsBeforeEnd([TabController controller]) {
+    if (!_isStartBeforeEnd()) {
+      if (controller != null) {
+        _animateBackToStartAndEndTime(controller);
+      }
+      throw EndTimeIsBeforeStartTimeException();
+    }
+  }
+
+  bool _isStartAndEndTimeEqual() {
     final startTime = _startTimeSubject.valueOrNull;
     final endTime = _endTimeSubject.valueOrNull;
-    if (startTime == endTime) {
+    return startTime == endTime;
+  }
+
+  void _throwIfStartAndEndTimeIsEqual([TabController controller]) {
+    if (_isStartAndEndTimeEqual()) {
       if (controller != null) {
         _animateBackToStartAndEndTime(controller);
       }
       throw StartTimeEndTimeIsEqualException();
     }
-    return true;
   }
 
   @override

--- a/app/lib/timetable/timetable_add_event/bloc/timetable_add_event_bloc.dart
+++ b/app/lib/timetable/timetable_add_event/bloc/timetable_add_event_bloc.dart
@@ -149,7 +149,8 @@ Time _calculateEndTime(Time startTime, int lessonsLength) {
         _isDateValid(controller) &&
         _isStartTimeValid(controller) &&
         _isEndTimeValid(controller) &&
-        isStartBeforeEnd()) {
+        isStartBeforeEnd() &&
+        _isStartAndEndTimeNotEqual(controller)) {
       return true;
     }
     return false;
@@ -267,6 +268,18 @@ Time _calculateEndTime(Time startTime, int lessonsLength) {
       return startTime.isBefore(endTime);
     }
     return false;
+  }
+
+  bool _isStartAndEndTimeNotEqual([TabController controller]) {
+    final startTime = _startTimeSubject.valueOrNull;
+    final endTime = _endTimeSubject.valueOrNull;
+    if (startTime == endTime) {
+      if (controller != null) {
+        _animateBackToStartAndEndTime(controller);
+      }
+      throw StartTimeEndTimeIsEqualException();
+    }
+    return true;
   }
 
   @override

--- a/app/lib/timetable/timetable_add_event/tabs/time_tab.dart
+++ b/app/lib/timetable/timetable_add_event/tabs/time_tab.dart
@@ -45,7 +45,8 @@ class _StartTime extends StatelessWidget {
               // Navigate to next Tab, if endTime is not Empty and startTime is before EndTime
               await waitingForPopAnimation();
               try {
-                if (bloc.isEndTimeValid()) {
+                bloc.throwIfStartTimeHasIncorrectValues();
+                if (!bloc.isEndTimeEmpty()) {
                   navigateToNextTab(context);
                 }
               } on Exception catch (e, s) {
@@ -82,7 +83,8 @@ class _EndTime extends StatelessWidget {
               // Navigate to next Tab, if startTime is not Empty and startTime is before EndTime
               await waitingForPopAnimation();
               try {
-                if (bloc.isStartTimeValid()) {
+                bloc.throwIfEndTimeHasIncorrectValues();
+                if (!bloc.isStartTimeEmpty()) {
                   navigateToNextTab(context);
                 }
               } on Exception catch (e, s) {

--- a/lib/sharezone_common/lib/src/api_errors/api_errors.dart
+++ b/lib/sharezone_common/lib/src/api_errors/api_errors.dart
@@ -122,6 +122,13 @@ class InvalidStartTimeException implements Exception {
   }
 }
 
+class StartTimeEndTimeIsEqualException implements Exception {
+  @override
+  String toString() {
+    return "StartTimeEndTimeIsEqualException";
+  }
+}
+
 class InvalidEndTimeException implements Exception {
   @override
   String toString() {

--- a/lib/sharezone_common/lib/src/api_errors/handle_error_message.dart
+++ b/lib/sharezone_common/lib/src/api_errors/handle_error_message.dart
@@ -57,6 +57,8 @@ String? handleErrorMessage(String? error, StackTrace s) {
     } else if (error ==
         StartTimeIsBeforeStartTimeOfNextLessonException().toString()) {
       return "Die Startzeit ist vor der Startzeit der nächsten Stunde!";
+    } else if (error == StartTimeEndTimeIsEqualException().toString()) {
+      return "Die Startzeit und die Endzeit darf nicht gleich sein!";
     } else if (error ==
         StartTimeIsBeforeEndTimeOfPreviousLessonException().toString()) {
       return "Die Startzeit ist vor der Endzeit der vorherigen Stunde!";


### PR DESCRIPTION
## Description

Prior to this PR, when adding an event where the start and end times are the same or the end time is before the start time, the application would simply close the event creation dialogue and display a confirmation message. This PR fixes this behavior and also adds a snack bar with a helpful message if the wrong values are selected.

Code quality is not the best, just sticking to the current approach because otherwise a big refactoring would be needed. 

## Demo

https://github.com/SharezoneApp/sharezone-app/assets/24459435/af91eec5-bbd2-459b-9cd7-1e89659f7701

## Related tickets

Fixes #107
