### PR TITLE
Going back to `macos-12` for iOS integration tests to improve the performance dramatically 

### DIFF
--- a/.github/workflows/integration_tests_app_ci.yml
+++ b/.github/workflows/integration_tests_app_ci.yml
@@ -196,7 +196,7 @@ jobs:
       - uses: futureware-tech/simulator-action@736249ceb5ed7916224ed6b6d3c3582fd8049deb
         id: simulator
         with:
-          model: "iPhone 14"
+          model: "iPhone 13"
 
       - name: Run integration tests
         working-directory: app

--- a/.github/workflows/integration_tests_app_ci.yml
+++ b/.github/workflows/integration_tests_app_ci.yml
@@ -196,7 +196,7 @@ jobs:
       - uses: futureware-tech/simulator-action@736249ceb5ed7916224ed6b6d3c3582fd8049deb
         id: simulator
         with:
-          model: "iPhone 13"
+          model: "iPhone 14"
 
       - name: Run integration tests
         working-directory: app

--- a/.github/workflows/integration_tests_app_ci.yml
+++ b/.github/workflows/integration_tests_app_ci.yml
@@ -170,9 +170,14 @@ jobs:
 
   ios-integration-test:
     needs: changes
-    runs-on: macos-13
+    # We are using macos-12 instead macos-13 because with macos-13 we have job
+    # times of 40 - 120 minutes.
+    #
+    # Before switching back to macos-13, we should check if the job times are
+    # still that long by running the job with a matrix (3 runs).
+    runs-on: macos-12
     if: ${{ needs.changes.outputs.changesFound == 'true' }}
-    timeout-minutes: 120
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
 
@@ -193,10 +198,16 @@ jobs:
           flutter pub global activate fvm 2.4.1
           fvm config --cache-path '${{ runner.tool_cache }}/flutter'
 
+      # Because macos-12 doesn't have Metal support, we need to disable Impeller
+      # https://github.com/flutter/flutter/issues/126768
+      - name: Disable Impeller
+        working-directory: app/ios/Runner
+        run: /usr/libexec/PlistBuddy -c "Add :FLTEnableImpeller bool false" Info.plist
+
       - uses: futureware-tech/simulator-action@736249ceb5ed7916224ed6b6d3c3582fd8049deb
         id: simulator
         with:
-          model: "iPhone 14"
+          model: "iPhone 13"
 
       - name: Run integration tests
         working-directory: app

--- a/.github/workflows/safe_app_ci.yml
+++ b/.github/workflows/safe_app_ci.yml
@@ -177,3 +177,62 @@ jobs:
             -c 4 \
             --package-timeout-minutes 15 \
             --exclude-goldens
+
+  ios-integration-test:
+    needs: changes
+    runs-on: macos-13
+    if: ${{ needs.changes.outputs.changesFound == 'true' }}
+    timeout-minutes: 120
+    strategy:
+      matrix:
+        A: [1, 2, 3]
+    steps:
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
+        with:
+          ref: '931ffdd1e179c2bac2502bc44156047c027b1bb4'
+
+      - name: Set Flutter version from FVM config file to environment variables
+        uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b
+
+      - uses: subosito/flutter-action@48cafc24713cca54bbe03cdc3a423187d413aafa
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: ${{ env.FLUTTER_CHANNEL }}
+          # Use format expected by FVM.
+          # Else this won't be recognized as an installed version when setting
+          # '.../flutter' as the FVM Flutter version cache folder.
+          cache-path: "${{ runner.tool_cache }}/flutter/:version:"
+
+      - name: Install FVM
+        run: |
+          flutter pub global activate fvm 2.4.1
+          fvm config --cache-path '${{ runner.tool_cache }}/flutter'
+
+      - uses: futureware-tech/simulator-action@736249ceb5ed7916224ed6b6d3c3582fd8049deb
+        id: simulator
+        with:
+          model: "iPhone 14"
+
+      - name: Run integration tests
+        working-directory: app
+        env:
+          USER_1_EMAIL: ${{ secrets.INTEGRATION_TEST_USER_1_EMAIL }}
+          USER_1_PASSWORD: ${{ secrets.INTEGRATION_TEST_USER_1_PASSWORD }}
+          SIMULATOR_UDID: ${{ steps.simulator.outputs.udid }}
+        # We use the `flutter drive` instead of the `flutter test` command
+        # because the test command times out after 12 minutes. But building the
+        # app takes more than 12 minutes... It seems so that there is no way to
+        # set the timeout (the --timeout argument has not effect). Tracking
+        # issue: https://github.com/flutter/flutter/issues/105913
+        run: |
+          # We need to run the integration tests with the prod flavor because
+          # using not the default flavor will cause an exception when
+          # uninstalling the app, see:
+          # https://github.com/flutter/flutter/issues/88690
+          fvm flutter drive \
+            --driver=test_driver/integration_test.dart \
+            --target=integration_test/app_test.dart \
+            --flavor prod \
+            --dart-define=USER_1_EMAIL=$USER_1_EMAIL \
+            --dart-define=USER_1_PASSWORD=$USER_1_PASSWORD \
+            -d $SIMULATOR_UDID

--- a/.github/workflows/safe_app_ci.yml
+++ b/.github/workflows/safe_app_ci.yml
@@ -14,13 +14,13 @@
 
 name: safe-app-ci
 
-# concurrency:
-  # group: safe-app-ci-${{ github.head_ref }}
+concurrency:
+  group: safe-app-ci-${{ github.head_ref }}
   # In order to conserve the use of GitHub Actions, we cancel the running action
   # of the previous commit. This means that if you first commit "A" and then
   # commit "B" to the pull request a few minutes later, the workflow for commit
   # "A" will be cancelled.
-  # cancel-in-progress: true
+  cancel-in-progress: true
 
 on:
   # Triggers the workflow on pull request events
@@ -177,69 +177,3 @@ jobs:
             -c 4 \
             --package-timeout-minutes 15 \
             --exclude-goldens
-
-  ios-integration-test:
-    needs: changes
-    # We are using macos-12 instead macos-13 because with macos-13 we have job
-    # times of 40 - 120 minutes.
-    runs-on: macos-12
-    if: ${{ needs.changes.outputs.changesFound == 'true' }}
-    timeout-minutes: 120
-    strategy:
-      matrix:
-        A: [1, 2, 3]
-      fail-fast: false
-    steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
-
-      - name: Set Flutter version from FVM config file to environment variables
-        uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b
-
-      - uses: subosito/flutter-action@48cafc24713cca54bbe03cdc3a423187d413aafa
-        with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: ${{ env.FLUTTER_CHANNEL }}
-          # Use format expected by FVM.
-          # Else this won't be recognized as an installed version when setting
-          # '.../flutter' as the FVM Flutter version cache folder.
-          cache-path: "${{ runner.tool_cache }}/flutter/:version:"
-
-      - name: Install FVM
-        run: |
-          flutter pub global activate fvm 2.4.1
-          fvm config --cache-path '${{ runner.tool_cache }}/flutter'
-
-      # Because macos-12 doesn't have Metal support, we need to disable Impeller
-      # https://github.com/flutter/flutter/issues/126768
-      - name: Disable Impeller
-        working-directory: app/ios/Runner
-        run: /usr/libexec/PlistBuddy -c "Add :FLTEnableImpeller bool false" Info.plist
-
-      - uses: futureware-tech/simulator-action@736249ceb5ed7916224ed6b6d3c3582fd8049deb
-        id: simulator
-        with:
-          model: "iPhone 13"
-
-      - name: Run integration tests
-        working-directory: app
-        env:
-          USER_1_EMAIL: ${{ secrets.INTEGRATION_TEST_USER_1_EMAIL }}
-          USER_1_PASSWORD: ${{ secrets.INTEGRATION_TEST_USER_1_PASSWORD }}
-          SIMULATOR_UDID: ${{ steps.simulator.outputs.udid }}
-        # We use the `flutter drive` instead of the `flutter test` command
-        # because the test command times out after 12 minutes. But building the
-        # app takes more than 12 minutes... It seems so that there is no way to
-        # set the timeout (the --timeout argument has not effect). Tracking
-        # issue: https://github.com/flutter/flutter/issues/105913
-        run: |
-          # We need to run the integration tests with the prod flavor because
-          # using not the default flavor will cause an exception when
-          # uninstalling the app, see:
-          # https://github.com/flutter/flutter/issues/88690
-          fvm flutter drive \
-            --driver=test_driver/integration_test.dart \
-            --target=integration_test/app_test.dart \
-            --flavor prod \
-            --dart-define=USER_1_EMAIL=$USER_1_EMAIL \
-            --dart-define=USER_1_PASSWORD=$USER_1_PASSWORD \
-            -d $SIMULATOR_UDID

--- a/.github/workflows/safe_app_ci.yml
+++ b/.github/workflows/safe_app_ci.yml
@@ -210,7 +210,7 @@ jobs:
       - uses: futureware-tech/simulator-action@736249ceb5ed7916224ed6b6d3c3582fd8049deb
         id: simulator
         with:
-          model: "iPhone 14"
+          model: "iPhone 13"
 
       - name: Run integration tests
         working-directory: app

--- a/.github/workflows/safe_app_ci.yml
+++ b/.github/workflows/safe_app_ci.yml
@@ -14,13 +14,13 @@
 
 name: safe-app-ci
 
-concurrency:
-  group: safe-app-ci-${{ github.head_ref }}
+# concurrency:
+  # group: safe-app-ci-${{ github.head_ref }}
   # In order to conserve the use of GitHub Actions, we cancel the running action
   # of the previous commit. This means that if you first commit "A" and then
   # commit "B" to the pull request a few minutes later, the workflow for commit
   # "A" will be cancelled.
-  cancel-in-progress: true
+  # cancel-in-progress: true
 
 on:
   # Triggers the workflow on pull request events
@@ -180,7 +180,7 @@ jobs:
 
   ios-integration-test:
     needs: changes
-    runs-on: macos-13
+    runs-on: macos-12
     if: ${{ needs.changes.outputs.changesFound == 'true' }}
     timeout-minutes: 120
     strategy:
@@ -188,8 +188,6 @@ jobs:
         A: [1, 2, 3]
     steps:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
-        with:
-          ref: '931ffdd1e179c2bac2502bc44156047c027b1bb4'
 
       - name: Set Flutter version from FVM config file to environment variables
         uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b

--- a/.github/workflows/safe_app_ci.yml
+++ b/.github/workflows/safe_app_ci.yml
@@ -186,6 +186,7 @@ jobs:
     strategy:
       matrix:
         A: [1, 2, 3]
+      fail-fast: false
     steps:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
 

--- a/.github/workflows/safe_app_ci.yml
+++ b/.github/workflows/safe_app_ci.yml
@@ -180,6 +180,8 @@ jobs:
 
   ios-integration-test:
     needs: changes
+    # We are using macos-12 instead macos-13 because with macos-13 we have job
+    # times of 40 - 120 minutes.
     runs-on: macos-12
     if: ${{ needs.changes.outputs.changesFound == 'true' }}
     timeout-minutes: 120
@@ -206,6 +208,12 @@ jobs:
         run: |
           flutter pub global activate fvm 2.4.1
           fvm config --cache-path '${{ runner.tool_cache }}/flutter'
+
+      # Because macos-12 doesn't have Metal support, we need to disable Impeller
+      # https://github.com/flutter/flutter/issues/126768
+      - name: Disable Impeller
+        working-directory: app/ios/Runner
+        run: /usr/libexec/PlistBuddy -c "Add :FLTEnableImpeller bool false" Info.plist
 
       - uses: futureware-tech/simulator-action@736249ceb5ed7916224ed6b6d3c3582fd8049deb
         id: simulator


### PR DESCRIPTION
I found the issue why our build times for iOS integration tests went from 15 - 20 minutes to 60 - 100 minutes: it's `macos-13`. Going back to `macos-12` solves this issue. Invertase faced the same issue: https://github.com/firebase/flutterfire/pull/11451.

I tested it with 3 builds using `macos-12`. All three only took 23 minutes:

![image](https://github.com/SharezoneApp/sharezone-app/assets/24459435/9579f51b-1b19-4784-aaf3-98f7e7bb4d56)

https://github.com/SharezoneApp/sharezone-app/actions/runs/6228178121/job/16904381314?pr=1012

However, using `macos-12` has the problem that `macos-12` does not support Metal (https://github.com/flutter/flutter/issues/126768), which is used by Impeller. So we have to disable Impeller for integration testing. This is not really great, because in production we use Impeller, and there could be a problem with Impeller in our application that is not tested. In the end, it's a trade-off. I think the probability that there is an issue with Impeller that is covered by our integration tests is very low, and having 120 minutes of integration tests really slows down development. So I would choose the option to disable Impeller for now.