### PR TITLE
Use `TextCapitalization`

### DIFF
--- a/app/lib/auth/email_and_password_link_page.dart
+++ b/app/lib/auth/email_and_password_link_page.dart
@@ -223,6 +223,7 @@ class NameField extends StatelessWidget {
                 errorText: snapshot.error?.toString(),
                 border: const OutlineInputBorder(),
               ),
+              textCapitalization: TextCapitalization.sentences,
             ),
             const SizedBox(height: 8),
             Padding(

--- a/app/lib/blackboard/blackboard_dialog.dart
+++ b/app/lib/blackboard/blackboard_dialog.dart
@@ -322,6 +322,7 @@ class _TitleField extends StatelessWidget {
                     border: InputBorder.none,
                   ),
                   onChanged: (String title) => bloc.changeTitle(title),
+                  textCapitalization: TextCapitalization.sentences,
                 ),
                 Text(
                   snapshot.error?.toString() ?? "",

--- a/app/lib/comments/widgets/user_comment_field.dart
+++ b/app/lib/comments/widgets/user_comment_field.dart
@@ -67,6 +67,7 @@ class _UserCommentFieldState extends State<UserCommentField> {
         onChanged: (s) => text = s,
         textInputAction: TextInputAction.newline,
         style: Theme.of(context).textTheme.titleMedium,
+        textCapitalization: TextCapitalization.sentences,
       ),
     );
   }

--- a/app/lib/feedback/feedback_box_page.dart
+++ b/app/lib/feedback/feedback_box_page.dart
@@ -369,6 +369,7 @@ class _FeedbackTextField extends StatelessWidget {
             textInputAction: TextInputAction.newline,
             maxLines: null,
             onChanged: onChanged,
+            textCapitalization: TextCapitalization.sentences,
           ),
         )
       ],

--- a/app/lib/groups/src/pages/course/create/course_create_page.dart
+++ b/app/lib/groups/src/pages/course/create/course_create_page.dart
@@ -156,6 +156,7 @@ class _Subject extends StatelessWidget {
             onChanged: bloc.changeSubject,
             onEditingComplete: () =>
                 FocusManager.instance.primaryFocus?.unfocus(),
+            textCapitalization: TextCapitalization.sentences,
           ),
         );
       },
@@ -186,6 +187,7 @@ class _Abbreviation extends StatelessWidget {
         hintText: "z.B. M",
       ),
       maxLength: 3,
+      textCapitalization: TextCapitalization.characters,
     );
   }
 }
@@ -207,6 +209,7 @@ class _CourseName extends StatelessWidget {
           labelText: "Name des Kurses",
           hintText: "z.B. Mathematik GK Q2",
         ),
+        textCapitalization: TextCapitalization.sentences,
       ),
       description:
           "Der Kursname dient hauptsächlich für die Lehrkraft zur Unterscheidung der einzelnen Kurse. Denn würden bei der Lehrkraft alle Kurse Mathematik heißen, könnte diese nicht mehr Kurse unterscheiden.",

--- a/app/lib/groups/src/pages/school_class/create_course/school_class_create_course.dart
+++ b/app/lib/groups/src/pages/school_class/create_course/school_class_create_course.dart
@@ -149,6 +149,7 @@ class _Subject extends StatelessWidget {
             onChanged: bloc.changeSubject,
             onEditingComplete: () =>
                 FocusManager.instance.primaryFocus?.unfocus(),
+            textCapitalization: TextCapitalization.sentences,
           ),
         );
       },
@@ -179,6 +180,7 @@ class _Abbreviation extends StatelessWidget {
         hintText: "z.B. M",
       ),
       maxLength: 3,
+      textCapitalization: TextCapitalization.characters,
     );
   }
 }
@@ -200,6 +202,7 @@ class _CourseName extends StatelessWidget {
           labelText: "Name des Kurses",
           hintText: "z.B. Mathematik GK Q2",
         ),
+        textCapitalization: TextCapitalization.sentences,
       ),
       description:
           "Der Kursname dient hauptsächlich für die Lehrkraft zur Unterscheidung der einzelnen Kurse. Denn würden bei der Lehrkraft alle Kurse Mathematik heißen, könnte diese nicht mehr Kurse unterscheiden.",

--- a/app/lib/groups/src/pages/school_class/edit/school_class_edit_page.dart
+++ b/app/lib/groups/src/pages/school_class/edit/school_class_edit_page.dart
@@ -134,6 +134,7 @@ class _NameField extends StatelessWidget {
           ),
           maxLength: 32,
           textInputAction: TextInputAction.done,
+          textCapitalization: TextCapitalization.sentences,
         );
       },
     );

--- a/app/lib/groups/src/pages/school_class/school_class_create.dart
+++ b/app/lib/groups/src/pages/school_class/school_class_create.dart
@@ -126,6 +126,7 @@ class _NameField extends StatelessWidget {
       maxLength: 32,
       onChanged: onChanged,
       onSubmitted: onSubmitted,
+      textCapitalization: TextCapitalization.sentences,
     );
   }
 }

--- a/app/lib/onboarding/group_onboarding/pages/create_schoolclass.dart
+++ b/app/lib/onboarding/group_onboarding/pages/create_schoolclass.dart
@@ -122,6 +122,7 @@ class __TextFieldSubmitButtonState extends State<_TextFieldSubmitButton> {
                           hintText: 'z.B. 10A',
                           border: OutlineInputBorder(),
                         ),
+                        textCapitalization: TextCapitalization.sentences,
                       ),
                     ),
                   ),

--- a/app/lib/pages/homework/homework_dialog.dart
+++ b/app/lib/pages/homework/homework_dialog.dart
@@ -346,6 +346,7 @@ class _TitleField extends StatelessWidget {
                     border: InputBorder.none,
                   ),
                   onChanged: (String title) => bloc.changeTitle(title),
+                  textCapitalization: TextCapitalization.sentences,
                 ),
                 Text(
                   snapshot.error?.toString() ?? "",
@@ -449,6 +450,7 @@ class _DescriptionField extends StatelessWidget {
                     border: InputBorder.none,
                   ),
                   onChanged: bloc.changeDescription,
+                  textCapitalization: TextCapitalization.sentences,
                 ),
               ),
               Padding(

--- a/app/lib/report/page/report_page.dart
+++ b/app/lib/report/page/report_page.dart
@@ -206,6 +206,7 @@ class _DescriptionField extends StatelessWidget {
             textInputAction: TextInputAction.newline,
             maxLines: null,
             onChanged: bloc.changeDescription,
+            textCapitalization: TextCapitalization.sentences,
           ),
         ],
       ),

--- a/app/lib/timetable/timetable_add_event/tabs/optional_tab.dart
+++ b/app/lib/timetable/timetable_add_event/tabs/optional_tab.dart
@@ -97,6 +97,7 @@ class _DescriptionField extends StatelessWidget {
                 maxLines: null,
                 onEditingComplete: () => _submit(context),
                 textInputAction: TextInputAction.newline,
+                textCapitalization: TextCapitalization.sentences,
               ),
               const SizedBox(height: 10),
               Padding(

--- a/app/lib/timetable/timetable_add_event/tabs/title_tab.dart
+++ b/app/lib/timetable/timetable_add_event/tabs/title_tab.dart
@@ -36,6 +36,7 @@ class _TitleTab extends StatelessWidget {
               maxLength: 36,
               textInputAction: TextInputAction.next,
               onEditingComplete: () => navigateToNextTab(context),
+              textCapitalization: TextCapitalization.sentences,
             ),
           );
         },

--- a/app/lib/timetable/timetable_edit/event/timetable_event_edit_page.dart
+++ b/app/lib/timetable/timetable_edit/event/timetable_event_edit_page.dart
@@ -216,6 +216,7 @@ class _TitleField extends StatelessWidget {
           ),
           onChanged: bloc.changeTitle,
           maxLength: 36,
+          textCapitalization: TextCapitalization.sentences,
         ),
       ),
     );

--- a/app/lib/timetable/timetable_edit/lesson/timetable_lesson_edit_page.dart
+++ b/app/lib/timetable/timetable_edit/lesson/timetable_lesson_edit_page.dart
@@ -339,6 +339,7 @@ class _RoomField extends StatelessWidget {
             border: const OutlineInputBorder(),
             labelText: "Raum",
           ),
+          textCapitalization: TextCapitalization.sentences,
           maxLength: 32,
           onChanged: bloc.changeRoom,
         ),

--- a/lib/sharezone_widgets/lib/src/prefilled_text_field.dart
+++ b/lib/sharezone_widgets/lib/src/prefilled_text_field.dart
@@ -26,6 +26,7 @@ class PrefilledTextField extends StatefulWidget {
     this.scrollPadding = const EdgeInsets.all(20.0),
     this.autofillHints,
     this.autoSelectAllCharactersOnFirstBuild = false,
+    this.textCapitalization = TextCapitalization.none,
   }) : super(key: key);
 
   /// The text that will be already filled into the underlying [TextField] on
@@ -419,6 +420,9 @@ class PrefilledTextField extends StatefulWidget {
   /// (Copied from [TextField.autofillHints])
   final Iterable<String>? autofillHints;
 
+  /// See [TextField.textCapitalization].
+  final TextCapitalization textCapitalization;
+
   @override
   State createState() => _PrefilledTextFieldState();
 }
@@ -453,6 +457,7 @@ class _PrefilledTextFieldState extends State<PrefilledTextField> {
       keyboardType: widget.keyboardType,
       cursorColor: widget.cursorColor,
       scrollPadding: widget.scrollPadding,
+      textCapitalization: widget.textCapitalization,
     );
   }
 }


### PR DESCRIPTION
Adds `TextCapitalization` to text field where `TextCapitalization.sentences` or `TextCapitalization.characters` could be helpful. `TextCapitalization.sentences` starts the first character with an upper case characters. This can be helpful for the text field where I added it because in most cases you want to start a with an upper case character. `TextCapitalization.characters` writes every character as upper case character. It can be helpful for abbreviations.

This change only effects Android and iOS.