### PR TITLE
Add `--rollout-percentage` to `sz deploy android`

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -36,6 +36,12 @@ on:
           Android changelog: Used for the Google Play Store release notes. If the 
           changelog is not provided, the deployment for Android will be skipped.
           Use '\n' for line breaks.
+      android-rollout-percentage:
+        type: number
+        description: |
+          Android rollout percentage: The percentage of users that should receive
+          the new version.
+        default: '1.0'
 
 # Set permissions to none.
 #
@@ -205,4 +211,5 @@ jobs:
 
           sz deploy android \
             --stage beta \
-            --whats-new "$CHANGELOG_WITH_NEW_LINES"
+            --whats-new "$CHANGELOG_WITH_NEW_LINES" \
+            --rollout-percentage ${{ github.event.inputs.android-rollout-percentage }}

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -41,7 +41,7 @@ on:
         description: |
           Android rollout percentage: The percentage of users that should receive
           the new version.
-        default: '1.0'
+        default: "1.0"
 
 # Set permissions to none.
 #

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -36,6 +36,12 @@ on:
           Android changelog: Used for the Google Play Store release notes. If the 
           changelog is not provided, the deployment for Android will be skipped.
           Use '\n' for line breaks.
+      android-rollout-percentage:
+        type: number
+        description: |
+          Android rollout percentage: The percentage of users that should receive
+          the new version.
+        default: '0.2'
 
 # Set permissions to none.
 #
@@ -207,4 +213,5 @@ jobs:
 
           sz deploy android \
             --stage stable \
-            --whats-new "$CHANGELOG_WITH_NEW_LINES"
+            --whats-new "$CHANGELOG_WITH_NEW_LINES" \
+            --rollout-percentage ${{ github.event.inputs.android-rollout-percentage }}

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -41,7 +41,7 @@ on:
         description: |
           Android rollout percentage: The percentage of users that should receive
           the new version.
-        default: '0.2'
+        default: "0.2"
 
 # Set permissions to none.
 #

--- a/app/android/fastlane/Fastfile
+++ b/app/android/fastlane/Fastfile
@@ -22,6 +22,7 @@ platform :android do
       track: ENV['TRACK'],
       package_name: 'de.codingbrain.sharezone',
       aab: '../build/app/outputs/bundle/prodRelease/app-prod-release.aab',
+      rollout: ENV["ROLLOUT"]
     )
   end
 end

--- a/tools/sz_repo_cli/lib/src/commands/src/deploy_android_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/deploy_android_command.dart
@@ -183,7 +183,7 @@ class DeployAndroidCommand extends Command {
     stdout.writeln(
         'This release will be rolled out to: ${rolloutPercentageDouble * 100}% of users.}');
     stdout.writeln(
-        'You can later change the rollout percentage in the Play Store Console: Go to "Production" -> "Releases"');
+        'You can later change the rollout percentage in the Play Store Console: Go to "Production" (or Open testing or Closed Testing) -> "Releases"');
   }
 
   Future<void> _setChangelog() async {

--- a/tools/sz_repo_cli/lib/src/commands/src/deploy_android_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/deploy_android_command.dart
@@ -165,12 +165,25 @@ class DeployAndroidCommand extends Command {
     try {
       await _setChangelog();
 
+      final rolloutPercentage =
+          argResults![rolloutPercentageOptionName] as String;
+      _printRolloutPercentage(rolloutPercentage);
+
       await _uploadToGooglePlay(
         track: _getGooglePlayTrackFromStage(),
+        rollout: rolloutPercentage,
       );
     } finally {
       await _removeChangelogFile();
     }
+  }
+
+  void _printRolloutPercentage(String rolloutPercentage) {
+    final rolloutPercentageDouble = double.parse(rolloutPercentage);
+    stdout.writeln(
+        'This release will be rolled out to: ${rolloutPercentageDouble * 100}% of users.}');
+    stdout.writeln(
+        'You can later change the rollout percentage in the Play Store Console: Go to "Production" -> "Releases"');
   }
 
   Future<void> _setChangelog() async {
@@ -206,6 +219,7 @@ class DeployAndroidCommand extends Command {
 
   Future<void> _uploadToGooglePlay({
     required String track,
+    required String rollout,
   }) async {
     await runProcess(
       'fastlane',
@@ -213,7 +227,7 @@ class DeployAndroidCommand extends Command {
       workingDirectory: '${_repo.sharezoneFlutterApp.location.path}/android',
       environment: {
         'TRACK': track,
-        'ROLLOUT': argResults![rolloutPercentageOptionName] as String,
+        'ROLLOUT': rollout,
       },
     );
   }


### PR DESCRIPTION
This PR adds the `--rollout-percentage` to `sz deploy android`: The percentage (between 0.0 - 1.0) of the user fraction when uploading to the rollout track (setting to 1 will complete the rollout).

Additionally, this PR adds the parameters to `stable.yml` (default: 0.2) and `beta.yml` (default: 1.0).