### PR TITLE
Remove `abiFilters` filters for Android

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -82,11 +82,6 @@ android {
             if(hasKeystorePropertiesFile) {
                 signingConfig signingConfigs.release
             }
-
-            ndk {
-                // From: https://stackoverflow.com/a/46051246/8358501
-                abiFilters "x86", "x86_64", "armeabi-v7a", "arm64-v8a"
-            }
         }
     }
 


### PR DESCRIPTION
As described in #1073, we are getting some data in Crashlytics about an early crash when our app is launched. From what I found out, it is something about the `abiFilters` we set in `build.gradle`. Normally you don't need them and they are not set when you run `flutter create .`. I added them many years ago because I thought I wanted to fix something, but I didn't know what I was doing.

Fix #1073