### PR TITLE
Remove `SharezoneContext` from `MatchingTypeOfUserStreamBuilder`

### DIFF
--- a/app/lib/blocs/sharezone_bloc_providers.dart
+++ b/app/lib/blocs/sharezone_bloc_providers.dart
@@ -106,6 +106,7 @@ import 'package:sharezone/util/notification_token_adder.dart';
 import 'package:sharezone/util/platform_information_manager/flutter_platform_information_retreiver.dart';
 import 'package:sharezone/util/platform_information_manager/get_platform_information_retreiver.dart';
 import 'package:sharezone_common/references.dart';
+import 'package:user/user.dart';
 
 import '../blocs/homework/homework_page_bloc.dart' as old;
 import '../notifications/is_firebase_messaging_supported.dart';
@@ -334,7 +335,11 @@ class _SharezoneBlocProvidersState extends State<SharezoneBlocProviders> {
           purchaseService: RevenueCatPurchaseService(),
           subscriptionService: subscriptionService,
         ),
-      )
+      ),
+      StreamProvider<TypeOfUser?>.value(
+        value: typeOfUserStream,
+        initialData: null,
+      ),
     ];
 
     final mainBlocProviders = <BlocProvider>[

--- a/app/lib/dashboard/dashboard_page.dart
+++ b/app/lib/dashboard/dashboard_page.dart
@@ -47,7 +47,7 @@ import 'package:sharezone/util/cache/streaming_key_value_store.dart';
 import 'package:sharezone/util/navigation_service.dart';
 import 'package:sharezone/widgets/animated_stream_list.dart';
 import 'package:sharezone/widgets/homework/homework_card.dart';
-import 'package:sharezone/widgets/machting_type_of_user_stream_builder.dart';
+import 'package:sharezone/widgets/matching_type_of_user_builder.dart';
 import 'package:sharezone/widgets/material/modal_bottom_sheet_big_icon_button.dart';
 import 'package:sharezone_common/helper_functions.dart';
 import 'package:sharezone_utils/platform.dart';

--- a/app/lib/dashboard/widgets/dashboard_fab.dart
+++ b/app/lib/dashboard/widgets/dashboard_fab.dart
@@ -20,7 +20,7 @@ class _DashboardPageFABState extends State<_DashboardPageFAB> {
 
   @override
   Widget build(BuildContext context) {
-    return MatchingTypeOfUserStreamBuilder(
+    return MatchingTypeOfUserBuilder(
       expectedTypeOfUser: TypeOfUser.parent,
       matchesTypeOfUserWidget: Container(),
       notMatchingWidget: ModalFloatingActionButton(

--- a/app/lib/pages/homework/homework_details/homework_details.dart
+++ b/app/lib/pages/homework/homework_details/homework_details.dart
@@ -28,7 +28,7 @@ import 'package:sharezone/report/report_item.dart';
 import 'package:sharezone/util/launch_link.dart';
 import 'package:sharezone/util/next_lesson_calculator/next_lesson_calculator.dart';
 import 'package:sharezone/widgets/homework/delete_homework.dart';
-import 'package:sharezone/widgets/machting_type_of_user_stream_builder.dart';
+import 'package:sharezone/widgets/matching_type_of_user_builder.dart';
 import 'package:sharezone/widgets/material/bottom_action_bar.dart';
 import 'package:sharezone_widgets/sharezone_widgets.dart';
 import 'package:url_launcher_extended/url_launcher_extended.dart';
@@ -442,7 +442,7 @@ class _BottomHomeworkIsDoneActionButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final bloc = BlocProvider.of<HomeworkDetailsBloc>(context);
-    return MatchingTypeOfUserStreamBuilder(
+    return MatchingTypeOfUserBuilder(
       expectedTypeOfUser: TypeOfUser.student,
       // Hier wird ein leeres Text-Widget anstatt einem Container verwendet,
       // da bei einem Container einfach nur eine weiße Seite angezeigt

--- a/app/lib/pages/settings/notification.dart
+++ b/app/lib/pages/settings/notification.dart
@@ -12,7 +12,7 @@ import 'package:interval_time_picker/interval_time_picker.dart';
 import 'package:sharezone/blocs/settings/notifications_bloc.dart';
 import 'package:sharezone/blocs/settings/notifications_bloc_factory.dart';
 import 'package:sharezone/timetable/src/edit_time.dart';
-import 'package:sharezone/widgets/machting_type_of_user_stream_builder.dart';
+import 'package:sharezone/widgets/matching_type_of_user_builder.dart';
 import 'package:sharezone/widgets/material/list_tile_with_description.dart';
 import 'package:sharezone_utils/platform.dart';
 import 'package:sharezone_widgets/sharezone_widgets.dart';
@@ -61,7 +61,7 @@ class _NotificationPage extends StatelessWidget {
           child: MaxWidthConstraintBox(
             child: Column(
               children: <Widget>[
-                MatchingTypeOfUserStreamBuilder(
+                MatchingTypeOfUserBuilder(
                   expectedTypeOfUser: TypeOfUser.student,
                   matchesTypeOfUserWidget: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,

--- a/app/lib/widgets/machting_type_of_user_stream_builder.dart
+++ b/app/lib/widgets/machting_type_of_user_stream_builder.dart
@@ -6,9 +6,8 @@
 //
 // SPDX-License-Identifier: EUPL-1.2
 
-import 'package:bloc_provider/bloc_provider.dart';
 import 'package:flutter/material.dart';
-import 'package:sharezone/blocs/application_bloc.dart';
+import 'package:provider/provider.dart';
 import 'package:user/user.dart';
 
 /// If the current user matches [expectedTypeOfUser] [matchesTypeOfUserWidget] is build
@@ -27,16 +26,9 @@ class MatchingTypeOfUserStreamBuilder extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final api = BlocProvider.of<SharezoneContext>(context).api;
-    return StreamBuilder<AppUser?>(
-      stream: api.user.userStream,
-      builder: (context, snapshot) {
-        if (snapshot.hasData &&
-            snapshot.data?.typeOfUser == expectedTypeOfUser) {
-          return matchesTypeOfUserWidget;
-        }
-        return notMatchingWidget;
-      },
-    );
+    final typeOfUser = context.watch<TypeOfUser?>();
+    return typeOfUser == expectedTypeOfUser
+        ? matchesTypeOfUserWidget
+        : notMatchingWidget;
   }
 }

--- a/app/lib/widgets/matching_type_of_user_builder.dart
+++ b/app/lib/widgets/matching_type_of_user_builder.dart
@@ -10,19 +10,19 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:user/user.dart';
 
-/// If the current user matches [expectedTypeOfUser] [matchesTypeOfUserWidget] is build
-/// else [notMatchingWidget] is build
-class MatchingTypeOfUserStreamBuilder extends StatelessWidget {
-  final TypeOfUser expectedTypeOfUser;
-  final Widget matchesTypeOfUserWidget;
-  final Widget notMatchingWidget;
-
-  const MatchingTypeOfUserStreamBuilder({
+/// If the current user matches [expectedTypeOfUser] [matchesTypeOfUserWidget]
+/// is build else [notMatchingWidget] is build
+class MatchingTypeOfUserBuilder extends StatelessWidget {
+  const MatchingTypeOfUserBuilder({
     Key? key,
     required this.expectedTypeOfUser,
     required this.matchesTypeOfUserWidget,
     required this.notMatchingWidget,
   }) : super(key: key);
+
+  final TypeOfUser expectedTypeOfUser;
+  final Widget matchesTypeOfUserWidget;
+  final Widget notMatchingWidget;
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
Should rename this widget since we are not using a `StreamBuilder` anymore?