### PR TITLE
Add retry logic for fetching Firebase Remote Config

### DIFF
--- a/lib/remote_configuration/lib/src/implementation/firebase_remote_configuration.dart
+++ b/lib/remote_configuration/lib/src/implementation/firebase_remote_configuration.dart
@@ -10,6 +10,7 @@ import 'dart:async';
 import 'dart:developer';
 
 import 'package:firebase_remote_config/firebase_remote_config.dart';
+import 'package:retry/retry.dart';
 
 import '../remote_configuration.dart';
 
@@ -63,7 +64,10 @@ class FirebaseRemoteConfiguration extends RemoteConfiguration {
   /// Fetches and caches configuration from the Remote Config service.
   @override
   Future<void> fetch() async {
-    await _remoteConfig.fetch();
+    await retry(
+      () => _remoteConfig.fetch(),
+      maxAttempts: 3,
+    );
   }
 }
 

--- a/lib/remote_configuration/pubspec.lock
+++ b/lib/remote_configuration/pubspec.lock
@@ -216,6 +216,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.5"
+  retry:
+    dependency: "direct main"
+    description:
+      name: retry
+      sha256: "822e118d5b3aafed083109c72d5f484c6dc66707885e07c0fbcb8b986bba7efc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.2"
   rxdart:
     dependency: transitive
     description:

--- a/lib/remote_configuration/pubspec.yaml
+++ b/lib/remote_configuration/pubspec.yaml
@@ -17,6 +17,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  retry: ^3.1.2
   sharezone_utils:
     path: ../sharezone_utils
   firebase_remote_config: ^4.2.5


### PR DESCRIPTION
We have a lot of unknown errors when fetching the Firebase Remote Config in Crashlytics. Adding a retry method may improve this issue.