### PR TITLE
Remove creating `SubscriptionEnabledFlag` provider in `sharezone_bloc_providers.dart`

### DIFF
--- a/app/lib/blocs/sharezone_bloc_providers.dart
+++ b/app/lib/blocs/sharezone_bloc_providers.dart
@@ -322,9 +322,6 @@ class _SharezoneBlocProvidersState extends State<SharezoneBlocProviders> {
       Provider<SubscriptionService>(
         create: (context) => subscriptionService,
       ),
-      ChangeNotifierProvider<SubscriptionEnabledFlag>(
-        create: (context) => subscriptionEnabledFlag,
-      ),
       StreamProvider<auth.AuthUser?>(
         create: (context) => api.user.authUserStream,
         initialData: null,


### PR DESCRIPTION
We already create `SubscriptionEnabledFlag` provider in `sharezone.dart`. The one `sharezone_bloc_providers.dart` isn't needed anymore.