### PR TITLE
Fix parsing `Lesson.periodNumber` when it's null

### DIFF
--- a/app/lib/timetable/src/models/lesson.dart
+++ b/app/lib/timetable/src/models/lesson.dart
@@ -49,7 +49,7 @@ class Lesson {
       endDate: Date.parseOrNull(data['endDate'] as String?),
       startTime: Time.parse(data['startTime'] as String),
       endTime: Time.parse(data['endTime'] as String),
-      periodNumber: data['periodNumber'] as int,
+      periodNumber: data['periodNumber'] as int?,
       weekday: WeekDay.values.byName(data['weekday'] as String),
       weektype: WeekType.values.byName(data['weektype'] as String),
       teacher: data['teacher'] as String?,


### PR DESCRIPTION
`periodNumber` can be null. 

Fixes #967