### PR TITLE
Remove adding the stage to build name on iOS and macOS because Flutter doesn't support this.

### DIFF
--- a/tools/sz_repo_cli/lib/src/commands/src/build_ios_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/build_ios_command.dart
@@ -85,8 +85,6 @@ When none is specified, the value from pubspec.yaml is used.''',
       final stage = argResults![releaseStageOptionName] as String;
       final buildNumber = argResults![buildNumberOptionName] as String?;
       final exportOptionsPlist = argResults![exportOptionsPlistName] as String?;
-      final buildNameWithStage =
-          getBuildNameWithStage(_repo.sharezoneFlutterApp, stage);
       await runProcessSucessfullyOrThrow(
         'fvm',
         [
@@ -101,7 +99,13 @@ When none is specified, the value from pubspec.yaml is used.''',
           '--dart-define',
           'DEVELOPMENT_STAGE=${stage.toUpperCase()}',
           if (buildNumber != null) ...['--build-number', buildNumber],
-          if (stage != 'stable') ...['--build-name', buildNameWithStage],
+          // For Android we add the stage to the build name (using
+          // --build-name), but for iOS we can't do that because Flutter removes
+          // the stage from the build name.
+          //
+          // See:
+          //  * https://github.com/flutter/flutter/issues/27589#issuecomment-573121390
+          //  * https://github.com/flutter/flutter/issues/115483
           if (exportOptionsPlist != null) ...[
             '--export-options-plist',
             exportOptionsPlist

--- a/tools/sz_repo_cli/lib/src/commands/src/build_ios_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/build_ios_command.dart
@@ -10,7 +10,6 @@ import 'dart:io';
 
 import 'package:args/command_runner.dart';
 import 'package:sz_repo_cli/src/common/common.dart';
-import 'package:sz_repo_cli/src/common/src/build_utils.dart';
 
 final _iosStages = [
   'stable',

--- a/tools/sz_repo_cli/lib/src/commands/src/build_macos_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/build_macos_command.dart
@@ -64,8 +64,6 @@ When none is specified, the value from pubspec.yaml is used.''',
       const flavor = 'prod';
       final stage = argResults![releaseStageOptionName] as String;
       final buildNumber = argResults![buildNumberOptionName] as String?;
-      final buildNameWithStage =
-          getBuildNameWithStage(_repo.sharezoneFlutterApp, stage);
       await runProcessSucessfullyOrThrow(
         'fvm',
         [
@@ -78,7 +76,13 @@ When none is specified, the value from pubspec.yaml is used.''',
           '--dart-define',
           'DEVELOPMENT_STAGE=${stage.toUpperCase()}',
           if (buildNumber != null) ...['--build-number', buildNumber],
-          if (stage != 'stable') ...['--build-name', buildNameWithStage]
+          // For Android we add the stage to the build name (using
+          // --build-name), but for iOS we can't do that because Flutter removes
+          // the stage from the build name.
+          //
+          // See:
+          //  * https://github.com/flutter/flutter/issues/27589#issuecomment-573121390
+          //  * https://github.com/flutter/flutter/issues/115483
         ],
         workingDirectory: _repo.sharezoneFlutterApp.location.path,
       );

--- a/tools/sz_repo_cli/lib/src/commands/src/build_macos_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/build_macos_command.dart
@@ -10,7 +10,6 @@ import 'dart:io';
 
 import 'package:args/command_runner.dart';
 import 'package:sz_repo_cli/src/common/common.dart';
-import 'package:sz_repo_cli/src/common/src/build_utils.dart';
 
 final _macOsStages = [
   'stable',


### PR DESCRIPTION
Unfortunately, we can't add `alpha` and `beta` as suffix to the build name because Flutter doesn't support it on iOS and macOS.

See:
* https://github.com/flutter/flutter/issues/27589#issuecomment-573121390
* https://github.com/flutter/flutter/issues/115483