### PR TITLE
Fix adding changelog when deploying to Google Play Console

### DIFF
--- a/tools/sz_repo_cli/lib/src/commands/src/deploy_android_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/deploy_android_command.dart
@@ -52,7 +52,8 @@ class DeployAndroidCommand extends Command {
   static const flavorOptionName = 'flavor';
   static const whatsNewOptionName = 'whats-new';
 
-  static const _changelogDirectory = 'android/fastlane/metadata/android/de-DE';
+  static const _changelogDirectory =
+      'android/fastlane/metadata/android/de-DE/changelogs';
   static const _defaultChangelogFileName = 'default.txt';
   static const _changelogFilePath =
       '$_changelogDirectory/$_defaultChangelogFileName';


### PR DESCRIPTION
The directory `changelogs` was missing. 