### PR TITLE
Add `foregroundColor` and `backgroundColor` to `sharezone_plus_widgets.dart`

### DIFF
--- a/lib/sharezone_widgets/lib/src/sharezone_plus/sharezone_plus_widgets.dart
+++ b/lib/sharezone_widgets/lib/src/sharezone_plus/sharezone_plus_widgets.dart
@@ -62,9 +62,11 @@ class SharezonePlusCard extends StatelessWidget {
             backgroundColor ?? Theme.of(context).primaryColor.withOpacity(0.2),
         borderRadius: BorderRadius.circular(7.5),
       ),
-      child: const Padding(
-        padding: EdgeInsets.fromLTRB(8, 4, 10, 4),
-        child: SharezonePlusBadge(),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(8, 4, 10, 4),
+        child: SharezonePlusBadge(
+          color: foregroundColor,
+        ),
       ),
     );
   }

--- a/lib/sharezone_widgets/lib/src/sharezone_plus/sharezone_plus_widgets.dart
+++ b/lib/sharezone_widgets/lib/src/sharezone_plus/sharezone_plus_widgets.dart
@@ -10,13 +10,19 @@ import 'package:flutter/material.dart';
 import 'package:sharezone_widgets/sharezone_widgets.dart';
 
 class SharezonePlusBadge extends StatelessWidget {
-  const SharezonePlusBadge({super.key});
+  const SharezonePlusBadge({
+    super.key,
+    this.color,
+  });
+
+  final Color? color;
 
   @override
   Widget build(BuildContext context) {
-    final color = isDarkThemeEnabled(context)
-        ? Theme.of(context).primaryColor
-        : darkBlueColor;
+    final color = this.color ??
+        (isDarkThemeEnabled(context)
+            ? Theme.of(context).primaryColor
+            : darkBlueColor);
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
@@ -39,13 +45,21 @@ class SharezonePlusBadge extends StatelessWidget {
 }
 
 class SharezonePlusCard extends StatelessWidget {
-  const SharezonePlusCard({super.key});
+  const SharezonePlusCard({
+    super.key,
+    this.backgroundColor,
+    this.foregroundColor,
+  });
+
+  final Color? backgroundColor;
+  final Color? foregroundColor;
 
   @override
   Widget build(BuildContext context) {
     return Container(
       decoration: BoxDecoration(
-        color: Theme.of(context).primaryColor.withOpacity(0.2),
+        color:
+            backgroundColor ?? Theme.of(context).primaryColor.withOpacity(0.2),
         borderRadius: BorderRadius.circular(7.5),
       ),
       child: const Padding(


### PR DESCRIPTION
We need when implementing a white Sharezone plus badge, like in [here](https://www.figma.com/file/EIlLPe7KdF4bQXLQVAsDeM/SharezoneApp?type=design&node-id=2489-836&mode=design&t=g2lJet1Axfs02rza-4).