### PR TITLE
Fix opening links on Android

### DIFF
--- a/app/lib/util/launch_link.dart
+++ b/app/lib/util/launch_link.dart
@@ -12,10 +12,17 @@ import 'package:url_launcher/url_launcher.dart';
 
 /// Hpyerlink fürs Web
 Future<void> launchURL(String url, {BuildContext context}) async {
-  final _url = Uri.parse(url);
-  if (await canLaunchUrl(_url)) {
-    await launchUrl(_url);
-  } else {
+  try {
+    await launchUrl(
+      Uri.parse(url),
+      // We are not using [LaunchMode.platformDefault] because this opens by
+      // default the link in an in-app webview on iOS and Android, which is not
+      // what we want. This prevents opening the apps of the links, e.g.
+      // Discord, Twitter, etc. are opened in the in-app webview instead of the
+      // app.
+      mode: LaunchMode.externalApplication,
+    );
+  } catch (e) {
     if (context != null) {
       showSnackSec(
         context: context,


### PR DESCRIPTION
As in #790 described, opening links on Android doesn't work anymore. I tried it with two phones: Pixel 6a and Pixel 4a. When I removed the `canLaunch` check, it worked again. Additionally, I added `LaunchMode.externalApplication` to prevent opening links in an in-app web view. This is required to open the apps of the link, like the Play Store in case for #782.

Fixes #790 