### PR TITLE
Fix null safety error on password change page

### DIFF
--- a/app/lib/blocs/settings/change_data_bloc.dart
+++ b/app/lib/blocs/settings/change_data_bloc.dart
@@ -35,10 +35,12 @@ class ChangeDataBloc extends BlocBase with AuthentificationValidators {
   }
 
   Stream<String> get email => _emailSubject.stream.transform(validateEmail);
-  Stream<String> get password =>
-      _passwordSubject.stream.transform(validatePassword);
-  Stream<String> get newPassword =>
-      _newPasswordSubject.stream.transform(validatePassword);
+  Stream<String> get password => _passwordSubject.stream
+      .where((value) => value != null)
+      .transform(validatePassword);
+  Stream<String> get newPassword => _newPasswordSubject.stream
+      .where((value) => value != null)
+      .transform(validatePassword);
 
   Function(String) get changeEmail => _emailSubject.sink.add;
   Function(String) get changePassword => _passwordSubject.sink.add;


### PR DESCRIPTION
## Description

Issue was that `null` was submitted as password. 

## Demo

![image](https://github.com/SharezoneApp/sharezone-app/assets/24459435/8b87d490-b136-4abf-84b8-e43510cf873d)

## Related tickets

Fixes #796