### PR TITLE
Auto-collapse `*.mocks.dart` changes via `.gitattributes`.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Automatically collapses these files when looking at a diff in GitHub
+**.mock.dart linguist-generated

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # Automatically collapses these files when looking at a diff in GitHub
-*.mock.dart linguist-generated
+*.mocks.dart linguist-generated

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # Automatically collapses these files when looking at a diff in GitHub
-**.mock.dart linguist-generated
+*.mock.dart linguist-generated

--- a/app/test/notifications/notification_permission_test.mocks.dart
+++ b/app/test/notifications/notification_permission_test.mocks.dart
@@ -21,7 +21,7 @@ import 'package:mockito/mockito.dart' as _i1;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
-
+// aa
 class _FakeFirebaseApp_0 extends _i1.SmartFake implements _i2.FirebaseApp {
   _FakeFirebaseApp_0(
     Object parent,

--- a/app/test/notifications/notification_permission_test.mocks.dart
+++ b/app/test/notifications/notification_permission_test.mocks.dart
@@ -21,7 +21,7 @@ import 'package:mockito/mockito.dart' as _i1;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
-// aa
+
 class _FakeFirebaseApp_0 extends _i1.SmartFake implements _i2.FirebaseApp {
   _FakeFirebaseApp_0(
     Object parent,


### PR DESCRIPTION
This will automatically collapse all `.mocks.dart` diffs in "Files changed" tab on GitHub:  
![grafik](https://github.com/SharezoneApp/sharezone-app/assets/29028262/91c20bef-50c3-490b-93b5-ce10ed4770c4)
