### PR TITLE
Remove `--name-status` for Git diff check because otherwise you can't see what changed in the file

### DIFF
--- a/.github/workflows/cli_ci.yml
+++ b/.github/workflows/cli_ci.yml
@@ -114,12 +114,12 @@ jobs:
       # Therefore, fails this check if there are Git changes.
       - name: Fail if there are Git diffs
         run: |
+          # Fail if there are Git diffs and print the diff.
+          git diff --exit-code
+          
           # Print the Git diff with the file names and their status as a
           # summary. 
           git diff --name-status
-
-          # Fail if there are Git diffs and print the diff.
-          git diff --exit-code
 
   test:
     needs: changes

--- a/.github/workflows/cli_ci.yml
+++ b/.github/workflows/cli_ci.yml
@@ -113,7 +113,7 @@ jobs:
       # updated. Or other cases where files are changed during a build.
       # Therefore, fails this check if there are Git changes.
       - name: Fail if there are Git diffs
-        run: git diff --exit-code --name-status
+        run: git diff --exit-code
 
   test:
     needs: changes

--- a/.github/workflows/cli_ci.yml
+++ b/.github/workflows/cli_ci.yml
@@ -113,7 +113,13 @@ jobs:
       # updated. Or other cases where files are changed during a build.
       # Therefore, fails this check if there are Git changes.
       - name: Fail if there are Git diffs
-        run: git diff --exit-code
+        run: |
+          # Print the Git diff with the file names and their status as a
+          # summary. 
+          git diff --name-status
+
+          # Fail if there are Git diffs and print the diff.
+          git diff --exit-code
 
   test:
     needs: changes

--- a/.github/workflows/integration_tests_app_ci.yml
+++ b/.github/workflows/integration_tests_app_ci.yml
@@ -160,12 +160,12 @@ jobs:
       # Therefore, fails this check if there are Git changes.
       - name: Fail if there are Git diffs
         run: |
+          # Fail if there are Git diffs and print the diff.
+          git diff --exit-code
+          
           # Print the Git diff with the file names and their status as a
           # summary. 
           git diff --name-status
-
-          # Fail if there are Git diffs and print the diff.
-          git diff --exit-code
 
   ios-integration-test:
     needs: changes

--- a/.github/workflows/integration_tests_app_ci.yml
+++ b/.github/workflows/integration_tests_app_ci.yml
@@ -159,7 +159,7 @@ jobs:
       # updated. Or other cases where files are changed during a build.
       # Therefore, fails this check if there are Git changes.
       - name: Fail if there are Git diffs
-        run: git diff --exit-code --name-status
+        run: git diff --exit-code
 
   ios-integration-test:
     needs: changes

--- a/.github/workflows/integration_tests_app_ci.yml
+++ b/.github/workflows/integration_tests_app_ci.yml
@@ -159,7 +159,13 @@ jobs:
       # updated. Or other cases where files are changed during a build.
       # Therefore, fails this check if there are Git changes.
       - name: Fail if there are Git diffs
-        run: git diff --exit-code
+        run: |
+          # Print the Git diff with the file names and their status as a
+          # summary. 
+          git diff --name-status
+
+          # Fail if there are Git diffs and print the diff.
+          git diff --exit-code
 
   ios-integration-test:
     needs: changes

--- a/.github/workflows/safe_app_ci.yml
+++ b/.github/workflows/safe_app_ci.yml
@@ -129,7 +129,13 @@ jobs:
       # updated. Or other cases where files are changed during a build.
       # Therefore, fails this check if there are Git changes.
       - name: Fail if there are Git diffs
-        run: git diff --exit-code
+        run: |
+          # Print the Git diff with the file names and their status as a
+          # summary. 
+          git diff --name-status
+
+          # Fail if there are Git diffs and print the diff.
+          git diff --exit-code
 
   # We split the tests into two jobs, because we want to run the golden tests on
   # a macOS runner, because the golden tests were generated on macOS. To reduce

--- a/.github/workflows/safe_app_ci.yml
+++ b/.github/workflows/safe_app_ci.yml
@@ -129,7 +129,7 @@ jobs:
       # updated. Or other cases where files are changed during a build.
       # Therefore, fails this check if there are Git changes.
       - name: Fail if there are Git diffs
-        run: git diff --exit-code --name-status
+        run: git diff --exit-code
 
   # We split the tests into two jobs, because we want to run the golden tests on
   # a macOS runner, because the golden tests were generated on macOS. To reduce

--- a/.github/workflows/safe_app_ci.yml
+++ b/.github/workflows/safe_app_ci.yml
@@ -130,12 +130,12 @@ jobs:
       # Therefore, fails this check if there are Git changes.
       - name: Fail if there are Git diffs
         run: |
+          # Fail if there are Git diffs and print the diff.
+          git diff --exit-code
+          
           # Print the Git diff with the file names and their status as a
           # summary. 
           git diff --name-status
-
-          # Fail if there are Git diffs and print the diff.
-          git diff --exit-code
 
   # We split the tests into two jobs, because we want to run the golden tests on
   # a macOS runner, because the golden tests were generated on macOS. To reduce


### PR DESCRIPTION
Remove the `--name-status` option for the Git diff check because otherwise you can't see the changed content of the file, like in https://github.com/SharezoneApp/sharezone-app/actions/runs/6004428175/job/16286215041?pr=844 