### PR TITLE
Add missing code generation of `sharezone_plus_page_test.mocks.dart` and `serializers.g.dart`

### DIFF
--- a/app/test_goldens/sharezone_plus/sharezone_plus_page_test.mocks.dart
+++ b/app/test_goldens/sharezone_plus/sharezone_plus_page_test.mocks.dart
@@ -263,12 +263,6 @@ class _FakeAppFunctionsResult_18<T> extends _i2.SmartFake
 class MockSharezonePlusPageController extends _i2.Mock
     implements _i21.SharezonePlusPageController {
   @override
-  bool get hasPlus => (super.noSuchMethod(
-        Invocation.getter(#hasPlus),
-        returnValue: false,
-        returnValueForMissingStub: false,
-      ) as bool);
-  @override
   set hasPlus(bool? _hasPlus) => super.noSuchMethod(
         Invocation.setter(
           #hasPlus,
@@ -276,12 +270,6 @@ class MockSharezonePlusPageController extends _i2.Mock
         ),
         returnValueForMissingStub: null,
       );
-  @override
-  String get price => (super.noSuchMethod(
-        Invocation.getter(#price),
-        returnValue: '',
-        returnValueForMissingStub: '',
-      ) as String);
   @override
   set price(String? _price) => super.noSuchMethod(
         Invocation.setter(

--- a/lib/abgabe/abgabe_http_api/lib/serializers.g.dart
+++ b/lib/abgabe/abgabe_http_api/lib/serializers.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of serializers;
+part of 'serializers.dart';
 
 // **************************************************************************
 // BuiltValueGenerator


### PR DESCRIPTION
Missing code generation in `sharezone_plus_page_test.mocks.dart` caused in #990