### PR TITLE
Add `mounted` check to `animated_tab_visibility.dart`

### DIFF
--- a/app/lib/homework/shared/animated_tab_visibility.dart
+++ b/app/lib/homework/shared/animated_tab_visibility.dart
@@ -113,7 +113,7 @@ class _AnimatedTabVisibilityState extends State<AnimatedTabVisibility> {
 
   void _animateVisibilityIfNecessary() {
     final shouldBeVisible = _shouldChildBeVisible();
-    if (shouldBeVisible != isVisible) {
+    if (shouldBeVisible != isVisible && mounted) {
       setState(() {
         isVisible = shouldBeVisible;
       });


### PR DESCRIPTION
This should hopefully fix [this issue](https://console.firebase.google.com/u/0/project/sharezone-c2bd8/crashlytics/app/ios:de.codingbrain.sharezone.app/issues/cba0ecb2e24d3674972ac23e99ad4003) in Crashlytics.