### PR TITLE
Replace `FocusManager` call with `focusNode.requestFocus` in `delayKeyboard(...)`.

### DIFF
--- a/lib/sharezone_widgets/lib/src/theme/theme.dart
+++ b/lib/sharezone_widgets/lib/src/theme/theme.dart
@@ -24,7 +24,7 @@ Future<void> delayKeyboard(
     required FocusNode focusNode,
     Duration duration = const Duration(milliseconds: 250)}) async {
   await Future.delayed(duration);
-  FocusManager.instance.primaryFocus?.requestFocus();
+  focusNode.requestFocus();
 }
 
 Future<void> hideKeyboardWithDelay(


### PR DESCRIPTION
The old way didn't work for me to request focus for the title field in the add homework dialog. This fixes it.