### PR TITLE
Set build number to 0 since the build number is managed by our CD pipeline.

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -8,12 +8,10 @@
 
 name: sharezone
 description: A collaborative school planner for students, teachers and parents.
-# Note that this build number is not the latest build number. Please go to App
-# Store Connect
-# (https://appstoreconnect.apple.com/apps/1434868489/testflight/ios) or use
-# "app-store-connect get-latest-build-number 1434868489" to get the latest build
-# number.
-version: 1.7.6+318
+# Note that we do not store the current build number in the pubspec.yaml. The
+# build number is automatically increased by the CD pipeline (using `sz deploy`
+# command).
+version: 1.7.6+0
 publish_to: none
 
 environment:


### PR DESCRIPTION
Since our build number is manged by our CD pipeline, I set the build number in the `pubspec.yaml` to 0 to indicate that the current build number is _not_ stored in the `pubspec.yaml`. 