### PR TITLE
Fix "Bad state: Cannot add new events after calling close" in `changeTodoUntilNextLessonOrNextSchoolDay()`

### DIFF
--- a/app/lib/blocs/homework/homework_dialog_bloc.dart
+++ b/app/lib/blocs/homework/homework_dialog_bloc.dart
@@ -182,6 +182,10 @@ class HomeworkDialogBloc extends BlocBase with HomeworkValidators {
 
   void changeTodoUntilNextLessonOrNextSchoolDay(String courseID) {
     api.nextLessonCalculator.calculateNextLesson(courseID).then((result) {
+      // If the user has closed the dialog before the result is calculated, the
+      // stream is closed. In this case, the result is not used.
+      if (_todoUntilSubject.isClosed) return;
+
       if (result == null) {
         changeTodoUntil(_getSeedTodoUntilDate());
       } else {


### PR DESCRIPTION
Related to #1053

Fixes #1056