### PR TITLE
Fix timetable when device locale is set to Arabic

### DIFF
--- a/lib/time/lib/src/time.dart
+++ b/lib/time/lib/src/time.dart
@@ -13,7 +13,19 @@ class Time {
   final String _time;
 
   factory Time({required int hour, int minute = 0}) {
-    final numberFormat = NumberFormat("00");
+    final numberFormat = NumberFormat(
+      "00",
+      // We need to set the locale to "de_DE", otherwise the number formatter
+      // will use the device's locale, which can cause problems if the number
+      // formatter does not work as we expect, e.g. if the device is set to
+      // Arabic.
+      //
+      // If we go international with Sharezone, we should probably remove this
+      // and instead use a number formatter that is locale independent.
+      //
+      // See: https://github.com/SharezoneApp/sharezone-app/issues/903
+      "de_DE",
+    );
     return Time._(
         "${numberFormat.format(hour)}:${numberFormat.format(minute)}");
   }


### PR DESCRIPTION
## Description

The issue was that `NumberFormat` worked a bit different in the Arabic system than in the German system. As a workaround, I hard-coded the `NumberFormat` to German because our App is primarily focused on the German market. If we go international, we need to refactor the whole `Time` system.

## Demo

| Before | After |
|--------|--------|
| <img width="456" alt="image" src="https://github.com/SharezoneApp/sharezone-app/assets/24459435/6911148d-3bd5-4e19-8f59-3981967314e8"> | <img width="456" alt="image" src="https://github.com/SharezoneApp/sharezone-app/assets/24459435/87bc791f-3a5d-4dad-b1c2-301b11c12525"> | 

## Related tickets

Fixes #903 