### PR TITLE
Increase timeout for iOS integration tests to 120 minutes

### DIFF
--- a/.github/workflows/integration_tests_app_ci.yml
+++ b/.github/workflows/integration_tests_app_ci.yml
@@ -172,7 +172,7 @@ jobs:
     needs: changes
     runs-on: macos-13
     if: ${{ needs.changes.outputs.changesFound == 'true' }}
-    timeout-minutes: 90
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
 


### PR DESCRIPTION
https://github.com/SharezoneApp/sharezone-app/actions/runs/6114559217/job/16596367651

This run took 1.5 hours to build the app. Seems so that 90 minutes timeout is not enough...