### PR TITLE
Add fallback for "web-integration-test" workflow

### DIFF
--- a/.github/workflows/integration_tests_app_fallback_ci.yml
+++ b/.github/workflows/integration_tests_app_fallback_ci.yml
@@ -33,6 +33,11 @@ jobs:
     steps:
       - run: 'echo "No ios-integration-test required"'
 
+  web-integration-test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No web-integration-test required"'
+
   macos-build-test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Is needed to make `web-integration-test` workflow required. See file comment for more details.