### PR TITLE
Fix Mockito for `test_goldens` folder

### DIFF
--- a/app/build.yaml
+++ b/app/build.yaml
@@ -8,6 +8,12 @@
 
 targets:
   $default:
+    sources:
+      - $package$
+      - lib/$lib$
+      - lib/**.dart
+      - test/**.dart
+      - test_goldens/**.dart
     builders:
       # To speed up the code generation, only watch the test files.
       mockito|mockBuilder:


### PR DESCRIPTION
We had the problem that Mockito haven't created mock files for the `test_goldens` folder. This PR fixes it.