### PR TITLE
Remove `minifyEnabled` flag for Android for a readable Crashlytics stack trace

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -83,14 +83,10 @@ android {
                 signingConfig signingConfigs.release
             }
 
-            minifyEnabled true
             ndk {
                 // From: https://stackoverflow.com/a/46051246/8358501
                 abiFilters "x86", "x86_64", "armeabi-v7a", "arm64-v8a"
             }
-        }
-        debug {
-            minifyEnabled false
         }
     }
 


### PR DESCRIPTION
We had the problem that our stack trace was not readable (see #835). This is a huge problem for us because we want to detect errors in our beta and alpha versions and fix them. Without the stack trace it's super hard to fix them.

I'm pretty sure that the [`minifyEnabled` flag](https://developer.android.com/build/shrink-code) obfuscates the stack trace. I would value the stack trace much higher than a bit smaller APK file. But I also made the test:

1. Run `sz build android --output-type apk` (with `minifyEnabled`): 54.0 MB
2. Run `fvm flutter clean && sz build android --output-type apk` (without `minifyEnabled`): 54.0 MB

Fixes #835 