### PR TITLE
Add `waitFor` method to make integration tests more stable

### DIFF
--- a/app/integration_test/app_test.dart
+++ b/app/integration_test/app_test.dart
@@ -161,11 +161,6 @@ class _UserCredentials {
 /// ```dart
 /// await waitFor(tester, find.text('Hello, World'));
 /// ```
-///
-/// ## Exceptions
-///
-/// Throws an [Exception] if the [timeout] is reached before the widget is
-/// found.
 Future<void> waitFor(
   WidgetTester tester,
   Finder finder, {

--- a/app/integration_test/app_test.dart
+++ b/app/integration_test/app_test.dart
@@ -85,14 +85,17 @@ void main() {
       await tester.tap(find.byKey(const Key('nav-item-group-E2E')));
       await tester.pumpAndSettle();
 
+      // Ensure that the group list is loaded.
+      await waitFor(tester, find.text('Meine Klasse:'));
+
       // We assume that the user is in at least 5 groups with the following
       // group names.
-      await waitFor(tester, find.text('10A'));
-      await waitFor(tester, find.text('Deutsch LK'));
-      await waitFor(tester, find.text('Englisch LK'));
-      await waitFor(tester, find.text('Französisch LK'));
-      await waitFor(tester, find.text('Latein LK'));
-      await waitFor(tester, find.text('Spanisch LK'));
+      expect(find.text('10A'), findsOneWidget);
+      expect(find.text('Deutsch LK'), findsOneWidget);
+      expect(find.text('Englisch LK'), findsOneWidget);
+      expect(find.text('Französisch LK'), findsOneWidget);
+      expect(find.text('Latein LK'), findsOneWidget);
+      expect(find.text('Spanisch LK'), findsOneWidget);
 
       print("Test: User should be able to load timetable");
       await tester.tap(find.byKey(const Key('nav-item-timetable-E2E')));

--- a/app/integration_test/app_test.dart
+++ b/app/integration_test/app_test.dart
@@ -87,12 +87,12 @@ void main() {
 
       // We assume that the user is in at least 5 groups with the following
       // group names.
-      expect(find.text('10A'), findsOneWidget);
-      expect(find.text('Deutsch LK'), findsOneWidget);
-      expect(find.text('Englisch LK'), findsOneWidget);
-      expect(find.text('Französisch LK'), findsOneWidget);
-      expect(find.text('Latein LK'), findsOneWidget);
-      expect(find.text('Spanisch LK'), findsOneWidget);
+      await waitFor(tester, find.text('10A'));
+      await waitFor(tester, find.text('Deutsch LK'));
+      await waitFor(tester, find.text('Englisch LK'));
+      await waitFor(tester, find.text('Französisch LK'));
+      await waitFor(tester, find.text('Latein LK'));
+      await waitFor(tester, find.text('Spanisch LK'));
 
       print("Test: User should be able to load timetable");
       await tester.tap(find.byKey(const Key('nav-item-timetable-E2E')));
@@ -112,7 +112,7 @@ void main() {
 
       // We a searching for an information sheet that is already created.
       const informationSheetTitel = 'German Course Trip to Berlin';
-      expect(find.text(informationSheetTitel), findsOneWidget);
+      await waitFor(tester, find.text(informationSheetTitel));
 
       // We don't check the text of the information sheet for now because the
       // `find.text()` can't find text `MarkdownBody` which it a bit more
@@ -133,4 +133,46 @@ class _UserCredentials {
 
   /// The password of the user.
   final String password;
+}
+
+/// Waits for a widget identified by [finder] to be present in the widget tree.
+///
+/// The function can be helpful when no loading indicator is present and the
+/// widget tree is not yet ready to be tested.
+///
+/// The function repeatedly calls `tester.pumpAndSettle()` and then delays for a
+/// short duration, checking at each iteration if the widget identified by
+/// [finder] is present in the widget tree. This continues until the widget is
+/// found or the [timeout] duration has passed, whichever occurs first.
+///
+/// Throws an [Exception] if the [timeout] duration passes without the widget
+/// being found in the widget tree.
+///
+/// Workaround for https://github.com/flutter/flutter/issues/88765.
+///
+/// ## Example
+///
+/// ```dart
+/// await waitFor(tester, find.text('Hello, World'));
+/// ```
+///
+/// ## Exceptions
+///
+/// Throws an [Exception] if the [timeout] is reached before the widget is
+/// found.
+Future<void> waitFor(
+  WidgetTester tester,
+  Finder finder, {
+  Duration timeout = const Duration(seconds: 70),
+}) async {
+  final end = tester.binding.clock.now().add(timeout);
+
+  do {
+    if (tester.binding.clock.now().isAfter(end)) {
+      throw Exception('Timed out waiting for $finder');
+    }
+
+    await tester.pumpAndSettle();
+    await Future.delayed(const Duration(milliseconds: 100));
+  } while (finder.evaluate().isEmpty);
 }

--- a/app/integration_test/app_test.dart
+++ b/app/integration_test/app_test.dart
@@ -117,6 +117,7 @@ void main() {
       // We a searching for an information sheet that is already created.
       const informationSheetTitel = 'German Course Trip to Berlin';
       await waitFor(tester, find.text(informationSheetTitel));
+      expect(find.text(informationSheetTitel), findsOneWidget);
 
       // We don't check the text of the information sheet for now because the
       // `find.text()` can't find text `MarkdownBody` which it a bit more

--- a/app/integration_test/app_test.dart
+++ b/app/integration_test/app_test.dart
@@ -87,7 +87,7 @@ void main() {
 
       // Ensure that the group list is loaded. When the school class is loaded,
       // we assume that the courses list is loaded as well.
-      await waitFor(tester, find.text('Meine Klasse:'));
+      await tester.pumpUntil(find.text('Meine Klasse:'));
 
       // We assume that the user is in at least 5 groups with the following
       // group names.
@@ -116,7 +116,7 @@ void main() {
 
       // We a searching for an information sheet that is already created.
       const informationSheetTitel = 'German Course Trip to Berlin';
-      await waitFor(tester, find.text(informationSheetTitel));
+      await tester.pumpUntil(find.text(informationSheetTitel));
       expect(find.text(informationSheetTitel), findsOneWidget);
 
       // We don't check the text of the information sheet for now because the
@@ -140,40 +140,42 @@ class _UserCredentials {
   final String password;
 }
 
-/// Waits for a widget identified by [finder] to be present in the widget tree.
-///
-/// This function can be useful when there is no load indicator (if there were,
-/// `await tester.pumpAndSettle()` would wait until the load animation was
-/// finished) and the widget tree is not yet ready to be tested.
-///
-/// The function repeatedly calls `tester.pumpAndSettle()` and then delays for a
-/// short duration, checking at each iteration if the widget identified by
-/// [finder] is present in the widget tree. This continues until the widget is
-/// found or the [timeout] duration has passed, whichever occurs first.
-///
-/// Throws an [Exception] if the [timeout] duration passes without the widget
-/// being found in the widget tree.
-///
-/// Workaround for https://github.com/flutter/flutter/issues/88765.
-///
-/// ## Example
-///
-/// ```dart
-/// await waitFor(tester, find.text('Hello, World'));
-/// ```
-Future<void> waitFor(
-  WidgetTester tester,
-  Finder finder, {
-  Duration timeout = const Duration(seconds: 70),
-}) async {
-  final end = tester.binding.clock.now().add(timeout);
+extension on WidgetTester {
+  /// Waits for a widget identified by [finder] to be present in the widget
+  /// tree.
+  ///
+  /// This function can be useful when there is no load indicator (if there
+  /// were, `await tester.pumpAndSettle()` would wait until the load animation
+  /// was finished) and the widget tree is not yet ready to be tested.
+  ///
+  /// The function repeatedly calls `tester.pump()` and then delays for
+  /// a short duration, checking at each iteration if the widget identified by
+  /// [finder] is present in the widget tree. This continues until the widget is
+  /// found or the [timeout] duration has passed, whichever occurs first.
+  ///
+  /// Throws an [Exception] if the [timeout] duration passes without the widget
+  /// being found in the widget tree.
+  ///
+  /// Workaround for https://github.com/flutter/flutter/issues/88765.
+  ///
+  /// ## Example
+  ///
+  /// ```dart
+  /// await tester.pumpUntil(find.text('Hello, World'));
+  /// ```
+  Future<void> pumpUntil(
+    Finder finder, {
+    Duration timeout = const Duration(seconds: 70),
+  }) async {
+    final end = binding.clock.now().add(timeout);
 
-  do {
-    if (tester.binding.clock.now().isAfter(end)) {
-      throw Exception('Timed out waiting for $finder');
-    }
+    do {
+      if (binding.clock.now().isAfter(end)) {
+        throw Exception('Timed out waiting for $finder');
+      }
 
-    await tester.pump();
-    await Future.delayed(const Duration(milliseconds: 200));
-  } while (finder.evaluate().isEmpty);
+      await pump();
+      await Future.delayed(const Duration(milliseconds: 200));
+    } while (finder.evaluate().isEmpty);
+  }
 }

--- a/app/integration_test/app_test.dart
+++ b/app/integration_test/app_test.dart
@@ -137,8 +137,9 @@ class _UserCredentials {
 
 /// Waits for a widget identified by [finder] to be present in the widget tree.
 ///
-/// The function can be helpful when no loading indicator is present and the
-/// widget tree is not yet ready to be tested.
+/// This function can be useful when there is no load indicator (if there were,
+/// `await tester.pumpAndSettle()` would wait until the load animation was
+/// finished) and the widget tree is not yet ready to be tested.
 ///
 /// The function repeatedly calls `tester.pumpAndSettle()` and then delays for a
 /// short duration, checking at each iteration if the widget identified by

--- a/app/integration_test/app_test.dart
+++ b/app/integration_test/app_test.dart
@@ -85,7 +85,8 @@ void main() {
       await tester.tap(find.byKey(const Key('nav-item-group-E2E')));
       await tester.pumpAndSettle();
 
-      // Ensure that the group list is loaded.
+      // Ensure that the group list is loaded. When the school class is loaded,
+      // we assume that the courses list is loaded as well.
       await waitFor(tester, find.text('Meine Klasse:'));
 
       // We assume that the user is in at least 5 groups with the following

--- a/app/integration_test/app_test.dart
+++ b/app/integration_test/app_test.dart
@@ -173,7 +173,7 @@ Future<void> waitFor(
       throw Exception('Timed out waiting for $finder');
     }
 
-    await tester.pumpAndSettle();
-    await Future.delayed(const Duration(milliseconds: 100));
+    await tester.pump();
+    await Future.delayed(const Duration(milliseconds: 200));
   } while (finder.evaluate().isEmpty);
 }


### PR DESCRIPTION
## Description

### Pull Request Description

#### Summary:
In this pull request, we have introduced a new utility function `waitFor` to enhance the stability of our integration tests by ensuring certain widgets are present in the widget tree before proceeding with subsequent test operations. This alleviates the issue of tests failing due to widgets not being loaded within the expected time frame.

## Demo

https://github.com/SharezoneApp/sharezone-app/assets/24459435/2039e579-18b4-4f53-af3c-d868d6abb934

## Related tickets

Fixes #905
Workaround for https://github.com/flutter/flutter/issues/88765