### PR TITLE
Add x86 as abi filter for Android

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -85,7 +85,8 @@ android {
 
             minifyEnabled true
             ndk {
-                abiFilters "x86_64", "armeabi-v7a", "arm64-v8a"
+                // From: https://stackoverflow.com/a/46051246/8358501
+                abiFilters "x86", "x86_64", "armeabi-v7a", "arm64-v8a"
             }
         }
         debug {


### PR DESCRIPTION
This should fix the following crash: https://console.firebase.google.com/u/0/project/sharezone-c2bd8/crashlytics/app/android:de.codingbrain.sharezone/issues/65ba2e8079346923b845161e869084d9?time=last-seven-days&sessionEventKey=64E7F5F6020A0001175AF619AA6EE742_1849496163909073438