### PR TITLE
Fix `NoSuchMethodError: Class '_Map<String, dynamic>' has no instance getter 'code'` in `FirebaseDynamicLinks.onLink`

### DIFF
--- a/lib/dynamic_links/lib/src/implementation/firebase_dynamic_links.dart
+++ b/lib/dynamic_links/lib/src/implementation/firebase_dynamic_links.dart
@@ -42,8 +42,15 @@ class FirebaseDynamicLinks extends DynamicLinks {
         onSuccess!(_getPendingFromFirebase(pending));
       },
       onError: (error) async {
-        onError!(OnDynamicLinkErrorException(
-            error.code, error.message, error.details));
+        if (onError != null) {
+          onError(
+            OnDynamicLinkErrorException(
+              error['code'],
+              error['message'],
+              error['details'],
+            ),
+          );
+        }
       },
       cancelOnError: false,
     );


### PR DESCRIPTION
Fixes #994