### PR TITLE
Fix `SchoolClassFilter` when Sharezone Plus is not enabled

### DIFF
--- a/app/lib/timetable/timetable_page/school_class_filter/school_class_filter.dart
+++ b/app/lib/timetable/timetable_page/school_class_filter/school_class_filter.dart
@@ -337,7 +337,7 @@ class _SelectionSheetTileTrailing extends StatelessWidget {
     if (filter.shouldFilterForClass && !isUnlocked) {
       return const SharezonePlusChip();
     }
-    return isSelected ? activeIcon : Container();
+    return isSelected ? activeIcon : const SizedBox();
   }
 }
 


### PR DESCRIPTION
<img width="275" alt="image" src="https://github.com/SharezoneApp/sharezone-app/assets/24459435/fa36cba5-e612-4ad8-ad4c-5f56916c9270">

Fixes #1002