### PR TITLE
Fix showing information sheet picture when editing the sheet

### DIFF
--- a/app/lib/blackboard/blocs/blackboard_dialog_bloc.dart
+++ b/app/lib/blackboard/blocs/blackboard_dialog_bloc.dart
@@ -47,6 +47,9 @@ class BlackboardDialogBloc extends BlocBase with BlackboardValidators {
       if (blackboardItem.text != null) {
         changeText(blackboardItem.text!);
       }
+      if (blackboardItem.pictureURL != null) {
+        changePictureURL(blackboardItem.pictureURL!);
+      }
       changeSendNotification(false);
       final c = Course.create().copyWith(
         subject: blackboardItem.subject,


### PR DESCRIPTION
<img width="776" alt="image" src="https://github.com/SharezoneApp/sharezone-app/assets/24459435/1d18be1c-746a-486f-97f3-c88c28513204">

Fixes #877