### PR TITLE
Do not trigger CI on only Fastlane changes

### DIFF
--- a/.github/workflows/integration_tests_app_ci.yml
+++ b/.github/workflows/integration_tests_app_ci.yml
@@ -69,6 +69,7 @@ jobs:
               - "!**/*.gitignore"
               - "!**/firebase.json"
               - "!**/.firebaserc"
+              - "!app/android/fastlane/**"
 
   android-integration-test:
     needs: changes

--- a/.github/workflows/safe_app_ci.yml
+++ b/.github/workflows/safe_app_ci.yml
@@ -89,6 +89,7 @@ jobs:
               - "!**/*.gitignore"
               - "!**/firebase.json"
               - "!**/.firebaserc"
+              - "!app/android/fastlane/**"
 
   analyze:
     needs: changes

--- a/.github/workflows/unsafe_app_ci.yml
+++ b/.github/workflows/unsafe_app_ci.yml
@@ -107,6 +107,7 @@ jobs:
               - "!**/*.gitignore"
               - "!**/firebase.json"
               - "!**/.firebaserc"
+              - "!app/android/fastlane/**"
 
   # We are building for every PR a web preview, which will be deployed to
   # Firebase Hosting. The link to the website will posted as comment (like:


### PR DESCRIPTION
The PR https://github.com/SharezoneApp/sharezone-app/pull/1019 also triggered the integration tests although in `app/` only the Fastlane file changed and this file not covered by our CI.