### PR TITLE
Add option to switch layout for events from grid to list view

### DIFF
--- a/app/lib/blocs/sharezone_bloc_providers.dart
+++ b/app/lib/blocs/sharezone_bloc_providers.dart
@@ -37,7 +37,9 @@ import 'package:sharezone/blocs/auth/type_of_user_bloc.dart';
 import 'package:sharezone/blocs/bloc_dependencies.dart';
 import 'package:sharezone/blocs/settings/change_data_bloc.dart';
 import 'package:sharezone/blocs/settings/notifications_bloc_factory.dart';
+import 'package:sharezone/calendrical_events/analytics/calendrical_events_page_analytics.dart';
 import 'package:sharezone/calendrical_events/bloc/calendrical_events_page_bloc_factory.dart';
+import 'package:sharezone/calendrical_events/bloc/calendrical_events_page_cache.dart';
 import 'package:sharezone/comments/comment_view_factory.dart';
 import 'package:sharezone/comments/comments_analytics.dart';
 import 'package:sharezone/comments/comments_bloc_factory.dart';
@@ -380,7 +382,14 @@ class _SharezoneBlocProvidersState extends State<SharezoneBlocProviders> {
       )),
       BlocProvider<CalendricalEventsPageBlocFactory>(
         bloc: CalendricalEventsPageBlocFactory(
-            api.timetable, api.course, api.schoolClassGateway),
+          api.timetable,
+          api.course,
+          api.schoolClassGateway,
+          CalendricalEventsPageCache(
+            FlutterKeyValueStore(widget.blocDependencies.sharedPreferences),
+          ),
+          CalendricalEventsPageAnalytics(analytics),
+        ),
       ),
       BlocProvider<AccountPageBlocFactory>(
           bloc: AccountPageBlocFactory(api.user)),

--- a/app/lib/calendrical_events/analytics/calendrical_events_page_analytics.dart
+++ b/app/lib/calendrical_events/analytics/calendrical_events_page_analytics.dart
@@ -1,0 +1,24 @@
+import 'package:analytics/analytics.dart';
+import 'package:sharezone/calendrical_events/models/calendrical_events_layout.dart';
+
+class CalendricalEventsPageAnalytics {
+  final Analytics analytics;
+
+  const CalendricalEventsPageAnalytics(this.analytics);
+
+  void logChangeLayout(CalendricalEventsPageLayout layout) {
+    analytics.log(
+      CalendricalEventsPageAnalyticsEvent(
+        'changed_layout',
+        data: {'layout': layout.name},
+      ),
+    );
+  }
+}
+
+class CalendricalEventsPageAnalyticsEvent extends AnalyticsEvent {
+  const CalendricalEventsPageAnalyticsEvent(
+    String name, {
+    Map<String, dynamic>? data,
+  }) : super('events_page_$name', data: data);
+}

--- a/app/lib/calendrical_events/analytics/calendrical_events_page_analytics.dart
+++ b/app/lib/calendrical_events/analytics/calendrical_events_page_analytics.dart
@@ -1,3 +1,11 @@
+// Copyright (c) 2023 Sharezone UG (haftungsbeschränkt)
+// Licensed under the EUPL-1.2-or-later.
+//
+// You may obtain a copy of the Licence at:
+// https://joinup.ec.europa.eu/software/page/eupl
+//
+// SPDX-License-Identifier: EUPL-1.2
+
 import 'package:analytics/analytics.dart';
 import 'package:sharezone/calendrical_events/models/calendrical_events_layout.dart';
 

--- a/app/lib/calendrical_events/bloc/calendrical_events_page_bloc.dart
+++ b/app/lib/calendrical_events/bloc/calendrical_events_page_bloc.dart
@@ -10,7 +10,10 @@ import 'package:bloc_base/bloc_base.dart';
 import 'package:date/date.dart';
 import 'package:group_domain_models/group_domain_models.dart';
 import 'package:rxdart/rxdart.dart';
+import 'package:sharezone/calendrical_events/analytics/calendrical_events_page_analytics.dart';
+import 'package:sharezone/calendrical_events/bloc/calendrical_events_page_cache.dart';
 import 'package:sharezone/calendrical_events/models/calendrical_event.dart';
+import 'package:sharezone/calendrical_events/models/calendrical_events_layout.dart';
 import 'package:sharezone/timetable/src/widgets/events/event_view.dart';
 import 'package:sharezone/util/api/course_gateway.dart';
 import 'package:sharezone/util/api/school_class_gateway.dart';
@@ -20,9 +23,16 @@ class CalendricalEventsPageBloc extends BlocBase {
   final TimetableGateway timetableGateway;
   final CourseGateway courseGateway;
   final SchoolClassGateway schoolClassGateway;
+  final CalendricalEventsPageCache cache;
+  final CalendricalEventsPageAnalytics analytics;
+
+  static const CalendricalEventsPageLayout defaultLayout =
+      CalendricalEventsPageLayout.grid;
 
   final _allUpcomingEventsSubject = BehaviorSubject<List<EventView>>();
+  final _layoutSubject = BehaviorSubject<CalendricalEventsPageLayout>();
 
+  Stream<CalendricalEventsPageLayout> get layout => _layoutSubject.stream;
   ValueStream<List<EventView>> get allUpcomingEvents =>
       _allUpcomingEventsSubject;
 
@@ -30,7 +40,11 @@ class CalendricalEventsPageBloc extends BlocBase {
     this.timetableGateway,
     this.courseGateway,
     this.schoolClassGateway,
+    this.cache,
+    this.analytics,
   ) {
+    _layoutSubject.add(cache.getLayout() ?? defaultLayout);
+
     CombineLatestStream([
       timetableGateway.streamEvents(Date.today()),
       courseGateway.getGroupInfoStream(schoolClassGateway)
@@ -47,8 +61,15 @@ class CalendricalEventsPageBloc extends BlocBase {
     }).listen(_allUpcomingEventsSubject.sink.add);
   }
 
+  void setLayout(CalendricalEventsPageLayout layout) {
+    _layoutSubject.add(layout);
+    analytics.logChangeLayout(layout);
+    cache.setLayout(layout);
+  }
+
   @override
   void dispose() {
+    _layoutSubject.close();
     _allUpcomingEventsSubject.close();
   }
 }

--- a/app/lib/calendrical_events/bloc/calendrical_events_page_bloc_factory.dart
+++ b/app/lib/calendrical_events/bloc/calendrical_events_page_bloc_factory.dart
@@ -7,6 +7,8 @@
 // SPDX-License-Identifier: EUPL-1.2
 
 import 'package:bloc_base/bloc_base.dart';
+import 'package:sharezone/calendrical_events/analytics/calendrical_events_page_analytics.dart';
+import 'package:sharezone/calendrical_events/bloc/calendrical_events_page_cache.dart';
 import 'package:sharezone/util/api/course_gateway.dart';
 import 'package:sharezone/util/api/school_class_gateway.dart';
 import 'package:sharezone/util/api/timetable_gateway.dart';
@@ -17,13 +19,25 @@ class CalendricalEventsPageBlocFactory extends BlocBase {
   final TimetableGateway _timetableGateway;
   final CourseGateway _courseGateway;
   final SchoolClassGateway _schoolClassGateway;
+  final CalendricalEventsPageCache _cache;
+  final CalendricalEventsPageAnalytics _analytics;
 
   CalendricalEventsPageBlocFactory(
-      this._timetableGateway, this._courseGateway, this._schoolClassGateway);
+    this._timetableGateway,
+    this._courseGateway,
+    this._schoolClassGateway,
+    this._cache,
+    this._analytics,
+  );
 
   CalendricalEventsPageBloc create() {
     return CalendricalEventsPageBloc(
-        _timetableGateway, _courseGateway, _schoolClassGateway);
+      _timetableGateway,
+      _courseGateway,
+      _schoolClassGateway,
+      _cache,
+      _analytics,
+    );
   }
 
   @override

--- a/app/lib/calendrical_events/bloc/calendrical_events_page_cache.dart
+++ b/app/lib/calendrical_events/bloc/calendrical_events_page_cache.dart
@@ -1,0 +1,19 @@
+import 'package:key_value_store/key_value_store.dart';
+import 'package:sharezone/calendrical_events/models/calendrical_events_layout.dart';
+import 'package:sharezone_common/helper_functions.dart';
+
+class CalendricalEventsPageCache {
+  final KeyValueStore keyValueStore;
+  static const _layoutKey = 'calendrical-events-page-layout';
+
+  const CalendricalEventsPageCache(this.keyValueStore);
+
+  CalendricalEventsPageLayout? getLayout() {
+    final layoutString = keyValueStore.getString(_layoutKey);
+    return CalendricalEventsPageLayout.values.byNameOrNull(layoutString);
+  }
+
+  Future<bool> setLayout(CalendricalEventsPageLayout layout) {
+    return keyValueStore.setString(_layoutKey, layout.name);
+  }
+}

--- a/app/lib/calendrical_events/bloc/calendrical_events_page_cache.dart
+++ b/app/lib/calendrical_events/bloc/calendrical_events_page_cache.dart
@@ -1,3 +1,11 @@
+// Copyright (c) 2023 Sharezone UG (haftungsbeschränkt)
+// Licensed under the EUPL-1.2-or-later.
+//
+// You may obtain a copy of the Licence at:
+// https://joinup.ec.europa.eu/software/page/eupl
+//
+// SPDX-License-Identifier: EUPL-1.2
+
 import 'package:key_value_store/key_value_store.dart';
 import 'package:sharezone/calendrical_events/models/calendrical_events_layout.dart';
 import 'package:sharezone_common/helper_functions.dart';

--- a/app/lib/calendrical_events/models/calendrical_events_layout.dart
+++ b/app/lib/calendrical_events/models/calendrical_events_layout.dart
@@ -1,3 +1,11 @@
+// Copyright (c) 2023 Sharezone UG (haftungsbeschränkt)
+// Licensed under the EUPL-1.2-or-later.
+//
+// You may obtain a copy of the Licence at:
+// https://joinup.ec.europa.eu/software/page/eupl
+//
+// SPDX-License-Identifier: EUPL-1.2
+
 /// Enum for the layout of the calendrical events cards on the calendrical
 /// events page.
 enum CalendricalEventsPageLayout {

--- a/app/lib/calendrical_events/models/calendrical_events_layout.dart
+++ b/app/lib/calendrical_events/models/calendrical_events_layout.dart
@@ -1,0 +1,6 @@
+/// Enum for the layout of the calendrical events cards on the calendrical
+/// events page.
+enum CalendricalEventsPageLayout {
+  grid,
+  list,
+}

--- a/app/lib/calendrical_events/page/calendrical_events_page.dart
+++ b/app/lib/calendrical_events/page/calendrical_events_page.dart
@@ -82,20 +82,19 @@ class _EventList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SingleChildScrollView(
-      padding: const EdgeInsets.fromLTRB(0, 16, 12, 4),
-      child: SafeArea(
-        child: WrappableList(
-          minWidth: 150.0,
-          maxElementsPerSection: 3,
-          children: <Widget>[
-            for (final event in events)
-              Padding(
-                padding: const EdgeInsets.only(bottom: 12),
-                child: CalenderEventCard(event),
-              )
-          ],
-        ),
+    return SafeArea(
+      child: ListView.builder(
+        padding: const EdgeInsets.fromLTRB(0, 16, 12, 4),
+        itemCount: events.length,
+        itemBuilder: (context, index) {
+          final event = events[index];
+          return MaxWidthConstraintBox(
+            child: Padding(
+              padding: const EdgeInsets.only(bottom: 12),
+              child: CalenderEventCard(event),
+            ),
+          );
+        },
       ),
     );
   }

--- a/lib/sharezone_common/lib/src/helper_functions.dart
+++ b/lib/sharezone_common/lib/src/helper_functions.dart
@@ -69,4 +69,12 @@ extension EnumByNameWithDefault<T extends Enum> on Iterable<T> {
     if (defaultValue != null) return defaultValue;
     throw ArgumentError.value(name, "name", "No enum value with that name");
   }
+
+  T? byNameOrNull(String? name) {
+    for (T value in this) {
+      if (value.name == name) return value;
+    }
+
+    return null;
+  }
 }


### PR DESCRIPTION
## Description

This PR adds the ability to switch from grid view to list view. Finding an event in grid view can be difficult because it's hard for the eye to scan the events.

Setting an option is cached. I also added analytics for this button.

## Demo

https://github.com/SharezoneApp/sharezone-app/assets/24459435/4742669a-1f0b-4d1e-a20c-af176b324fb6

(Don't be confused that there are events from the past. For the demo I changed the query to load all events to have more events on my page).