### PR TITLE
Add missing validation step to `actions-ci` when formatting files

### DIFF
--- a/.github/workflows/actions_ci.yml
+++ b/.github/workflows/actions_ci.yml
@@ -79,13 +79,4 @@ jobs:
         run: npm install --global prettier@3.0.1
 
       - name: Format
-        run: ./bin/format_action_files.sh
-
-      - name: Fail if files were changed
-        id: changes
-        run: |
-          git diff --exit-code
-
-          # Print the Git diff with the file names and their status as a
-          # summary. 
-          git diff --name-status
+        run: ./bin/check_format_action_files.sh

--- a/.github/workflows/actions_ci.yml
+++ b/.github/workflows/actions_ci.yml
@@ -80,3 +80,12 @@ jobs:
 
       - name: Format
         run: ./bin/format_action_files.sh
+
+      - name: Fail if files were changed
+        id: changes
+        run: |
+          git diff --exit-code
+
+          # Print the Git diff with the file names and their status as a
+          # summary. 
+          git diff --name-status

--- a/bin/check_format_action_files.sh
+++ b/bin/check_format_action_files.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Copyright (c) 2023 Sharezone UG (haftungsbeschränkt)
+# Licensed under the EUPL-1.2-or-later.
+#
+# You may obtain a copy of the Licence at:
+# https://joinup.ec.europa.eu/software/page/eupl
+#
+# SPDX-License-Identifier: EUPL-1.2
+
+script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+get_cmd="$script_dir/source_of_truth/get_sot_cmd.sh"
+
+check_format_action_files=$($get_cmd check_format_action_files)
+eval $"($check_format_action_files)"

--- a/bin/source_of_truth/commands_source_of_truth.yaml
+++ b/bin/source_of_truth/commands_source_of_truth.yaml
@@ -26,3 +26,4 @@
 check_license_headers: addlicense -check -c "Sharezone UG (haftungsbeschränkt)" -f header_template.txt -ignore "**/GeneratedPluginRegistrant.swift" -ignore "**/**.g.dart" -ignore "**/**.mocks.dart"
 add_license_headers: addlicense -c "Sharezone UG (haftungsbeschränkt)" -f header_template.txt -ignore "**/GeneratedPluginRegistrant.swift" -ignore "**/**.g.dart" -ignore "**/**.mocks.dart"
 format_action_files: prettier ".github/workflows/" --write
+check_format_action_files: prettier ".github/workflows/" --check


### PR DESCRIPTION
I forgot to check if files changed after the formatting. We achieve this by using `prettier ".github/workflows/" --check` instead of `prettier ".github/workflows/" --write`.