### PR TITLE
Upgrade Codemagic CLI tools to `0.45.1`

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -124,7 +124,7 @@ jobs:
           fvm config --cache-path '${{ runner.tool_cache }}/flutter'
 
       - name: Install Codemagic CLI Tools
-        run: pip3 install codemagic-cli-tools==0.44.1
+        run: pip3 install codemagic-cli-tools==0.45.1
 
       - name: Setup signing
         working-directory: app/android
@@ -212,7 +212,7 @@ jobs:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
 
       - name: Install Codemagic CLI Tools
-        run: pip3 install codemagic-cli-tools==0.44.1
+        run: pip3 install codemagic-cli-tools==0.45.1
 
       - name: Set Flutter version from FVM config file to environment variables
         uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b
@@ -278,7 +278,7 @@ jobs:
     steps:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
       - name: Install Codemagic CLI Tools
-        run: pip3 install codemagic-cli-tools==0.44.1
+        run: pip3 install codemagic-cli-tools==0.45.1
       - name: Setup signing
         env:
           # The following secrets are used by the Codemagic CLI tool. It's important

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
 
       - name: Install Codemagic CLI Tools
-        run: pip3 install codemagic-cli-tools==0.44.1
+        run: pip3 install codemagic-cli-tools==0.45.1
 
       - name: Set Flutter version from FVM config file to environment variables
         uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b
@@ -151,7 +151,7 @@ jobs:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
 
       - name: Install Codemagic CLI Tools
-        run: pip3 install codemagic-cli-tools==0.44.1
+        run: pip3 install codemagic-cli-tools==0.45.1
 
       - name: Setup signing
         working-directory: app/android

--- a/.github/workflows/integration_tests_app_ci.yml
+++ b/.github/workflows/integration_tests_app_ci.yml
@@ -295,7 +295,7 @@ jobs:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
 
       - name: Install Codemagic CLI Tools
-        run: pip3 install codemagic-cli-tools==0.44.1
+        run: pip3 install codemagic-cli-tools==0.45.1
 
       - name: Setup signing
         env:

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
 
       - name: Install Codemagic CLI Tools
-        run: pip3 install codemagic-cli-tools==0.44.1
+        run: pip3 install codemagic-cli-tools==0.45.1
 
       - name: Set Flutter version from FVM config file to environment variables
         uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b
@@ -153,7 +153,7 @@ jobs:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
 
       - name: Install Codemagic CLI Tools
-        run: pip3 install codemagic-cli-tools==0.44.1
+        run: pip3 install codemagic-cli-tools==0.45.1
 
       - name: Setup signing
         working-directory: app/android


### PR DESCRIPTION
We had the problem that sometimes our macOS builds weren't successfully uploaded to TestFlight (see https://github.com/codemagic-ci-cd/cli-tools/issues/346#issuecomment-1725176978). The new version `0.45.1` should fix this.