### PR TITLE
Fix null safety error on reset password page

### DIFF
--- a/app/lib/auth/reset_pw_page.dart
+++ b/app/lib/auth/reset_pw_page.dart
@@ -14,6 +14,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:rxdart/subjects.dart';
+import 'package:sharezone_common/helper_functions.dart';
 import 'package:sharezone_widgets/sharezone_widgets.dart';
 
 import 'email_and_password_link_page.dart';
@@ -60,7 +61,9 @@ class _ResetPasswordPageState extends State<_ResetPasswordPage> {
   void initState() {
     super.initState();
     bloc = _ResetPasswordBloc();
-    bloc.changeEmail(widget.loginMail);
+    if (isNotEmptyOrNull(widget.loginMail)) {
+      bloc.changeEmail(widget.loginMail);
+    }
 
     delayKeyboard(
       context: context,


### PR DESCRIPTION
## Description

Issue was that `null` was submitted as email. 

## Demo

https://github.com/SharezoneApp/sharezone-app/assets/24459435/ac5f981e-b134-4a1f-8fc8-6a6439bf1b25

## Related tickets

Closes #797

