### PR TITLE
Add stage to build name for non stable builds

### DIFF
--- a/tools/sz_repo_cli/lib/src/commands/src/build_android_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/build_android_command.dart
@@ -10,6 +10,7 @@ import 'dart:io';
 
 import 'package:args/command_runner.dart';
 import 'package:sz_repo_cli/src/common/common.dart';
+import 'package:sz_repo_cli/src/common/src/build_utils.dart';
 
 final _androidStages = [
   'stable',
@@ -91,6 +92,8 @@ When none is specified, the value from pubspec.yaml is used.''',
       final stage = argResults![releaseStageOptionName] as String;
       final outputType = argResults![outputTypeName] as String;
       final buildNumber = argResults![buildNumberOptionName] as String?;
+      final buildNameWithStage =
+          getBuildNameWithStage(_repo.sharezoneFlutterApp, stage);
       await runProcessSucessfullyOrThrow(
         'fvm',
         [
@@ -105,6 +108,7 @@ When none is specified, the value from pubspec.yaml is used.''',
           '--dart-define',
           'DEVELOPMENT_STAGE=${stage.toUpperCase()}',
           if (buildNumber != null) ...['--build-number', buildNumber],
+          if (stage != 'stable') ...['--build-name', buildNameWithStage]
         ],
         workingDirectory: _repo.sharezoneFlutterApp.location.path,
       );

--- a/tools/sz_repo_cli/lib/src/commands/src/build_ios_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/build_ios_command.dart
@@ -10,6 +10,7 @@ import 'dart:io';
 
 import 'package:args/command_runner.dart';
 import 'package:sz_repo_cli/src/common/common.dart';
+import 'package:sz_repo_cli/src/common/src/build_utils.dart';
 
 final _iosStages = [
   'stable',
@@ -83,6 +84,8 @@ When none is specified, the value from pubspec.yaml is used.''',
       final stage = argResults![releaseStageOptionName] as String;
       final buildNumber = argResults![buildNumberOptionName] as String?;
       final exportOptionsPlist = argResults![exportOptionsPlistName] as String?;
+      final buildNameWithStage =
+          getBuildNameWithStage(_repo.sharezoneFlutterApp, stage);
       await runProcessSucessfullyOrThrow(
         'fvm',
         [
@@ -97,6 +100,7 @@ When none is specified, the value from pubspec.yaml is used.''',
           '--dart-define',
           'DEVELOPMENT_STAGE=${stage.toUpperCase()}',
           if (buildNumber != null) ...['--build-number', buildNumber],
+          if (stage != 'stable') ...['--build-name', buildNameWithStage],
           if (exportOptionsPlist != null) ...[
             '--export-options-plist',
             exportOptionsPlist

--- a/tools/sz_repo_cli/lib/src/commands/src/build_macos_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/build_macos_command.dart
@@ -10,6 +10,7 @@ import 'dart:io';
 
 import 'package:args/command_runner.dart';
 import 'package:sz_repo_cli/src/common/common.dart';
+import 'package:sz_repo_cli/src/common/src/build_utils.dart';
 
 final _macOsStages = [
   'stable',
@@ -63,6 +64,8 @@ When none is specified, the value from pubspec.yaml is used.''',
       const flavor = 'prod';
       final stage = argResults![releaseStageOptionName] as String;
       final buildNumber = argResults![buildNumberOptionName] as String?;
+      final buildNameWithStage =
+          getBuildNameWithStage(_repo.sharezoneFlutterApp, stage);
       await runProcessSucessfullyOrThrow(
         'fvm',
         [
@@ -75,6 +78,7 @@ When none is specified, the value from pubspec.yaml is used.''',
           '--dart-define',
           'DEVELOPMENT_STAGE=${stage.toUpperCase()}',
           if (buildNumber != null) ...['--build-number', buildNumber],
+          if (stage != 'stable') ...['--build-name', buildNameWithStage]
         ],
         workingDirectory: _repo.sharezoneFlutterApp.location.path,
       );

--- a/tools/sz_repo_cli/lib/src/commands/src/build_web_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/build_web_command.dart
@@ -10,6 +10,7 @@ import 'dart:io';
 
 import 'package:args/command_runner.dart';
 import 'package:sz_repo_cli/src/common/common.dart';
+import 'package:sz_repo_cli/src/common/src/build_utils.dart';
 
 final _webStages = [
   'stable',
@@ -67,6 +68,8 @@ class BuildWebCommand extends Command {
     try {
       final flavor = argResults![flavorOptionName] as String;
       final stage = argResults![releaseStageOptionName] as String;
+      final buildNameWithStage =
+          getBuildNameWithStage(_repo.sharezoneFlutterApp, stage);
       await runProcessSucessfullyOrThrow(
         'fvm',
         [
@@ -79,7 +82,8 @@ class BuildWebCommand extends Command {
           '--web-renderer',
           'canvaskit',
           '--dart-define',
-          'DEVELOPMENT_STAGE=${stage.toUpperCase()}'
+          'DEVELOPMENT_STAGE=${stage.toUpperCase()}',
+          if (stage != 'stable') ...['--build-name', buildNameWithStage]
         ],
         workingDirectory: _repo.sharezoneFlutterApp.location.path,
       );

--- a/tools/sz_repo_cli/lib/src/common/src/build_utils.dart
+++ b/tools/sz_repo_cli/lib/src/common/src/build_utils.dart
@@ -1,0 +1,10 @@
+import 'package:sz_repo_cli/src/common/common.dart';
+
+/// Returns the build name for the app and adds the stage.
+///
+/// Example:
+///  * Stage is `beta`: `1.0.0-beta` -> `1.0.0-beta`
+String getBuildNameWithStage(Package package, String stage) {
+  final versionWithoutBuildNumber = package.version.split('+').first;
+  return '$versionWithoutBuildNumber-$stage';
+}

--- a/tools/sz_repo_cli/lib/src/common/src/build_utils.dart
+++ b/tools/sz_repo_cli/lib/src/common/src/build_utils.dart
@@ -1,3 +1,11 @@
+// Copyright (c) 2023 Sharezone UG (haftungsbeschränkt)
+// Licensed under the EUPL-1.2-or-later.
+//
+// You may obtain a copy of the Licence at:
+// https://joinup.ec.europa.eu/software/page/eupl
+//
+// SPDX-License-Identifier: EUPL-1.2
+
 import 'package:sz_repo_cli/src/common/common.dart';
 
 /// Returns the build name for the app and adds the stage.
@@ -5,6 +13,13 @@ import 'package:sz_repo_cli/src/common/common.dart';
 /// Example:
 ///  * Stage is `beta`: `1.0.0-beta` -> `1.0.0-beta`
 String getBuildNameWithStage(Package package, String stage) {
-  final versionWithoutBuildNumber = package.version.split('+').first;
+  final version = package.version;
+  if (version == null) {
+    throw Exception(
+      'Package "${package.name}" has no version. Please add a version.',
+    );
+  }
+
+  final versionWithoutBuildNumber = version.split('+').first;
   return '$versionWithoutBuildNumber-$stage';
 }

--- a/tools/sz_repo_cli/lib/src/common/src/package.dart
+++ b/tools/sz_repo_cli/lib/src/common/src/package.dart
@@ -17,6 +17,12 @@ class Package {
   final Directory location;
   String get path => location.path;
   final String name;
+
+  /// The version of the package.
+  ///
+  /// Contains the build number if it was specified in the pubspec.yaml.
+  final String version;
+
   final PackageType type;
   bool get isFlutterPackage => type == PackageType.flutter;
   bool get isPureDartPackage => type == PackageType.pureDart;
@@ -29,6 +35,7 @@ class Package {
     required this.type,
     required this.hasTestDirectory,
     required this.hasGoldenTestsDirectory,
+    required this.version,
   });
 
   factory Package.fromDirectory(Directory directory) {
@@ -40,6 +47,7 @@ class Package {
     final containsFlutter = dependencies.containsKey('flutter') ||
         devDependencies.containsKey('flutter');
     final name = pubspecYaml['name'] as String?;
+    final version = pubspecYaml['version'] as String? ?? '0.0.0';
     if (name == null) {
       throw Exception(
         'Package at "${directory.path}" has no name. Please add a name',
@@ -56,6 +64,7 @@ class Package {
       hasTestDirectory: hasTestDirectory,
       hasGoldenTestsDirectory: hasTestGoldensDirectory,
       type: containsFlutter ? PackageType.flutter : PackageType.pureDart,
+      version: version,
     );
   }
 

--- a/tools/sz_repo_cli/lib/src/common/src/package.dart
+++ b/tools/sz_repo_cli/lib/src/common/src/package.dart
@@ -21,7 +21,9 @@ class Package {
   /// The version of the package.
   ///
   /// Contains the build number if it was specified in the pubspec.yaml.
-  final String version;
+  ///
+  /// Is `null` if no version was specified.
+  final String? version;
 
   final PackageType type;
   bool get isFlutterPackage => type == PackageType.flutter;
@@ -47,7 +49,7 @@ class Package {
     final containsFlutter = dependencies.containsKey('flutter') ||
         devDependencies.containsKey('flutter');
     final name = pubspecYaml['name'] as String?;
-    final version = pubspecYaml['version'] as String? ?? '0.0.0';
+    final version = pubspecYaml['version'] as String?;
     if (name == null) {
       throw Exception(
         'Package at "${directory.path}" has no name. Please add a name',

--- a/tools/sz_repo_cli/test/common/build_utils_test.dart
+++ b/tools/sz_repo_cli/test/common/build_utils_test.dart
@@ -1,3 +1,11 @@
+// Copyright (c) 2023 Sharezone UG (haftungsbeschränkt)
+// Licensed under the EUPL-1.2-or-later.
+//
+// You may obtain a copy of the Licence at:
+// https://joinup.ec.europa.eu/software/page/eupl
+//
+// SPDX-License-Identifier: EUPL-1.2
+
 import 'dart:io';
 
 import 'package:sz_repo_cli/src/common/common.dart';
@@ -7,23 +15,32 @@ import 'package:test/test.dart';
 void main() {
   group('Build Utils', () {
     group('getBuildNameWithStage()', () {
-      Package createEmptyPackage() {
+      Package createEmptyPackage({required String? version}) {
         return Package(
           location: Directory(''),
           name: 'test_package',
           type: PackageType.flutter,
           hasTestDirectory: false,
           hasGoldenTestsDirectory: false,
-          version: '1.0.0+42',
+          version: version,
         );
       }
 
       test('returns build name with stage', () {
-        final package = createEmptyPackage();
+        final package = createEmptyPackage(version: '1.0.0+42');
 
         final buildName = getBuildNameWithStage(package, 'beta');
 
         expect(buildName, '1.0.0-beta');
+      });
+
+      test('throws if package has no version', () {
+        final package = createEmptyPackage(version: null);
+
+        expect(
+          () => getBuildNameWithStage(package, 'beta'),
+          throwsA(isA<Exception>()),
+        );
       });
     });
   });

--- a/tools/sz_repo_cli/test/common/build_utils_test.dart
+++ b/tools/sz_repo_cli/test/common/build_utils_test.dart
@@ -1,0 +1,30 @@
+import 'dart:io';
+
+import 'package:sz_repo_cli/src/common/common.dart';
+import 'package:sz_repo_cli/src/common/src/build_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Build Utils', () {
+    group('getBuildNameWithStage()', () {
+      Package createEmptyPackage() {
+        return Package(
+          location: Directory(''),
+          name: 'test_package',
+          type: PackageType.flutter,
+          hasTestDirectory: false,
+          hasGoldenTestsDirectory: false,
+          version: '1.0.0+42',
+        );
+      }
+
+      test('returns build name with stage', () {
+        final package = createEmptyPackage();
+
+        final buildName = getBuildNameWithStage(package, 'beta');
+
+        expect(buildName, '1.0.0-beta');
+      });
+    });
+  });
+}


### PR DESCRIPTION
The goal of the PR is to add `beta` and `alpha` as suffix to the build name, so that we have versions like `1.2.3-beta`. However, this applies not for stable versions. This should help to indicate that the user has a non-stable version. 