### PR TITLE
Read Google Play credentials from env instead of from file for `sz deploy android`

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -192,18 +192,10 @@ jobs:
           fvm flutter pub global activate --source path "$CI_CD_DART_SCRIPTS_PACKAGE_PATH"
           echo $(pwd)/bin >> $GITHUB_PATH
 
-      - name: Set up Google Play credentials for Fastlane
-        env:
-          GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.SHAREZONE_GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
-        working-directory: app
-        run: |
-          mkdir private_keys && cd private_keys
-          echo $GOOGLE_PLAY_SERVICE_ACCOUNT_JSON > google-play-gserviceaccount.json
-
       - name: Deploy
         env:
           # Export the Google Play service account credentials as an environment
-          # variable for Codemagic CLI tools.
+          # variable for Sharezone Repo CLI.
           GCLOUD_SERVICE_ACCOUNT_CREDENTIALS: ${{ secrets.SHAREZONE_GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
         run: |
           # When passing the changelog from GitHub Actions to the CLI, the line

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -211,18 +211,10 @@ jobs:
           fvm flutter pub global activate --source path "$CI_CD_DART_SCRIPTS_PACKAGE_PATH"
           echo $(pwd)/bin >> $GITHUB_PATH
 
-      - name: Set up Google Play credentials for Fastlane
-        env:
-          GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.SHAREZONE_GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
-        working-directory: app
-        run: |
-          mkdir private_keys && cd private_keys
-          echo $GOOGLE_PLAY_SERVICE_ACCOUNT_JSON > google-play-gserviceaccount.json
-
       - name: Deploy
         env:
           # Export the Google Play service account credentials as an environment
-          # variable for Codemagic CLI tools.
+          # variable for Sharezone Repo CLI.
           GCLOUD_SERVICE_ACCOUNT_CREDENTIALS: ${{ secrets.SHAREZONE_GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
         run: |
           # When passing the changelog from GitHub Actions to the CLI, the line

--- a/app/android/fastlane/Appfile
+++ b/app/android/fastlane/Appfile
@@ -1,2 +1,2 @@
-json_key_file("../private_keys/google-play-gserviceaccount.json")
+json_key_data_raw(ENV['GCLOUD_SERVICE_ACCOUNT_CREDENTIALS'])
 package_name("de.codingbrain.sharezone")


### PR DESCRIPTION
Uses the env `GCLOUD_SERVICE_ACCOUNT_CREDENTIALS` instead of the file. This simplifies the setup because the creation of `google-play-gserviceaccount.json` is not needed anymore and `GCLOUD_SERVICE_ACCOUNT_CREDENTIALS` is anyway used by the Codemagic CLI tools.