### PR TITLE
Expire web previews after 3 instead of 7 days

### DIFF
--- a/.github/workflows/unsafe_app_ci.yml
+++ b/.github/workflows/unsafe_app_ci.yml
@@ -173,5 +173,7 @@ jobs:
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_SHAREZONE_DEBUG }}
           projectId: sharezone-debug
           entryPoint: "./app"
-          expires: "7d"
+          # The expiration date shouldn't be too high, because if we open a lot
+          # of pull requests, we will run out of quota (we get 429 errors).
+          expires: "3d"
           target: "test-web-app"


### PR DESCRIPTION
This change should help to avoid getting 429 errors, like in https://github.com/SharezoneApp/sharezone-app/actions/runs/5985515393/job/16237693748?pr=828.