### PR TITLE
Fix "Bad state: Cannot add new events after calling close" when using QR code sign in

### DIFF
--- a/lib/authentification/authentification_qrcode/lib/src/blocs/qr_sign_in_web_bloc.dart
+++ b/lib/authentification/authentification_qrcode/lib/src/blocs/qr_sign_in_web_bloc.dart
@@ -65,6 +65,7 @@ class QrSignInWebBloc extends BlocBase {
         _signInWithCustomToken(customToken);
       }
       try {
+        if (_qrSignInStateSubject.isClosed) return;
         _qrSignInStateSubject.sink.add(onUpdate);
       } catch (e, s) {
         getCrashAnalytics().recordError(e, s);


### PR DESCRIPTION
Fixes #1058