### PR TITLE
Remove "extra-gen-snapshot-options=--obfuscate" from `gradle.properties` to get readable stack traces

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -12,7 +12,7 @@ if (flutterRoot == null) {
 }
 
 apply plugin: 'com.android.application'
-apply plugin: 'com.google.firebase.crashlytics'
+apply plugin: 'com.google.gms.google-services'
 apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
@@ -120,5 +120,6 @@ dependencies {
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 }
-apply plugin: 'com.google.gms.google-services'
+
 apply plugin: 'com.google.firebase.firebase-perf'
+apply plugin: 'com.google.firebase.crashlytics'

--- a/app/android/gradle.properties
+++ b/app/android/gradle.properties
@@ -1,6 +1,5 @@
 android.enableJetifier=true
 android.useAndroidX=true
-extra-gen-snapshot-options=--obfuscate
 android.enableR8=true
 
 # Workaround for 'Unable to make field private final java.lang.String


### PR DESCRIPTION
This was the last part missing getting readable stack traces (#835).