### PR TITLE
Remove workaround for publishing macOS apps

### DIFF
--- a/tools/sz_repo_cli/lib/src/commands/src/deploy_macos_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/deploy_macos_command.dart
@@ -118,12 +118,9 @@ class DeployMacOsCommand extends Command {
         workingDirectory: _repo.sharezoneFlutterApp.path,
       );
 
-      await setWorkaroundPermission();
       await _buildApp(buildNumber: buildNumber);
-      await setWorkaroundPermission();
 
       await _createSignedPackage();
-
       await publishToAppStoreConnect(
         appStoreConnectConfig: appStoreConnectConfig,
         stage: argResults![releaseStageOptionName] as String,

--- a/tools/sz_repo_cli/lib/src/common/src/app_store_connect_utils.dart
+++ b/tools/sz_repo_cli/lib/src/common/src/app_store_connect_utils.dart
@@ -153,15 +153,6 @@ Future<int> _getLatestBuildNumberFromAppStoreConnect({
   }
 }
 
-// Sets the required permissions for deploying Flutter macOS.
-//
-// Workaround for https://github.com/flutter/flutter/issues/132725. Can be
-// removed with Flutter v3.13.5.
-Future<void> setWorkaroundPermission() async {
-  await runProcessSuccessfullyOrThrow('bash', ['-c', 'sudo chown -R \$USER .']);
-  await runProcessSuccessfullyOrThrow('bash', ['-c', 'sudo chmod -R a+rwx .']);
-}
-
 Future<void> publishToAppStoreConnect({
   required SharezoneRepo repo,
   required String path,


### PR DESCRIPTION
Since https://github.com/flutter/flutter/issues/132725 is now included in the new Flutter hotfix update v3.13.5, we can remove this workaround.

Requires #1047 