### PR TITLE
Fix "Null check operator used on a null value" on login page

### DIFF
--- a/app/lib/auth/login_page.dart
+++ b/app/lib/auth/login_page.dart
@@ -186,8 +186,8 @@ class _LoginPageState extends State<LoginPage> {
     try {
       await bloc.submit();
     } on Exception catch (e, s) {
-      setState(() => isLoading = false);
       if (context.mounted) {
+        setState(() => isLoading = false);
         showSnackSec(
           text: handleErrorMessage(e.toString(), s),
           context: context,


### PR DESCRIPTION
The method `setState()` is causing the issue. Using `context.mounted` is the solution.
