### PR TITLE
Fix Multiline Release Notes Handling in GitHub Action

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -260,13 +260,16 @@ jobs:
           # longer than 4000 characters.
           export SHORT_LAST_COMMIT_MESSAGE=${LAST_COMMIT_MESSAGE:0:4000}
 
-          # Tempoary prints
-          echo "LAST_COMMIT_MESSAGE: $LAST_COMMIT_MESSAGE"
-          echo "SHORT_LAST_COMMIT_MESSAGE: $SHORT_LAST_COMMIT_MESSAGE"
+          # Note that we use '--whats-new "$SHORT_LAST_COMMIT_MESSAGE"' instead
+          # of '--whats-new="$SHORT_LAST_COMMIT_MESSAGE"' to correctly pass the
+          # multiline string stored in the $SHORT_LAST_COMMIT_MESSAGE variable
+          # as a single argument. Including "=" can cause issues with argument
+          # parsing in the shell, potentially leading to incorrect handling of
+          # the multiline string argument.
 
           sz deploy ios \
             --stage alpha \
-            --whats-new="$SHORT_LAST_COMMIT_MESSAGE" \
+            --whats-new "$SHORT_LAST_COMMIT_MESSAGE" \
             --export-options-plist=$HOME/export_options.plist
 
   deploy-alpha-macos-app:
@@ -404,4 +407,4 @@ jobs:
             --beta-group=alpha \
             --testflight \
             --release-type=AFTER_APPROVAL \
-            --whats-new="$SHORT_LAST_COMMIT_MESSAGE"
+            --whats-new "$SHORT_LAST_COMMIT_MESSAGE"

--- a/tools/sz_repo_cli/lib/src/commands/src/deploy_ios_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/deploy_ios_command.dart
@@ -98,9 +98,6 @@ class DeployIosCommand extends Command {
     _throwIfFlavorIsNotSupportForDeployment();
     await throwIfCodemagicCliToolsAreNotInstalled();
 
-    final whatsNew = argResults![whatsNewOptionName] as String?;
-    stdout.writeln('Deploy iOS with the following release notes:\n$whatsNew');
-
     // Is used so that runProcess commands print the command that was run. Right
     // now this can't be done via an argument.
     //
@@ -136,7 +133,7 @@ class DeployIosCommand extends Command {
       await publishToAppStoreConnect(
         appStoreConnectConfig: appStoreConnectConfig,
         stage: argResults![releaseStageOptionName] as String,
-        whatsNew: whatsNew,
+        whatsNew: argResults![whatsNewOptionName] as String?,
         path: 'build/ios/ipa/*.ipa',
         repo: _repo,
         stageToTracks: _iosStageToTracks,


### PR DESCRIPTION
In our previous GitHub Action configuration, the `--whats-new` parameter was passed with an equals symbol (`=`), as in `--whats-new="$SHORT_LAST_COMMIT_MESSAGE"`. However, this approach encountered issues when the release notes contained a multiline string, causing the multiline string not to be passed correctly to the Dart CLI tool, resulting in a null value received in the Dart script.

To resolve this, we modified the syntax to `--whats-new "$SHORT_LAST_COMMIT_MESSAGE"`, omitting the `=`. This ensures that multiline strings are correctly passed as a single argument to the CLI tool, preserving the integrity of the release notes.

This update ensures that release notes for alpha versions generated from multiline commit messages are correctly handled and displayed.

Also reverts the changes from #975

Fixes #922