### PR TITLE
Show snack bar when changing course color was not successful

### DIFF
--- a/app/lib/groups/src/pages/course/course_edit/design/course_edit_design.dart
+++ b/app/lib/groups/src/pages/course/course_edit/design/course_edit_design.dart
@@ -12,6 +12,7 @@ import 'package:flutter/material.dart';
 import 'package:sharezone/blocs/application_bloc.dart';
 import 'package:sharezone/groups/group_permission.dart';
 import 'package:sharezone/groups/src/pages/course/course_edit/design/src/bloc/course_edit_design_bloc.dart';
+import 'package:sharezone_common/api_errors.dart';
 import 'package:sharezone_widgets/sharezone_widgets.dart';
 
 part 'src/dialog/select_design_dialog.dart';
@@ -30,9 +31,9 @@ Future<void> editCourseDesign(BuildContext context, String courseId) async {
       context: context, builder: (context) => _SelectTypeDialog(bloc: bloc));
 
   if (selectTypePopResult != null) {
-    final initalDesign = selectTypePopResult.initialDesign;
+    final initialDesign = selectTypePopResult.initialDesign;
 
-    final selectDesignPopResult = await selectDesign(context, initalDesign,
+    final selectDesignPopResult = await selectDesign(context, initialDesign,
         type: selectTypePopResult.editDesignType);
 
     if (selectDesignPopResult != null) {
@@ -48,8 +49,9 @@ Future<void> editCourseDesign(BuildContext context, String courseId) async {
       } else if (selectDesignPopResult.design != null) {
         if (selectTypePopResult.editDesignType == _EditDesignType.personal) {
           bloc.submitPersonalDesign(
-              selectedDesign: selectDesignPopResult.design,
-              initalDesign: initalDesign);
+            selectedDesign: selectDesignPopResult.design,
+            initialDesign: initialDesign,
+          );
           showSnackSec(
             context: context,
             text: "Persönliche Farbe wurde gesetzt.",
@@ -58,14 +60,29 @@ Future<void> editCourseDesign(BuildContext context, String courseId) async {
         } else if (selectTypePopResult.editDesignType ==
             _EditDesignType.course) {
           sendDataToFrankfurtSnackBar(context);
-          await bloc.submitCourseDesign(
+          try {
+            await bloc.submitCourseDesign(
               selectedDesign: selectDesignPopResult.design,
-              initalDesign: initalDesign);
-          showSnackSec(
-            context: context,
-            text: "Farbe wurde erfolgreich für den gesamten Kurs geändert.",
-            seconds: 2,
-          );
+              initialDesign: initialDesign,
+            );
+            showSnackSec(
+              context: context,
+              text: "Farbe wurde erfolgreich für den gesamten Kurs geändert.",
+              seconds: 2,
+            );
+          } on ChangingDesignFailedException catch (_) {
+            showSnackSec(
+              context: context,
+              text: "Farbe konnte nicht geändert werden.",
+              seconds: 2,
+            );
+          } catch (e, s) {
+            showSnackSec(
+              context: context,
+              text: handleErrorMessage('$e', s),
+              seconds: 2,
+            );
+          }
         }
       }
     }

--- a/app/lib/groups/src/pages/course/course_edit/design/course_edit_design.dart
+++ b/app/lib/groups/src/pages/course/course_edit/design/course_edit_design.dart
@@ -74,13 +74,11 @@ Future<void> editCourseDesign(BuildContext context, String courseId) async {
             showSnackSec(
               context: context,
               text: "Farbe konnte nicht geändert werden.",
-              seconds: 2,
             );
           } catch (e, s) {
             showSnackSec(
               context: context,
               text: handleErrorMessage('$e', s),
-              seconds: 2,
             );
           }
         }

--- a/app/lib/groups/src/pages/course/course_edit/design/src/bloc/course_edit_design_bloc.dart
+++ b/app/lib/groups/src/pages/course/course_edit/design/src/bloc/course_edit_design_bloc.dart
@@ -25,22 +25,27 @@ class CourseEditDesignBloc extends BlocBase {
             .streamCourse(courseId)
             .map((course) => course.personalDesign);
 
-  Future<void> submitCourseDesign(
-      {@required Design initalDesign, @required Design selectedDesign}) async {
-    assert(initalDesign != null && selectedDesign != null,
-        "initalDesign and selectedDesign shouldn't be null");
+  Future<void> submitCourseDesign({
+    @required Design initialDesign,
+    @required Design selectedDesign,
+  }) async {
+    assert(initialDesign != null && selectedDesign != null,
+        "initialDesign and selectedDesign shouldn't be null");
 
-    if (_hasUserChangedDesign(initalDesign, selectedDesign)) {
-      await _editCourseDesign(selectedDesign);
+    if (_hasUserChangedDesign(initialDesign, selectedDesign)) {
+      final result = await _editCourseDesign(selectedDesign);
+      if (result == false) {
+        throw ChangingDesignFailedException();
+      }
     }
   }
 
   void submitPersonalDesign(
-      {Design initalDesign, @required Design selectedDesign}) {
+      {Design initialDesign, @required Design selectedDesign}) {
     assert(selectedDesign != null, "selectedDesign shouldn't be null");
 
-    if (_hasUserChangedDesign(initalDesign, selectedDesign)) {
-      _editPersonalDeisgn(selectedDesign);
+    if (_hasUserChangedDesign(initialDesign, selectedDesign)) {
+      _editPersonalDesign(selectedDesign);
     }
   }
 
@@ -48,23 +53,28 @@ class CourseEditDesignBloc extends BlocBase {
     courseGateway.removeCoursePersonalDesign(courseId);
   }
 
-  void _editPersonalDeisgn(Design selectedDesign) {
+  void _editPersonalDesign(Design selectedDesign) {
     courseGateway.editCoursePersonalDesign(
         personalDesign: selectedDesign, courseID: courseId);
   }
 
   Future<bool> _editCourseDesign(Design selectedDesign) async {
     try {
-      return await courseGateway.editCourseGeneralDesign(
-          courseID: courseId, design: selectedDesign);
+      return courseGateway.editCourseGeneralDesign(
+        courseID: courseId,
+        design: selectedDesign,
+      );
     } catch (e) {
       return false;
     }
   }
 
-  bool _hasUserChangedDesign(Design initalDesign, Design selectedDesign) =>
-      initalDesign != selectedDesign;
+  bool _hasUserChangedDesign(Design initialDesign, Design selectedDesign) =>
+      initialDesign != selectedDesign;
 
   @override
   void dispose() {}
 }
+
+/// Thrown when the design couldn't be changed.
+class ChangingDesignFailedException implements Exception {}

--- a/app/lib/util/api/course_gateway.dart
+++ b/app/lib/util/api/course_gateway.dart
@@ -150,13 +150,17 @@ class CourseGateway {
     );
   }
 
-  /// CHANGES THE GENERAL COLOR OF THE COURSE
-  Future<bool> editCourseGeneralDesign(
-      {@required String courseID, Design design}) async {
+  /// Changes the general color of the course.
+  ///
+  /// Returns `true` if the color was changed successfully, `false` otherwise.
+  Future<bool> editCourseGeneralDesign({
+    @required String courseID,
+    Design design,
+  }) async {
     final course = _connectionsGateway.current().courses[courseID];
     if (course != null) {
-      return editCourse(course.copyWith(design: design))
-          .then((result) => result.hasData && result.data == true);
+      final result = await editCourse(course.copyWith(design: design));
+      return result.hasData && result.data == true;
     }
     return false;
   }


### PR DESCRIPTION
When changing the color, the server could return `false` when for some reason the change was not successful (ideally, the server would send / throw an exception with more information). However, we when the change was not successful, we have just shown "Changing was successful" what is not true. With this PR we show that the change was not successful. In a different PR I'm going to fix #798 (this is PR is only related to #798) so that we show something like a lock icon when the user has no permission.

![image](https://github.com/SharezoneApp/sharezone-app/assets/24459435/ce919422-2fbd-4431-be75-adfe969dc9d2)

Related to #798 