### PR TITLE
Fix error when loading folders

### DIFF
--- a/lib/filesharing/filesharing_logic/lib/src/models/filesharing_data.dart
+++ b/lib/filesharing/filesharing_logic/lib/src/models/filesharing_data.dart
@@ -47,8 +47,8 @@ class FileSharingData {
     try {
       mFolders = decodeMap(data['folders'],
           (key, value) => Folder.fromData(id: key, data: value));
-    } catch (e) {
-      log("filesharingdata folders error: $id");
+    } catch (e, s) {
+      log("filesharingdata folders error: $id", error: e, stackTrace: s);
     }
     return FileSharingData._(
         courseID: id,

--- a/lib/filesharing/filesharing_logic/lib/src/models/folder.dart
+++ b/lib/filesharing/filesharing_logic/lib/src/models/folder.dart
@@ -54,8 +54,8 @@ class Folder {
     try {
       mFolders = decodeMap(data['folders'],
           (key, value) => Folder.fromData(id: key, data: value));
-    } catch (e) {
-      log("folders error: $id", error: e);
+    } catch (e, s) {
+      log("folders error: $id", error: e, stackTrace: s);
     }
     return Folder._(
       id: id,
@@ -66,7 +66,9 @@ class Folder {
           ? 'Automatisch erstellt'
           : data['creatorName'],
       folderType: FolderType.values.tryByName(
-        data['folderType'],
+        // We need to pass an empty string as fallback because `tryByName`
+        // assumes that the value is not null.
+        data['folderType'] ?? '',
         defaultValue: FolderType.normal,
       ),
     );

--- a/lib/filesharing/filesharing_logic/lib/src/models/folder.dart
+++ b/lib/filesharing/filesharing_logic/lib/src/models/folder.dart
@@ -66,9 +66,7 @@ class Folder {
           ? 'Automatisch erstellt'
           : data['creatorName'],
       folderType: FolderType.values.tryByName(
-        // We need to pass an empty string as fallback because `tryByName`
-        // assumes that the value is not null.
-        data['folderType'] ?? '',
+        data['folderType'],
         defaultValue: FolderType.normal,
       ),
     );

--- a/lib/sharezone_common/lib/src/helper_functions.dart
+++ b/lib/sharezone_common/lib/src/helper_functions.dart
@@ -61,7 +61,7 @@ Timestamp? timestampFromDateTime(DateTime? dateTime) {
 }
 
 extension EnumByNameWithDefault<T extends Enum> on Iterable<T> {
-  T tryByName(String name, {T? defaultValue}) {
+  T tryByName(String? name, {T? defaultValue}) {
     for (T value in this) {
       if (value.name == name) return value;
     }


### PR DESCRIPTION
This PR fixes the following error:

```
_TypeError (type 'Null' is not a subtype of type 'String')
[log] #0      new Folder.fromData
folder.dart:69
#1      new FileSharingData.fromData.<anonymous closure>
filesharing_data.dart:49
#2      decodeMap.<anonymous closure>
helper_functions.dart:23
#3      MapBase.map (dart:collection/maps.dart:82:28)
#4      decodeMap
helper_functions.dart:23
#5      new FileSharingData.fromData
filesharing_data.dart:48
#6      FileSharingGateway.courseFoldersStream.<anonymous closure>.<anonymous closure>
file_sharing_api.dart:49
#7      MappedListIterable.elementAt (dart:_internal/iterable.dart:415:31)
#8      ListIterator.moveNext (dart:_internal/iterable.dart:344:26)
#9      new _GrowableList._ofEfficientLengthIterable (dart:core-patch/growable_array.dart:189:27)
#10     new _GrowableList.of (dart:core-patch/growable_array.dart:150:28)
#11     new List.of (dart:core-patch/array_patch.dart:47:28)
#12     ListIterable.toList (dart:_internal/iterable.dart:214:7)
#13     FileSharingGateway.courseFoldersStream.<anonymous closure>
```