### PR TITLE
Fix setting up Google Play Console credentials in `beta.yml` and `stable.yml`

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -188,8 +188,10 @@ jobs:
       - name: Set up Google Play credentials
         env:
           GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.SHAREZONE_GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
-        working-directory: app/private_keys
-        run: echo $GOOGLE_PLAY_SERVICE_ACCOUNT_JSON > google-play-gserviceaccount.json
+        working-directory: app
+        run: |
+          mkdir private_keys && cd private_keys
+          echo $GOOGLE_PLAY_SERVICE_ACCOUNT_JSON > google-play-gserviceaccount.json
 
       - name: Deploy
         run: |

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -204,13 +204,13 @@ jobs:
           fvm flutter pub global activate --source path "$CI_CD_DART_SCRIPTS_PACKAGE_PATH"
           echo $(pwd)/bin >> $GITHUB_PATH
 
-          - name: Set up Google Play credentials
-          env:
-            GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.SHAREZONE_GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
-          working-directory: app
-          run: |
-            mkdir private_keys && cd private_keys
-            echo $GOOGLE_PLAY_SERVICE_ACCOUNT_JSON > google-play-gserviceaccount.json
+      - name: Set up Google Play credentials
+        env:
+          GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.SHAREZONE_GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+        working-directory: app
+        run: |
+          mkdir private_keys && cd private_keys
+          echo $GOOGLE_PLAY_SERVICE_ACCOUNT_JSON > google-play-gserviceaccount.json
 
       - name: Deploy
         run: |

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -204,11 +204,13 @@ jobs:
           fvm flutter pub global activate --source path "$CI_CD_DART_SCRIPTS_PACKAGE_PATH"
           echo $(pwd)/bin >> $GITHUB_PATH
 
-      - name: Set up Google Play credentials
-        env:
-          GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.SHAREZONE_GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
-        working-directory: app/private_keys
-        run: echo $GOOGLE_PLAY_SERVICE_ACCOUNT_JSON > google-play-gserviceaccount.json
+          - name: Set up Google Play credentials
+          env:
+            GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.SHAREZONE_GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          working-directory: app
+          run: |
+            mkdir private_keys && cd private_keys
+            echo $GOOGLE_PLAY_SERVICE_ACCOUNT_JSON > google-play-gserviceaccount.json
 
       - name: Deploy
         run: |


### PR DESCRIPTION
The issue was the folder `private_keys` wasn't created. Fixes https://github.com/SharezoneApp/sharezone-app/actions/runs/6143680786/job/16667611731