### PR TITLE
Refactor some of the homework dialog code.

### DIFF
--- a/app/lib/blocs/homework/homework_dialog_bloc.dart
+++ b/app/lib/blocs/homework/homework_dialog_bloc.dart
@@ -40,11 +40,14 @@ class HomeworkDialogBloc extends BlocBase with HomeworkValidators {
       BehaviorSubject<Time>.seeded(Time(hour: 23, minute: 59));
 
   final HomeworkDialogApi api;
+  final NextLessonCalculator nextLessonCalculator;
   final HomeworkDto? initialHomework;
 
   final MarkdownAnalytics _markdownAnalytics;
 
-  HomeworkDialogBloc(this.api, this._markdownAnalytics, {HomeworkDto? homework})
+  HomeworkDialogBloc(
+      this.api, this.nextLessonCalculator, this._markdownAnalytics,
+      {HomeworkDto? homework})
       : initialHomework = homework {
     if (homework != null) {
       _loadInitialCloudFiles(homework.courseReference!.id, homework.id);
@@ -181,7 +184,7 @@ class HomeworkDialogBloc extends BlocBase with HomeworkValidators {
   }
 
   void changeTodoUntilNextLessonOrNextSchoolDay(String courseID) {
-    api.nextLessonCalculator.calculateNextLesson(courseID).then((result) {
+    nextLessonCalculator.calculateNextLesson(courseID).then((result) {
       // If the user has closed the dialog before the result is calculated, the
       // stream is closed. In this case, the result is not used.
       if (_todoUntilSubject.isClosed) return;
@@ -335,9 +338,8 @@ class UserInput {
 
 class HomeworkDialogApi {
   final SharezoneGateway api;
-  final NextLessonCalculator nextLessonCalculator;
 
-  HomeworkDialogApi(this.api, this.nextLessonCalculator);
+  HomeworkDialogApi(this.api);
 
   Future<HomeworkDto> create(UserInput userInput) async {
     final localFiles = userInput.localFiles;

--- a/app/lib/homework/shared/open_homework_dialog.dart
+++ b/app/lib/homework/shared/open_homework_dialog.dart
@@ -31,7 +31,8 @@ Future<void> openHomeworkDialogAndShowConfirmationIfSuccessful(
     context,
     IgnoreWillPopScopeWhenIosSwipeBackRoute(
       builder: (context) => HomeworkDialog(
-        homeworkDialogApi: HomeworkDialogApi(api, nextLessonCalculator),
+        homeworkDialogApi: HomeworkDialogApi(api),
+        nextLessonCalculator: nextLessonCalculator,
         homework: homework,
       ),
       settings: const RouteSettings(name: HomeworkDialog.tag),

--- a/app/lib/pages/homework/homework_details/homework_details.dart
+++ b/app/lib/pages/homework/homework_details/homework_details.dart
@@ -399,7 +399,8 @@ class _EditIcon extends StatelessWidget {
           context,
           MaterialPageRoute(
             builder: (context) => HomeworkDialog(
-              homeworkDialogApi: HomeworkDialogApi(api, nextLessonCalculator),
+              homeworkDialogApi: HomeworkDialogApi(api),
+              nextLessonCalculator: nextLessonCalculator,
               homework: homework,
             ),
             settings: const RouteSettings(name: HomeworkDialog.tag),

--- a/app/lib/pages/homework/homework_dialog.dart
+++ b/app/lib/pages/homework/homework_dialog.dart
@@ -105,62 +105,60 @@ class __HomeworkDialogState extends State<__HomeworkDialog> {
 
   @override
   Widget build(BuildContext context) {
-    final bloc = BlocProvider.of<HomeworkDialogBloc>(context);
     return WillPopScope(
       onWillPop: () async => widget.bloc!.hasInputChanged()
           ? warnUserAboutLeavingForm(context)
           : Future.value(true),
-      child: StreamBuilder<String>(
-          stream: bloc.title,
-          builder: (context, snapshot) {
-            return Scaffold(
-              body: Column(
-                children: <Widget>[
-                  _AppBar(
-                    oldHomework: widget.homework,
-                    editMode: editMode,
-                    focusNodeTitle: titleNode,
-                    onCloseTap: () => leaveDialog(),
-                    titleField: MaxWidthConstraintBox(
-                      child: _TitleField(
+      child: Scaffold(
+        body: Column(
+          children: <Widget>[
+            _AppBar(
+              oldHomework: widget.homework,
+              editMode: editMode,
+              focusNodeTitle: titleNode,
+              onCloseTap: () => leaveDialog(),
+              titleField: MaxWidthConstraintBox(
+                child: StreamBuilder<String>(
+                    stream: widget.bloc!.title,
+                    builder: (context, snapshot) {
+                      return _TitleField(
                         prefilledTitle: widget.homework?.title ?? "",
                         focusNode: titleNode,
-                        onChanged: bloc.changeTitle,
+                        onChanged: widget.bloc!.changeTitle,
                         errorText: snapshot.error?.toString(),
-                      ),
-                    ),
-                  ),
-                  Expanded(
-                    child: SingleChildScrollView(
-                      child: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: <Widget>[
-                          const SizedBox(height: 8),
-                          _CourseTile(editMode: editMode),
-                          const _MobileDivider(),
-                          _TodoUntilPicker(),
-                          const _MobileDivider(),
-                          _SubmissionsSwitch(),
-                          const _MobileDivider(),
-                          _DescriptionField(
-                              oldDescription:
-                                  widget.homework?.description ?? ""),
-                          const _MobileDivider(),
-                          _AttachFile(),
-                          const _MobileDivider(),
-                          _SendNotification(editMode: editMode),
-                          const _MobileDivider(),
-                          _PrivateHomeworkSwitch(editMode: editMode),
-                          const _MobileDivider(),
-                        ],
-                      ),
-                    ),
-                  ),
-                ],
+                      );
+                    }),
               ),
-            );
-          }),
+            ),
+            Expanded(
+              child: SingleChildScrollView(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    const SizedBox(height: 8),
+                    _CourseTile(editMode: editMode),
+                    const _MobileDivider(),
+                    _TodoUntilPicker(),
+                    const _MobileDivider(),
+                    _SubmissionsSwitch(),
+                    const _MobileDivider(),
+                    _DescriptionField(
+                        oldDescription: widget.homework?.description ?? ""),
+                    const _MobileDivider(),
+                    _AttachFile(),
+                    const _MobileDivider(),
+                    _SendNotification(editMode: editMode),
+                    const _MobileDivider(),
+                    _PrivateHomeworkSwitch(editMode: editMode),
+                    const _MobileDivider(),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/app/lib/pages/homework/homework_dialog.dart
+++ b/app/lib/pages/homework/homework_dialog.dart
@@ -632,7 +632,7 @@ class _PrivateHomeworkSwitch extends StatelessWidget {
         child: StreamBuilder<bool>(
           stream: bloc.private,
           builder: (context, snapshot) {
-            return _PrivateTile(
+            return _PrivateHomeworkSwitchBase(
               isPrivate: snapshot.data ?? false,
               onChanged: editMode ? null : bloc.changePrivate,
             );
@@ -643,8 +643,8 @@ class _PrivateHomeworkSwitch extends StatelessWidget {
   }
 }
 
-class _PrivateTile extends StatelessWidget {
-  const _PrivateTile({
+class _PrivateHomeworkSwitchBase extends StatelessWidget {
+  const _PrivateHomeworkSwitchBase({
     required this.isPrivate,
     this.onChanged,
   });

--- a/app/lib/pages/homework/homework_dialog.dart
+++ b/app/lib/pages/homework/homework_dialog.dart
@@ -518,7 +518,7 @@ class _AttachFile extends StatelessWidget {
   }
 }
 
-typedef Res = ({
+typedef _SubmissionsData = ({
   bool isSubmissionEnableable,
   Time submissionTime,
   bool withSubmissions
@@ -529,7 +529,8 @@ class _SubmissionsSwitch extends StatelessWidget {
   Widget build(BuildContext context) {
     final bloc = BlocProvider.of<HomeworkDialogBloc>(context);
 
-    final combined = CombineLatestStream.combine3<bool, Time, bool, Res>(
+    final combined =
+        CombineLatestStream.combine3<bool, Time, bool, _SubmissionsData>(
       bloc.isSubmissionEnableable,
       bloc.submissionTime,
       bloc.withSubmissions,

--- a/app/lib/pages/homework/homework_dialog.dart
+++ b/app/lib/pages/homework/homework_dialog.dart
@@ -21,6 +21,7 @@ import 'package:sharezone/filesharing/dialog/course_tile.dart';
 import 'package:sharezone/markdown/markdown_analytics.dart';
 import 'package:sharezone/markdown/markdown_support.dart';
 import 'package:sharezone/timetable/src/edit_time.dart';
+import 'package:sharezone/util/next_lesson_calculator/next_lesson_calculator.dart';
 import 'package:sharezone/widgets/material/list_tile_with_description.dart';
 import 'package:sharezone/widgets/material/save_button.dart';
 import 'package:sharezone_common/homework_validators.dart';
@@ -34,12 +35,14 @@ class HomeworkDialog extends StatefulWidget {
     Key? key,
     this.homework,
     required this.homeworkDialogApi,
+    required this.nextLessonCalculator,
   }) : super(key: key);
 
   static const tag = "homework-dialog";
 
   final HomeworkDto? homework;
   final HomeworkDialogApi homeworkDialogApi;
+  final NextLessonCalculator nextLessonCalculator;
 
   @override
   State createState() => _HomeworkDialogState();
@@ -51,7 +54,8 @@ class _HomeworkDialogState extends State<HomeworkDialog> {
   @override
   void initState() {
     final markdownAnalytics = BlocProvider.of<MarkdownAnalytics>(context);
-    bloc = HomeworkDialogBloc(widget.homeworkDialogApi, markdownAnalytics,
+    bloc = HomeworkDialogBloc(widget.homeworkDialogApi,
+        widget.nextLessonCalculator, markdownAnalytics,
         homework: widget.homework);
     super.initState();
   }

--- a/app/lib/pages/homework/homework_dialog.dart
+++ b/app/lib/pages/homework/homework_dialog.dart
@@ -593,9 +593,12 @@ class _SubmissionsSwitch extends StatelessWidget {
 }
 
 class _PrivateHomeworkSwitch extends StatelessWidget {
-  const _PrivateHomeworkSwitch({Key? key, this.editMode}) : super(key: key);
+  const _PrivateHomeworkSwitch({
+    Key? key,
+    required this.editMode,
+  }) : super(key: key);
 
-  final bool? editMode;
+  final bool editMode;
 
   @override
   Widget build(BuildContext context) {
@@ -607,22 +610,44 @@ class _PrivateHomeworkSwitch extends StatelessWidget {
         child: StreamBuilder<bool>(
           stream: bloc.private,
           builder: (context, snapshot) {
-            return ListTile(
-              contentPadding:
-                  const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-              leading: const Icon(Icons.security),
-              title: const Text("Privat"),
-              subtitle: const Text("Hausaufgabe nicht mit dem Kurs teilen."),
-              enabled: !editMode!,
-              trailing: Switch.adaptive(
-                value: snapshot.data ?? false,
-                onChanged: !editMode! ? bloc.changePrivate : null,
-              ),
-              onTap: () => bloc.changePrivate(!snapshot.data!),
+            return _PrivateTile(
+              isPrivate: snapshot.data ?? false,
+              onChanged: editMode ? null : bloc.changePrivate,
             );
           },
         ),
       ),
+    );
+  }
+}
+
+class _PrivateTile extends StatelessWidget {
+  const _PrivateTile({
+    required this.isPrivate,
+    this.onChanged,
+  });
+
+  final bool isPrivate;
+
+  /// Called when the user changes if the homework is private.
+  ///
+  /// Passing `null` disables the tile.
+  final Function(bool)? onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final isEnabled = onChanged != null;
+    return ListTile(
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      leading: const Icon(Icons.security),
+      title: const Text("Privat"),
+      subtitle: const Text("Hausaufgabe nicht mit dem Kurs teilen."),
+      enabled: isEnabled,
+      trailing: Switch.adaptive(
+        value: isPrivate,
+        onChanged: isEnabled ? onChanged! : null,
+      ),
+      onTap: isEnabled ? () => onChanged!(!isPrivate) : null,
     );
   }
 }

--- a/app/lib/pages/homework_page.dart
+++ b/app/lib/pages/homework_page.dart
@@ -53,7 +53,8 @@ Future<void> openHomeworkDialogAndShowConfirmationIfSuccessful(
     context,
     IgnoreWillPopScopeWhenIosSwipeBackRoute(
       builder: (context) => HomeworkDialog(
-        homeworkDialogApi: HomeworkDialogApi(api, nextLessonCalculator),
+        homeworkDialogApi: HomeworkDialogApi(api),
+        nextLessonCalculator: nextLessonCalculator,
         homework: homework,
       ),
       settings: const RouteSettings(name: HomeworkDialog.tag),

--- a/app/lib/util/next_lesson_calculator/next_lesson_calculator.dart
+++ b/app/lib/util/next_lesson_calculator/next_lesson_calculator.dart
@@ -17,22 +17,24 @@ import 'package:sharezone/util/api/user_api.dart';
 import 'package:user/user.dart';
 
 class NextLessonCalculator {
-  final TimetableGateway timetableGateway;
-  final UserGateway userGateway;
-  final HolidayService holidayManager;
+  final TimetableGateway _timetableGateway;
+  final UserGateway _userGateway;
+  final HolidayService _holidayManager;
 
   NextLessonCalculator({
-    required this.timetableGateway,
-    required this.userGateway,
-    required this.holidayManager,
-  });
+    required TimetableGateway timetableGateway,
+    required UserGateway userGateway,
+    required HolidayService holidayManager,
+  })  : _timetableGateway = timetableGateway,
+        _userGateway = userGateway,
+        _holidayManager = holidayManager;
 
   Future<Date?> calculateNextLesson(String courseID) async {
-    List<Lesson> lessons = await timetableGateway.getLessonsOfGroup(courseID);
-    AppUser user = await userGateway.get();
+    List<Lesson> lessons = await _timetableGateway.getLessonsOfGroup(courseID);
+    AppUser user = await _userGateway.get();
     List<Holiday?> holidays;
     try {
-      holidays = await holidayManager.load(toStateOrThrow(user.state));
+      holidays = await _holidayManager.load(toStateOrThrow(user.state));
     } catch (e) {
       holidays = [];
     }

--- a/app/test/homework/homework_dialog_bloc_test.dart
+++ b/app/test/homework/homework_dialog_bloc_test.dart
@@ -7,19 +7,30 @@
 // SPDX-License-Identifier: EUPL-1.2
 
 import 'package:analytics/analytics.dart';
+import 'package:date/src/date.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:sharezone/blocs/homework/homework_dialog_bloc.dart';
 import 'package:sharezone/markdown/markdown_analytics.dart';
+import 'package:sharezone/util/next_lesson_calculator/next_lesson_calculator.dart';
 
 import '../analytics/analytics_test.dart';
 
 class MockHomeworkDialogApi extends Mock implements HomeworkDialogApi {}
 
+class MockNextLessonCalculator implements NextLessonCalculator {
+  @override
+  Future<Date?> calculateNextLesson(String courseID) async {
+    return Date('2032-01-03');
+  }
+}
+
 void main() {
   late HomeworkDialogBloc bloc;
   setUp(() {
-    bloc = HomeworkDialogBloc(MockHomeworkDialogApi(),
+    bloc = HomeworkDialogBloc(
+        MockHomeworkDialogApi(),
+        MockNextLessonCalculator(),
         MarkdownAnalytics(Analytics(LocalAnalyticsBackend())));
   });
 


### PR DESCRIPTION
This PR splits up the "is private" and "are submissions enabled" parts of the homework dialog into bloc-agnostic (`xyzBase` widgets) and composing widgets.
Doing this should make changing the homework dialog easier in the future. Also if we ever decide to break the edit and create dialog up into different widgets we need to use the bloc-agnostic base widgets anyways.

Additionally I moved the `NextLessonCalculator` out of the `HomeworkDialogApi` and made its attributes private. This should ease mocking in future widget tests of the homework dialog.