### PR TITLE
Add `--max-build-processing-wait` to `sz deploy ios` and `sz deploy macos` to prevent timeout when App Store Connect processes the build

### DIFF
--- a/tools/sz_repo_cli/lib/src/common/src/app_store_connect_utils.dart
+++ b/tools/sz_repo_cli/lib/src/common/src/app_store_connect_utils.dart
@@ -175,6 +175,15 @@ Future<void> publishToAppStoreConnect({
       appStoreConnectConfig.keyId,
       '--private-key',
       appStoreConnectConfig.privateKey,
+      // We set the maximum amount of minutes to wait for the freshly uploaded
+      // build to be processed by Apple and retry submitting the build for
+      // (beta) review to 60 minutes. This is necessary because the build
+      // processing can take a while and the default timeout of 20 minutes is
+      // not enough.
+      //
+      // See: https://github.com/codemagic-ci-cd/cli-tools/blob/master/docs/app-store-connect/publish.md#--max-build-processing-wait--wmax_build_processing_wait
+      '--max-build-processing-wait',
+      '60',
     ],
     workingDirectory: repo.sharezoneFlutterApp.location.path,
   );


### PR DESCRIPTION
Sometimes the `app-store-connect publish` command times out because App Store Connect needs longer than 20 minutes (the default value by the `app-store-connect publish` command) to process the build. If this happens, our CD pipeline fails:

* https://github.com/SharezoneApp/sharezone-app/actions/runs/6187203698/job/16796543131

In order to prevent this, I increased the timeout to 60 minutes.