### PR TITLE
Fix changelog showing always "please update the update"

### DIFF
--- a/app/lib/dashboard/update_reminder/update_reminder_bloc.dart
+++ b/app/lib/dashboard/update_reminder/update_reminder_bloc.dart
@@ -38,9 +38,8 @@ class UpdateReminderBloc extends BlocBase {
       getLatestRelease: () => changelogGateway
           .loadChange(to: 1)
           .then((change) => change.first.toChange()),
-      getCurrentVersion: () => platformInformationRetreiver
-          .init()
-          .then((_) => Version(name: platformInformationRetreiver.version)),
+      getCurrentVersion: () => platformInformationRetreiver.init().then(
+          (_) => Version.parse(name: platformInformationRetreiver.version)),
       updateGracePeriod: updateGracePeriod,
       getCurrentDateTime: () => DateTime.now(),
       crashAnalytics: crashAnalytics,

--- a/app/lib/pages/settings/changelog/change.dart
+++ b/app/lib/pages/settings/changelog/change.dart
@@ -52,19 +52,12 @@ class LineStringList with IterableMixin<String> {
 /// An Object which lets one compare different App-Versions.
 ///
 /// The Version must be three version number separated by docs (e.g. "1.3.1").
-class Version {
+class Version implements Comparable<Version> {
   final String name;
   static final _versionRegEx = RegExp(r'^(\d+\.)(\d+\.)(\d+)');
 
-  /// The major number of the version, incremented when making breaking changes.
   final int major;
-
-  /// The minor number of the version, incremented when adding new functionality
-  /// in a backwards-compatible manner.
   final int minor;
-
-  /// The patch number of the version, incremented when making
-  /// backwards-compatible bug fixes.
   final int patch;
 
   factory Version.parse({@required String name}) {
@@ -93,11 +86,11 @@ class Version {
   });
 
   bool operator >(Version other) {
-    return _compare(this, other) > 0;
+    return compareTo(other) > 0;
   }
 
   bool operator <(Version other) {
-    return _compare(this, other) < 0;
+    return compareTo(other) < 0;
   }
 
   bool operator >=(Version other) {
@@ -118,21 +111,14 @@ class Version {
     return name.hashCode;
   }
 
-  /// Returns the difference between two versions.
+  /// Compares this version to another [Version].
   ///
-  /// If the first version is newer than the second one, the result is positive.
-  /// If the first version is older than the second one, the result is negative.
-  /// If the versions are equal, the result is 0.
-  int _compare(Version a, Version b) {
-    if (a.major > b.major) return 1;
-    if (a.major < b.major) return -1;
-
-    if (a.minor > b.minor) return 1;
-    if (a.minor < b.minor) return -1;
-
-    if (a.patch > b.patch) return 1;
-    if (a.patch < b.patch) return -1;
-
-    return 0;
+  /// Returns a negative value if this version is older than [other], a positive
+  /// value if it's newer, and 0 if they're identical.
+  @override
+  int compareTo(Version other) {
+    if (major != other.major) return major.compareTo(other.major);
+    if (minor != other.minor) return minor.compareTo(other.minor);
+    return patch.compareTo(other.patch);
   }
 }

--- a/app/lib/pages/settings/changelog/change_database_model.dart
+++ b/app/lib/pages/settings/changelog/change_database_model.dart
@@ -57,7 +57,7 @@ class ChangeDatabaseModel {
         releaseDate: releaseDate,
         newFeatures: newFeatures,
         improvements: improvements,
-        version: Version(name: version),
+        version: Version.parse(name: version),
       );
 
   ChangeDatabaseModel copyWith({

--- a/app/lib/pages/settings/changelog/changelog_bloc.dart
+++ b/app/lib/pages/settings/changelog/changelog_bloc.dart
@@ -47,7 +47,8 @@ class ChangelogBloc extends BlocBase {
   Future<ChangelogPageView> _loadChangelogData(
       {int from = 0, @required int to}) async {
     assert(from <= to);
-    final currentVersion = Version(name: _platformInformationManager.version);
+    final currentVersion =
+        Version.parse(name: _platformInformationManager.version);
 
     final dbModels = await _gateway.loadChange(from: from, to: to);
     final changes = dbModels.map((model) => model.toChange()).toList();

--- a/app/test/dashboard/update_reminder_bloc_test.dart
+++ b/app/test/dashboard/update_reminder_bloc_test.dart
@@ -45,7 +45,7 @@ void main() {
         'should prompt for Update if current version is old and not in the grace period',
         () async {
       // Arrange
-      currentVersion = Version(name: '1.3.4');
+      currentVersion = Version.parse(name: '1.3.4');
 
       getCurrentDateTime = () => DateTime(2020, 02, 07);
       final bloc = blocWithGracePeriodOf(Duration(days: 3));
@@ -68,7 +68,7 @@ void main() {
         'should not prompt for Update if current version is old but the release date is still within the given grace period',
         () async {
       // Arrange
-      currentVersion = Version(name: '1.3.4');
+      currentVersion = Version.parse(name: '1.3.4');
 
       getCurrentDateTime = () => DateTime(2020, 02, 04);
       final bloc = blocWithGracePeriodOf(Duration(days: 3));
@@ -90,7 +90,7 @@ void main() {
     test(
         'should not prompt for Update if the current version is newer than latest release loaded (can happen if update is not manually to DB added before releasing via app and playstore)',
         () async {
-      currentVersion = Version(name: '1.3.5');
+      currentVersion = Version.parse(name: '1.3.5');
       latestRelease = _releaseWith(version: '1.3.4');
 
       // Act
@@ -126,7 +126,7 @@ void main() {
       // Arrange
       final bloc =
           blocWithGetLatestReleaseThrowing(Exception('Test-Exception'));
-      currentVersion = Version(name: '1.7.3');
+      currentVersion = Version.parse(name: '1.7.3');
 
       // Act
       final shouldShowReminder = await bloc.shouldRemindToUpdate();
@@ -139,7 +139,7 @@ void main() {
 
 Release _releaseWith({@required String version, DateTime releaseTime}) {
   return Release(
-      version: Version(name: version),
+      version: Version.parse(name: version),
       releaseDate:
           releaseTime ?? DateTime(2020, 02, Random.secure().nextInt(25) + 1));
 }

--- a/app/test/settings/changelog/changelog_test.dart
+++ b/app/test/settings/changelog/changelog_test.dart
@@ -39,16 +39,17 @@ void main() {
   });
 
   test('version', () {
-    expect(Version(name: "3.0.0") > Version(name: "1.0.0"), true);
-    expect(Version(name: "3.0.0") < Version(name: "1.0.0"), false);
-    expect(Version(name: "3.0.0") == Version(name: "1.0.0"), false);
-    expect(Version(name: "3.0.0") == Version(name: "3.0.0"), true);
-    expect(Version(name: "3.0.1") >= Version(name: "3.0.0"), true);
-    expect(Version(name: "3.0.0") >= Version(name: "3.0.0"), true);
-    expect(Version(name: "2.9.9") >= Version(name: "3.0.0"), false);
-    expect(Version(name: "2.9.9") <= Version(name: "3.0.0"), true);
-    expect(Version(name: "3.0.0") <= Version(name: "3.0.0"), true);
-    expect(Version(name: "3.0.1") <= Version(name: "3.0.0"), false);
+    expect(Version.parse(name: "3.0.0") > Version.parse(name: "1.0.0"), true);
+    expect(Version.parse(name: "3.0.0") < Version.parse(name: "1.0.0"), false);
+    expect(Version.parse(name: "3.0.0") == Version.parse(name: "1.0.0"), false);
+    expect(Version.parse(name: "3.0.0") == Version.parse(name: "3.0.0"), true);
+    expect(Version.parse(name: "3.0.1") >= Version.parse(name: "3.0.0"), true);
+    expect(Version.parse(name: "3.0.0") >= Version.parse(name: "3.0.0"), true);
+    expect(Version.parse(name: "2.9.9") >= Version.parse(name: "3.0.0"), false);
+    expect(Version.parse(name: "2.9.9") <= Version.parse(name: "3.0.0"), true);
+    expect(Version.parse(name: "3.0.0") <= Version.parse(name: "3.0.0"), true);
+    expect(Version.parse(name: "3.0.1") <= Version.parse(name: "3.0.0"), false);
+    expect(Version.parse(name: "1.7.3") > Version.parse(name: "1.5.81"), true);
   });
 }
 


### PR DESCRIPTION
The issue was that `1.7.3 > 1.5.81` was `false` (should be `true`). Therefore, the app thought there was a newer version. I refactored `Version` (removing `_versionNameToInt`) to fix the issue.

Fixes #781