### PR TITLE
Add alias `lh` for `sz license-headers` command

### DIFF
--- a/tools/sz_repo_cli/lib/src/commands/src/license_headers_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/license_headers_command.dart
@@ -14,4 +14,7 @@ class LicenseHeadersCommand extends Command {
 
   @override
   String get name => 'license-headers';
+
+  @override
+  List<String> get aliases => ['lh'];
 }


### PR DESCRIPTION
Often, I'm too stupid to write "license-headers" and I need a couple of seconds to type it correctly. Having an alias like `lh` would be make it much easier to write `sz lh add` to add the license headers.