### PR TITLE
Prevent the user to create a folder with `null` or an empty string

### DIFF
--- a/lib/sharezone_widgets/lib/src/form.dart
+++ b/lib/sharezone_widgets/lib/src/form.dart
@@ -88,7 +88,7 @@ class OneTextFieldDialog extends StatefulWidget {
     required this.title,
     required this.hint,
     required this.actionName,
-    this.isNullOrEmptyTextAllowed = false,
+    this.isEmptyAllowed = false,
     this.notAllowedChars,
     this.text,
   }) : super(key: key);
@@ -98,10 +98,10 @@ class OneTextFieldDialog extends StatefulWidget {
 
   /// Defines if the user is allowed to submit `null` or empty text.
   ///
-  /// If [isNullOrEmptyTextAllowed] is `false` and the user submits `null` or an
+  /// If [isEmptyAllowed] is `false` and the user submits `null` or an
   /// empty text, then the dialog will not be closed and the [onTap] callback
   /// will not be called. Instead an error message will be shown.
-  final bool isNullOrEmptyTextAllowed;
+  final bool isEmptyAllowed;
 
   /// The text, which will be set at the beginning
   final String? text;
@@ -169,7 +169,7 @@ class _OneTextFieldDialogState extends State<OneTextFieldDialog> {
           child: Text(widget.actionName!),
           onPressed: () {
             final isNullOrEmpty = name == null || name!.isEmpty;
-            if (!widget.isNullOrEmptyTextAllowed && isNullOrEmpty) {
+            if (!widget.isEmptyAllowed && isNullOrEmpty) {
               setState(() {
                 errorText = 'Das Textfeld darf nicht leer sein!';
               });

--- a/lib/sharezone_widgets/lib/src/form.dart
+++ b/lib/sharezone_widgets/lib/src/form.dart
@@ -98,9 +98,9 @@ class OneTextFieldDialog extends StatefulWidget {
 
   /// Defines if the user is allowed to submit `null` or empty text.
   ///
-  /// If [isNullOrEmptyTextAllowed] is `false` and the user submits `null` or
-  /// empty text, then the dialog will not be closed and the `onTap` callback
-  /// will not be called. Instead the user will be shown an error message.
+  /// If [isNullOrEmptyTextAllowed] is `false` and the user submits `null` or an
+  /// empty text, then the dialog will not be closed and the [onTap] callback
+  /// will not be called. Instead an error message will be shown.
   final bool isNullOrEmptyTextAllowed;
 
   /// The text, which will be set at the beginning

--- a/lib/sharezone_widgets/lib/src/form.dart
+++ b/lib/sharezone_widgets/lib/src/form.dart
@@ -88,12 +88,20 @@ class OneTextFieldDialog extends StatefulWidget {
     required this.title,
     required this.hint,
     required this.actionName,
+    this.isNullOrEmptyTextAllowed = false,
     this.notAllowedChars,
     this.text,
   }) : super(key: key);
 
   final ValueChanged<String?> onTap;
   final String? title, hint, actionName, notAllowedChars;
+
+  /// Defines if the user is allowed to submit `null` or empty text.
+  ///
+  /// If [isNullOrEmptyTextAllowed] is `false` and the user submits `null` or
+  /// empty text, then the dialog will not be closed and the `onTap` callback
+  /// will not be called. Instead the user will be shown an error message.
+  final bool isNullOrEmptyTextAllowed;
 
   /// The text, which will be set at the beginning
   final String? text;
@@ -160,6 +168,14 @@ class _OneTextFieldDialogState extends State<OneTextFieldDialog> {
           ),
           child: Text(widget.actionName!),
           onPressed: () {
+            final isNullOrEmpty = name == null || name!.isEmpty;
+            if (!widget.isNullOrEmptyTextAllowed && isNullOrEmpty) {
+              setState(() {
+                errorText = 'Das Textfeld darf nicht leer sein!';
+              });
+              return;
+            }
+
             if (widget.notAllowedChars == null) {
               widget.onTap(name);
             } else {


### PR DESCRIPTION
## Description

Before this PR, you could create a folder with an empty string or click the create button when a text field had the value `null` which caused a null operator exception. This PR fixes the issue by checking if the text is `null` or empty.

## Demo

<img width="1090" alt="image" src="https://github.com/SharezoneApp/sharezone-app/assets/24459435/8e7c5237-9589-470d-8177-c45669f45755">
