### PR TITLE
Add max width for reset password page

### DIFF
--- a/app/lib/auth/reset_pw_page.dart
+++ b/app/lib/auth/reset_pw_page.dart
@@ -75,19 +75,22 @@ class _ResetPasswordPageState extends State<_ResetPasswordPage> {
       body: Center(
         child: SingleChildScrollView(
           padding: const EdgeInsets.symmetric(horizontal: 12),
-          child: SafeArea(
-            child: Column(
-              children: <Widget>[
-                const _Logo(),
-                const SizedBox(height: 48),
-                _EmailField(
-                  bloc: bloc,
-                  focusNode: emailFocusNode,
-                  label: widget.loginMail,
-                ),
-                const SizedBox(height: 12),
-                _SubmitButton(bloc: bloc),
-              ],
+          child: MaxWidthConstraintBox(
+            maxWidth: 700,
+            child: SafeArea(
+              child: Column(
+                children: <Widget>[
+                  const _Logo(),
+                  const SizedBox(height: 48),
+                  _EmailField(
+                    bloc: bloc,
+                    focusNode: emailFocusNode,
+                    label: widget.loginMail,
+                  ),
+                  const SizedBox(height: 12),
+                  _SubmitButton(bloc: bloc),
+                ],
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
The text field used the complete width, looked a bit weird.

| Before | After |
|--------|--------|
| ![image](https://github.com/SharezoneApp/sharezone-app/assets/24459435/de1ed13e-20f1-4444-8c9b-9e9487c73774) | ![image](https://github.com/SharezoneApp/sharezone-app/assets/24459435/085cd2d8-7446-4611-9518-4f6958880d7a) | 