### PR TITLE
Add `underlayColor` to `SharezonePlusFeatureInfoCard`

### DIFF
--- a/app/lib/blackboard/details/blackboard_item_read_by_users_list/blackboard_item_read_by_users_list_page.dart
+++ b/app/lib/blackboard/details/blackboard_item_read_by_users_list/blackboard_item_read_by_users_list_page.dart
@@ -157,6 +157,7 @@ class _FreeUsersLockScreen extends StatelessWidget {
               child: SharezonePlusFeatureInfoCard(
                 withLearnMoreButton: true,
                 onLearnMorePressed: () => navigateToSharezonePlusPage(context),
+                underlayColor: Theme.of(context).scaffoldBackgroundColor,
                 child: const Text(
                     'Erwerbe Sharezone Plus, um nachzuvollziehen, wer den Infozettel bereits gelesen hat.'),
               ),

--- a/app/lib/homework/teacher/homework_done_by_users_list/homework_completion_user_list_page.dart
+++ b/app/lib/homework/teacher/homework_done_by_users_list/homework_completion_user_list_page.dart
@@ -152,6 +152,7 @@ class _FreeUsersLockScreen extends StatelessWidget {
               child: SharezonePlusFeatureInfoCard(
                 withLearnMoreButton: true,
                 onLearnMorePressed: () => navigateToSharezonePlusPage(context),
+                underlayColor: Theme.of(context).scaffoldBackgroundColor,
                 child: const Text(
                     'Erwerbe Sharezone Plus, um nachzuvollziehen, wer bereits die Hausaufgabe als erledigt markiert hat.'),
               ),

--- a/lib/sharezone_widgets/lib/src/sharezone_plus/sharezone_plus_widgets.dart
+++ b/lib/sharezone_widgets/lib/src/sharezone_plus/sharezone_plus_widgets.dart
@@ -141,7 +141,7 @@ class SharezonePlusFeatureInfoCard extends StatelessWidget {
         // because the card color has a low opacity.
         decoration: BoxDecoration(
           borderRadius: borderRadius,
-          color: Theme.of(context).scaffoldBackgroundColor,
+          color: underlayColor,
         ),
         child: Container(
           decoration: BoxDecoration(

--- a/lib/sharezone_widgets/lib/src/sharezone_plus/sharezone_plus_widgets.dart
+++ b/lib/sharezone_widgets/lib/src/sharezone_plus/sharezone_plus_widgets.dart
@@ -85,6 +85,7 @@ class SharezonePlusFeatureInfoCard extends StatelessWidget {
     this.withLearnMoreButton = false,
     this.onLearnMorePressed,
     this.maxWidth = 400,
+    this.underlayColor,
   }) : assert(withLearnMoreButton == false || onLearnMorePressed != null);
 
   /// Whether the card should display the [SharezonePlusBadge] at the top
@@ -110,6 +111,19 @@ class SharezonePlusFeatureInfoCard extends StatelessWidget {
 
   /// The maximum width of the card.
   final double maxWidth;
+
+  /// The color displayed behind the card's semi-transparent background.
+  ///
+  /// This color serves as an underlay to the card, helping to maintain the
+  /// visibility and integrity of the card's content by providing a solid
+  /// background color. It can be useful when the card is displayed over varied
+  /// or busy backgrounds, preventing the content behind the card from
+  /// interfering visually with the card's content. In this case, you may want
+  /// to use `Theme.of(context).scaffoldBackgroundColor` as the underlay color.
+  ///
+  /// When null, no underlay color is applied, and the card will blend with its
+  /// background based on its existing opacity setting.
+  final Color? underlayColor;
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
**Problem**:
In scenarios where the `SharezonePlusFeatureInfoCard` widget is displayed over backgrounds with varying colors or busy patterns, the card's semi-transparent background can blend undesirably with the underlying content, causing visual interference and reduced readability of the card's content.

Example:

![homework_completion_list_page_sharezone_ad_dark phone_landscape](https://github.com/SharezoneApp/sharezone-app/assets/24459435/b305bd4c-861e-4707-95b6-c74a5a165e8f)

This problem was the reason I added `Theme.of(context).scaffoldBackgroundColor` in #976 as underlying color behind the card. However, this fix caused another problem that the background color of the `SharezonePlusFeatureInfoCard` is too dark in some situations:

<img width="1552" alt="Screenshot 2023-09-18 at 10 57 21" src="https://github.com/SharezoneApp/sharezone-app/assets/24459435/416eaa3d-9ad0-4e9b-abd4-d172cee09f11">

**Solution**:
To solve this, we introduce the `underlayColor` attribute. This optional attribute allows developers to set a specific color to be displayed behind the card's semi-transparent background, effectively serving as a backdrop that ensures the card's content remains visually distinct, regardless of the background it is placed over.

Image of `SharezonePlusFeatureInfoCard` where `underlayColor` is `null`:

<img width="1552" alt="Screenshot 2023-09-18 at 10 57 07" src="https://github.com/SharezoneApp/sharezone-app/assets/24459435/28af562a-03cf-4632-b842-5603a276ac7e">

Image of `SharezonePlusFeatureInfoCard` where `underlayColor` is `Theme.of(context).scaffoldBackgroundColor`:

![homework_completion_list_page_sharezone_ad_dark phone_landscape](https://github.com/SharezoneApp/sharezone-app/assets/24459435/3facf35c-535e-46c5-96be-5fff65a556f6)

This addition maintains the aesthetic flexibility of the semi-transparent background while offering a way to preserve content clarity in diverse background environments (like using `underlayColor: Theme.of(context).scaffoldBackgroundColor`).

**Usage**:
Developers can now specify a color using the `underlayColor` attribute. If left unspecified, no underlay color is applied, retaining the current behavior where the card blends with its background based on its existing opacity setting.
