### PR TITLE
Remove "sharezone.net" as Android Intent

### DIFF
--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -59,12 +59,6 @@
                 <category android:name="android.intent.category.BROWSABLE"/>
                 <data android:host="sharez.one" android:scheme="https"/>
             </intent-filter>
-            <intent-filter android:autoVerify="true">
-                <action android:name="android.intent.action.VIEW"/>
-                <category android:name="android.intent.category.DEFAULT"/>
-                <category android:name="android.intent.category.BROWSABLE"/>
-                <data android:host="sharezone.net" android:scheme="https"/>
-            </intent-filter>
         </activity>
 
         <provider android:name="androidx.core.content.FileProvider" android:authorities="${applicationId}.fileProvider" android:exported="false" android:grantUriPermissions="true" tools:replace="android:authorities">


### PR DESCRIPTION
In #665 I added `sharezone.net` as Android Intent because it seemed to be needed to be able to open Firebase Dynamic Links. However, this breaks nearly all `sharezone.net/...` links because instantly the app opens instead the link, like `https://sharezone.net/discord`. I tested the change and the Firebase Dynamic Links still worked.