### PR TITLE
Fix layout of Discord privacy note dialog

### DIFF
--- a/app/lib/pages/settings/support_page.dart
+++ b/app/lib/pages/settings/support_page.dart
@@ -170,11 +170,13 @@ class _NoteAboutPrivacyPolicy extends StatelessWidget {
   Widget build(BuildContext context) {
     return AlertDialog(
       title: Text("Discord Datenschutz"),
-      content: MarkdownBody(
-        data:
-            "Bitte beachte, dass bei der Nutzung von Discord dessen [Datenschutzbestimmungen](https://discord.com/privacy) gelten.",
-        styleSheet: MarkdownStyleSheet(a: linkStyle(context, 14)),
-        onTapLink: (_, url, __) => launchUrl(Uri.parse(url)),
+      content: SingleChildScrollView(
+        child: MarkdownBody(
+          data:
+              "Bitte beachte, dass bei der Nutzung von Discord dessen [Datenschutzbestimmungen](https://discord.com/privacy) gelten.",
+          styleSheet: MarkdownStyleSheet(a: linkStyle(context, 14)),
+          onTapLink: (_, url, __) => launchUrl(Uri.parse(url)),
+        ),
       ),
       actions: [
         TextButton(


### PR DESCRIPTION
![image](https://github.com/SharezoneApp/sharezone-app/assets/24459435/6a5a5307-d740-492f-8032-ca0778bccb72)

Fixes #819 
