### PR TITLE
Add temporary remote config values for testing.

### DIFF
--- a/app/lib/main/plugin_initializations.dart
+++ b/app/lib/main/plugin_initializations.dart
@@ -80,6 +80,10 @@ class PluginInitializations {
       'revenuecat_api_android_key': 'goog_EyqDtrZhkswSqMAcfqawHGAqZnX',
       'firebase_messaging_vapid_key':
           'BNT7Da6B6wi-mUBcGrt-9HxeIJZsPTsPpmR8cae_LhgJPcSFb5j0T8o-r-oFV1xAtXVXfRPIZlgUJR3tx8mLbbA',
+      // These values are not used anymore, we just keep them here temporarily
+      // to test remote config behavior.
+      'revenuecat_api_key': 'LOCAL',
+      'zeige_pilotschule_karte': 'nöö',
     });
 
     try {

--- a/app/lib/main/plugin_initializations.dart
+++ b/app/lib/main/plugin_initializations.dart
@@ -87,7 +87,9 @@ class PluginInitializations {
     });
 
     try {
-      if (flavor == Flavor.dev) {
+      //ignore: dead_code
+      if (false) {
+        //if (flavor == Flavor.dev) {
         // Since we depend on some values from our Remote Config in the dev
         // environment, we can't use the "Load new values for next startup"
         // strategy.

--- a/app/lib/sharezone_plus/page/sharezone_plus_page.dart
+++ b/app/lib/sharezone_plus/page/sharezone_plus_page.dart
@@ -38,9 +38,15 @@ class SharezonePlusPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final remoteConfig = getRemoteConfiguration();
-    log('revenuecat_api_key: ${remoteConfig.getString('revenuecat_api_key')}');
-    log('zeige_pilotschule_karte: ${remoteConfig.getString('zeige_pilotschule_karte')}');
-    log('useCfHolidayEndpoint: ${remoteConfig.getBool('useCfHolidayEndpoint')}');
+    // ignore: avoid_print
+    print(
+        'revenuecat_api_key: ${remoteConfig.getString('revenuecat_api_key')}');
+    // ignore: avoid_print
+    print(
+        'zeige_pilotschule_karte: ${remoteConfig.getString('zeige_pilotschule_karte')}');
+    // ignore: avoid_print
+    print(
+        'useCfHolidayEndpoint: ${remoteConfig.getBool('useCfHolidayEndpoint')}');
 
     return const SharezoneMainScaffold(
       navigationItem: NavigationItem.sharezonePlus,

--- a/app/lib/sharezone_plus/page/sharezone_plus_page.dart
+++ b/app/lib/sharezone_plus/page/sharezone_plus_page.dart
@@ -10,6 +10,7 @@ import 'package:bloc_provider/bloc_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:provider/provider.dart';
+import 'package:remote_configuration/remote_configuration.dart';
 import 'package:sharezone/navigation/logic/navigation_bloc.dart';
 import 'package:sharezone/navigation/models/navigation_item.dart';
 import 'package:sharezone/navigation/scaffold/sharezone_main_scaffold.dart';
@@ -34,6 +35,14 @@ class SharezonePlusPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final remoteConfig = getRemoteConfiguration();
+    print(
+        'revenuecat_api_key: ${remoteConfig.getString('revenuecat_api_key')}');
+    print(
+        'zeige_pilotschule_karte: ${remoteConfig.getString('zeige_pilotschule_karte')}');
+    print(
+        'useCfHolidayEndpoint: ${remoteConfig.getBool('useCfHolidayEndpoint')}');
+
     return const SharezoneMainScaffold(
       navigationItem: NavigationItem.sharezonePlus,
       body: SharezonePlusPageMain(),

--- a/app/lib/sharezone_plus/page/sharezone_plus_page.dart
+++ b/app/lib/sharezone_plus/page/sharezone_plus_page.dart
@@ -6,6 +6,8 @@
 //
 // SPDX-License-Identifier: EUPL-1.2
 
+import 'dart:developer';
+
 import 'package:bloc_provider/bloc_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
@@ -36,12 +38,9 @@ class SharezonePlusPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final remoteConfig = getRemoteConfiguration();
-    print(
-        'revenuecat_api_key: ${remoteConfig.getString('revenuecat_api_key')}');
-    print(
-        'zeige_pilotschule_karte: ${remoteConfig.getString('zeige_pilotschule_karte')}');
-    print(
-        'useCfHolidayEndpoint: ${remoteConfig.getBool('useCfHolidayEndpoint')}');
+    log('revenuecat_api_key: ${remoteConfig.getString('revenuecat_api_key')}');
+    log('zeige_pilotschule_karte: ${remoteConfig.getString('zeige_pilotschule_karte')}');
+    log('useCfHolidayEndpoint: ${remoteConfig.getBool('useCfHolidayEndpoint')}');
 
     return const SharezoneMainScaffold(
       navigationItem: NavigationItem.sharezonePlus,


### PR DESCRIPTION
I want to test how remote config behaves if the website is hosted on a static domain (`alpha.web.sharezone.net`):
* Behavior on first load
* Behavior after completely closing the browser and opening the same site again
* Behavior when refreshing the page

I just used some of the values that are already in prod remote config but are not used anymore.

This is important so we know how a fallback price for Sharezone Plus would behave.  
