### PR TITLE
Increase timeout of iOS integration tests

### DIFF
--- a/.github/workflows/integration_tests_app_ci.yml
+++ b/.github/workflows/integration_tests_app_ci.yml
@@ -171,7 +171,7 @@ jobs:
     needs: changes
     runs-on: macos-13
     if: ${{ needs.changes.outputs.changesFound == 'true' }}
-    timeout-minutes: 45
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
 


### PR DESCRIPTION
It seems so that iOS build is taking now twice the time 🤔 I couldn't find out why. For now, we can just increase the timeout of the iOS integration test.