### PR TITLE
Fix requesting focus for keyboard

### DIFF
--- a/lib/sharezone_widgets/lib/src/theme/theme.dart
+++ b/lib/sharezone_widgets/lib/src/theme/theme.dart
@@ -23,7 +23,7 @@ Future<void> delayKeyboard(
     required FocusNode focusNode,
     Duration duration = const Duration(milliseconds: 250)}) async {
   await Future.delayed(duration);
-  FocusManager.instance.primaryFocus?.unfocus();
+  FocusManager.instance.primaryFocus?.requestFocus();
 }
 
 Future<void> hideKeyboardWithDelay(


### PR DESCRIPTION
The method `delayKeyboard` should open the keyboard and close the keyboard. For that can, the method below be used (`hideKeyboardWithDelay`).