### PR TITLE
Fix showing error message when homework `todoUntil` field is null

### DIFF
--- a/app/lib/blocs/homework/homework_dialog_bloc.dart
+++ b/app/lib/blocs/homework/homework_dialog_bloc.dart
@@ -205,6 +205,13 @@ class HomeworkDialogBloc extends BlocBase with HomeworkValidators {
       throw InvalidCourseException();
     }
 
+    final validatorTodoUntil = NotNullValidator(_todoUntilSubject.valueOrNull);
+    if (!validatorTodoUntil.isValid()) {
+      _todoUntilSubject.addError(
+          TextValidationException(HomeworkValidators.emptyDueDateUserMessage));
+      throw InvalidTodoUntilException();
+    }
+
     return true;
   }
 
@@ -290,6 +297,8 @@ class HomeworkDialogBloc extends BlocBase with HomeworkValidators {
 class InvalidTitleException implements Exception {}
 
 class InvalidCourseException implements Exception {}
+
+class InvalidTodoUntilException implements Exception {}
 
 class UserInput {
   final String? title, description;

--- a/app/lib/pages/homework/homework_dialog.dart
+++ b/app/lib/pages/homework/homework_dialog.dart
@@ -201,6 +201,13 @@ class _SaveButton extends StatelessWidget {
             .toString(),
         context: context,
       );
+    } on InvalidTodoUntilException {
+      showSnackSec(
+        text:
+            TextValidationException(HomeworkValidators.emptyDueDateUserMessage)
+                .toString(),
+        context: context,
+      );
     } on Exception catch (e) {
       log("Exception when submitting: $e", error: e);
       showSnackSec(
@@ -245,10 +252,15 @@ class _TodoUntilPicker extends StatelessWidget {
         bottom: false,
         child: StreamBuilder<DateTime>(
           stream: bloc.todoUntil,
-          builder: (context, snapshot) => DatePicker(
-            padding: const EdgeInsets.all(12),
-            selectedDate: snapshot.data,
-            selectDate: bloc.changeTodoUntil,
+          builder: (context, snapshot) => DefaultTextStyle.merge(
+            style: TextStyle(
+              color: snapshot.hasError ? Colors.red : null,
+            ),
+            child: DatePicker(
+              padding: const EdgeInsets.all(12),
+              selectedDate: snapshot.data,
+              selectDate: bloc.changeTodoUntil,
+            ),
           ),
         ),
       ),

--- a/lib/sharezone_common/lib/src/validators/homework_validators.dart
+++ b/lib/sharezone_common/lib/src/validators/homework_validators.dart
@@ -26,4 +26,6 @@ mixin HomeworkValidators {
       "Bitte gib einen Titel für die Hausaufgabe an!";
   static const emptyCourseUserMessage =
       "Bitte gib einen Kurs für die Hausaufgabe an!";
+  static const emptyDueDateUserMessage =
+      "Bitte gib ein Fälligkeitsdatum für die Hausaufgabe an!";
 }


### PR DESCRIPTION
## Description

Normally, the todo until field is calculated when the user selects a course. However, there is the edge case where this not work and the todo until field is still null after selecting a course. In this case, a null value exception was thrown (see #1052). This PR fixes this, throws a helpful exception and makes the "Datum auswählen" text red.

## Demo

https://github.com/SharezoneApp/sharezone-app/assets/24459435/5d2c67a8-d98f-4d23-adc2-589d9b7bbc50

## Related Tickets

Fixes #1052 
