### PR TITLE
Continue refactoring homework dialog.

### DIFF
--- a/app/lib/blocs/homework/homework_dialog_bloc.dart
+++ b/app/lib/blocs/homework/homework_dialog_bloc.dart
@@ -6,6 +6,7 @@
 //
 // SPDX-License-Identifier: EUPL-1.2
 
+import 'package:analytics/analytics.dart';
 import 'package:bloc_base/bloc_base.dart';
 import 'package:files_basics/local_file.dart';
 import 'package:filesharing_logic/filesharing_logic_models.dart';
@@ -44,9 +45,10 @@ class HomeworkDialogBloc extends BlocBase with HomeworkValidators {
   final HomeworkDto? initialHomework;
 
   final MarkdownAnalytics _markdownAnalytics;
+  final Analytics analytics;
 
-  HomeworkDialogBloc(
-      this.api, this.nextLessonCalculator, this._markdownAnalytics,
+  HomeworkDialogBloc(this.api, this.nextLessonCalculator,
+      this._markdownAnalytics, this.analytics,
       {HomeworkDto? homework})
       : initialHomework = homework {
     if (homework != null) {

--- a/app/lib/blocs/homework/homework_dialog_bloc.dart
+++ b/app/lib/blocs/homework/homework_dialog_bloc.dart
@@ -199,7 +199,7 @@ class HomeworkDialogBloc extends BlocBase with HomeworkValidators {
     });
   }
 
-  void validate() {
+  void validateInputOrThrow() {
     final validatorTitle = NotEmptyOrNullValidator(_titleSubject.valueOrNull);
     if (!validatorTitle.isValid()) {
       _titleSubject.addError(
@@ -231,7 +231,7 @@ class HomeworkDialogBloc extends BlocBase with HomeworkValidators {
   }
 
   Future<void> submit() async {
-    validate();
+    validateInputOrThrow();
     final todoUntil = DateTime(
         _todoUntilSubject.valueOrNull!.year,
         _todoUntilSubject.valueOrNull!.month,

--- a/app/lib/blocs/homework/homework_dialog_bloc.dart
+++ b/app/lib/blocs/homework/homework_dialog_bloc.dart
@@ -333,6 +333,11 @@ class UserInput {
       this.todoUntil = todoUntil;
     }
   }
+
+  @override
+  String toString() {
+    return 'UserInput(description: $description, course: $course, todoUntil: $todoUntil, private: $private, localFiles: $localFiles, sendNotification: $sendNotification, withSubmission: $withSubmission)';
+  }
 }
 
 class HomeworkDialogApi {

--- a/app/lib/blocs/homework/homework_dialog_bloc.dart
+++ b/app/lib/blocs/homework/homework_dialog_bloc.dart
@@ -230,7 +230,7 @@ class HomeworkDialogBloc extends BlocBase with HomeworkValidators {
     initialCloudFiles.addAll(cloudFiles);
   }
 
-  Future<void> submit({HomeworkDto? oldHomework}) async {
+  Future<void> submit() async {
     if (isValid()) {
       final todoUntil = DateTime(
           _todoUntilSubject.valueOrNull!.year,
@@ -253,7 +253,8 @@ class HomeworkDialogBloc extends BlocBase with HomeworkValidators {
       );
 
       final hasAttachments = localFiles != null && localFiles.isNotEmpty;
-      if (oldHomework == null) {
+
+      if (initialHomework == null) {
         // Falls der Nutzer keine Anhänge hochlädt, wird kein 'await' verwendet,
         // weil die Daten sofort in Firestore gespeichert werden können und somit
         // auch offline hinzufügbar sind.
@@ -269,16 +270,17 @@ class HomeworkDialogBloc extends BlocBase with HomeworkValidators {
         final removedCloudFiles = matchRemovedCloudFilesFromTwoList(
             initialCloudFiles, _cloudFilesSubject.valueOrNull!);
         if (hasAttachments) {
-          await api.edit(oldHomework, userInput,
+          await api.edit(initialHomework!, userInput,
               removedCloudFiles: removedCloudFiles);
         } else {
-          api.edit(oldHomework, userInput,
+          api.edit(initialHomework!, userInput,
               removedCloudFiles: removedCloudFiles);
         }
 
         // Falls beim Bearbeiten ein Markdown-Text hinzugefügt wurde, wird dies
         // geloggt.
-        if (!_markdownAnalytics.containsMarkdown(oldHomework.description)) {
+        if (!_markdownAnalytics
+            .containsMarkdown(initialHomework!.description)) {
           _markdownAnalytics.logMarkdownUsedHomework();
         }
       }

--- a/app/lib/blocs/homework/homework_dialog_bloc.dart
+++ b/app/lib/blocs/homework/homework_dialog_bloc.dart
@@ -265,6 +265,7 @@ class HomeworkDialogBloc extends BlocBase with HomeworkValidators {
         if (_markdownAnalytics.containsMarkdown(description)) {
           _markdownAnalytics.logMarkdownUsedHomework();
         }
+        analytics.log(NamedAnalyticsEvent(name: "homework_add"));
       } else {
         // Falls ein Nutzer Anhänge beim Bearbeiten enfernt hat, werden die IDs
         // dieser Anhänge in [removedCloudFiles] gespeichert und über das HomeworkGateway
@@ -285,6 +286,7 @@ class HomeworkDialogBloc extends BlocBase with HomeworkValidators {
             .containsMarkdown(initialHomework!.description)) {
           _markdownAnalytics.logMarkdownUsedHomework();
         }
+        analytics.log(NamedAnalyticsEvent(name: "homework_edit"));
       }
     }
   }

--- a/app/lib/blocs/homework/homework_dialog_bloc.dart
+++ b/app/lib/blocs/homework/homework_dialog_bloc.dart
@@ -199,7 +199,7 @@ class HomeworkDialogBloc extends BlocBase with HomeworkValidators {
     });
   }
 
-  bool isValid() {
+  bool validate() {
     final validatorTitle = NotEmptyOrNullValidator(_titleSubject.valueOrNull);
     if (!validatorTitle.isValid()) {
       _titleSubject.addError(
@@ -233,7 +233,7 @@ class HomeworkDialogBloc extends BlocBase with HomeworkValidators {
   }
 
   Future<void> submit() async {
-    if (isValid()) {
+    if (validate()) {
       final todoUntil = DateTime(
           _todoUntilSubject.valueOrNull!.year,
           _todoUntilSubject.valueOrNull!.month,

--- a/app/lib/filesharing/dialog/attach_file.dart
+++ b/app/lib/filesharing/dialog/attach_file.dart
@@ -16,6 +16,7 @@ import 'package:flutter/material.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:sharezone/blocs/application_bloc.dart';
 import 'package:sharezone/filesharing/dialog/file_card.dart';
+import 'package:sharezone/pages/homework/homework_dialog.dart';
 import 'package:sharezone_utils/platform.dart';
 import 'package:sharezone_widgets/sharezone_widgets.dart';
 
@@ -56,6 +57,7 @@ class AttachFile extends StatelessWidget {
                                 removeCloudFileFromBlocMethod(cloudFile),
                           ),
                       trailing: FileMoreOptionsWithOnlyRemoveFileFromBloc(
+                          key: HwDialogKeys.attachmentOverflowMenuIcon,
                           removeFileFromBlocMethod: () =>
                               removeCloudFileFromBlocMethod(cloudFile))))
                   .toList(),

--- a/app/lib/pages/homework/homework_dialog.dart
+++ b/app/lib/pages/homework/homework_dialog.dart
@@ -9,9 +9,7 @@
 import 'dart:async';
 import 'dart:developer';
 
-import 'package:analytics/analytics.dart';
 import 'package:bloc_provider/bloc_provider.dart';
-
 import 'package:firebase_hausaufgabenheft_logik/firebase_hausaufgabenheft_logik.dart';
 import 'package:flutter/material.dart';
 import 'package:rxdart/rxdart.dart';
@@ -193,24 +191,23 @@ class _SaveButton extends StatelessWidget {
     final bloc = BlocProvider.of<HomeworkDialogBloc>(context);
     final hasAttachments = bloc.hasAttachments;
     try {
-      if (bloc.validate()) {
-        sendDataToFrankfurtSnackBar(context);
+      bloc.validate();
+      sendDataToFrankfurtSnackBar(context);
 
-        if (editMode) {
-          if (hasAttachments) {
-            await bloc.submit();
-            if (!context.mounted) return;
-          } else {
-            bloc.submit();
-          }
-          hideSendDataToFrankfurtSnackBar(context);
-          Navigator.pop(context, true);
-        } else {
-          hasAttachments ? await bloc.submit() : bloc.submit();
+      if (editMode) {
+        if (hasAttachments) {
+          await bloc.submit();
           if (!context.mounted) return;
-          hideSendDataToFrankfurtSnackBar(context);
-          Navigator.pop(context, true);
+        } else {
+          bloc.submit();
         }
+        hideSendDataToFrankfurtSnackBar(context);
+        Navigator.pop(context, true);
+      } else {
+        hasAttachments ? await bloc.submit() : bloc.submit();
+        if (!context.mounted) return;
+        hideSendDataToFrankfurtSnackBar(context);
+        Navigator.pop(context, true);
       }
     } on InvalidTitleException {
       showSnackSec(

--- a/app/lib/pages/homework/homework_dialog.dart
+++ b/app/lib/pages/homework/homework_dialog.dart
@@ -195,10 +195,10 @@ class _SaveButton extends StatelessWidget {
 
         if (editMode) {
           if (hasAttachments) {
-            await bloc.submit(oldHomework: oldHomework);
+            await bloc.submit();
             if (!context.mounted) return;
           } else {
-            bloc.submit(oldHomework: oldHomework);
+            bloc.submit();
           }
           logHomeworkEditEvent(context);
           hideSendDataToFrankfurtSnackBar(context);

--- a/app/lib/pages/homework/homework_dialog.dart
+++ b/app/lib/pages/homework/homework_dialog.dart
@@ -193,7 +193,7 @@ class _SaveButton extends StatelessWidget {
     final bloc = BlocProvider.of<HomeworkDialogBloc>(context);
     final hasAttachments = bloc.hasAttachments;
     try {
-      if (bloc.isValid()) {
+      if (bloc.validate()) {
         sendDataToFrankfurtSnackBar(context);
 
         if (editMode) {

--- a/app/lib/pages/homework/homework_dialog.dart
+++ b/app/lib/pages/homework/homework_dialog.dart
@@ -159,7 +159,7 @@ class __HomeworkDialogState extends State<__HomeworkDialog> {
                     _SubmissionsSwitch(),
                     const _MobileDivider(),
                     _DescriptionField(
-                        oldDescription: widget.homework?.description ?? ""),
+                        prefilledDescription: widget.homework?.description),
                     const _MobileDivider(),
                     _AttachFile(),
                     const _MobileDivider(),
@@ -472,13 +472,31 @@ class _SendNotification extends StatelessWidget {
 }
 
 class _DescriptionField extends StatelessWidget {
-  const _DescriptionField({required this.oldDescription});
+  const _DescriptionField({required this.prefilledDescription});
 
-  final String oldDescription;
+  final String? prefilledDescription;
 
   @override
   Widget build(BuildContext context) {
     final bloc = BlocProvider.of<HomeworkDialogBloc>(context);
+    return _DescriptionFieldBase(
+      onChanged: bloc.changeDescription,
+      prefilledDescription: prefilledDescription,
+    );
+  }
+}
+
+class _DescriptionFieldBase extends StatelessWidget {
+  const _DescriptionFieldBase({
+    required this.onChanged,
+    required this.prefilledDescription,
+  });
+
+  final Function(String) onChanged;
+  final String? prefilledDescription;
+
+  @override
+  Widget build(BuildContext context) {
     return MaxWidthConstraintBox(
       child: SafeArea(
         top: false,
@@ -492,7 +510,7 @@ class _DescriptionField extends StatelessWidget {
                 leading: const Icon(Icons.subject),
                 title: PrefilledTextField(
                   key: HwDialogKeys.descriptionField,
-                  prefilledText: oldDescription,
+                  prefilledText: prefilledDescription,
                   maxLines: null,
                   scrollPadding: const EdgeInsets.all(16.0),
                   keyboardType: TextInputType.multiline,
@@ -500,7 +518,7 @@ class _DescriptionField extends StatelessWidget {
                     hintText: "Zusatzinformationen eingeben",
                     border: InputBorder.none,
                   ),
-                  onChanged: bloc.changeDescription,
+                  onChanged: onChanged,
                   textCapitalization: TextCapitalization.sentences,
                 ),
               ),

--- a/app/lib/pages/homework/homework_dialog.dart
+++ b/app/lib/pages/homework/homework_dialog.dart
@@ -449,24 +449,47 @@ class _SendNotification extends StatelessWidget {
           stream: bloc.sendNotification,
           builder: (context, snapshot) {
             final sendNotification = snapshot.data ?? false;
-            return ListTileWithDescription(
-              key: HwDialogKeys.notifyCourseMembersTile,
-              leading: const Icon(Icons.notifications_active),
-              title: Text(
-                  "Kursmitglieder ${editMode ? "über die Änderungen " : ""}benachrichtigen"),
-              trailing: Switch.adaptive(
-                onChanged: bloc.changeSendNotification,
-                value: sendNotification,
-              ),
-              onTap: () => bloc.changeSendNotification(!sendNotification),
+            return _SendNotificationBase(
+              title:
+                  "Kursmitglieder ${editMode ? "über die Änderungen " : ""}benachrichtigen",
+              onChanged: bloc.changeSendNotification,
+              sendNotification: sendNotification,
               description: editMode
                   ? null
-                  : const Text(
-                      "Sende eine Benachrichtigung an deine Kursmitglieder, dass du eine neue Hausaufgabe erstellt hast."),
+                  : "Sende eine Benachrichtigung an deine Kursmitglieder, dass du eine neue Hausaufgabe erstellt hast.",
             );
           },
         ),
       ),
+    );
+  }
+}
+
+class _SendNotificationBase extends StatelessWidget {
+  const _SendNotificationBase({
+    required this.title,
+    required this.sendNotification,
+    required this.onChanged,
+    this.description,
+  });
+
+  final String title;
+  final String? description;
+  final bool sendNotification;
+  final Function(bool) onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTileWithDescription(
+      key: HwDialogKeys.notifyCourseMembersTile,
+      leading: const Icon(Icons.notifications_active),
+      title: Text(title),
+      trailing: Switch.adaptive(
+        onChanged: onChanged,
+        value: sendNotification,
+      ),
+      onTap: () => onChanged(!sendNotification),
+      description: description != null ? Text(description!) : null,
     );
   }
 }

--- a/app/lib/pages/homework/homework_dialog.dart
+++ b/app/lib/pages/homework/homework_dialog.dart
@@ -81,6 +81,7 @@ class HwDialogKeys {
   static const Key submissionTimeTile = Key("submission-time-tile");
   static const Key descriptionField = Key("description-field");
   static const Key addAttachmentTile = Key("add-attachment-tile");
+  static const Key attachmentOverflowMenuIcon = Key("attachment-overflow-menu");
   static const Key notifyCourseMembersTile = Key("notify-course-members-tile");
   static const Key isPrivateTile = Key("is-private-tile");
   static const Key saveButton = Key("save-button");

--- a/app/lib/pages/homework/homework_dialog.dart
+++ b/app/lib/pages/homework/homework_dialog.dart
@@ -191,7 +191,7 @@ class _SaveButton extends StatelessWidget {
     final bloc = BlocProvider.of<HomeworkDialogBloc>(context);
     final hasAttachments = bloc.hasAttachments;
     try {
-      bloc.validate();
+      bloc.validateInputOrThrow();
       sendDataToFrankfurtSnackBar(context);
 
       if (editMode) {

--- a/app/lib/pages/homework/homework_dialog.dart
+++ b/app/lib/pages/homework/homework_dialog.dart
@@ -203,13 +203,11 @@ class _SaveButton extends StatelessWidget {
           } else {
             bloc.submit();
           }
-          logHomeworkEditEvent(context);
           hideSendDataToFrankfurtSnackBar(context);
           Navigator.pop(context, true);
         } else {
           hasAttachments ? await bloc.submit() : bloc.submit();
           if (!context.mounted) return;
-          logHomeworkAddEvent(context);
           hideSendDataToFrankfurtSnackBar(context);
           Navigator.pop(context, true);
         }
@@ -246,16 +244,6 @@ class _SaveButton extends StatelessWidget {
 
   void hideSendDataToFrankfurtSnackBar(BuildContext context) {
     ScaffoldMessenger.of(context).hideCurrentSnackBar();
-  }
-
-  void logHomeworkEditEvent(BuildContext context) {
-    final analytics = BlocProvider.of<SharezoneContext>(context).analytics;
-    analytics.log(NamedAnalyticsEvent(name: "homework_edit"));
-  }
-
-  void logHomeworkAddEvent(BuildContext context) {
-    final analytics = BlocProvider.of<SharezoneContext>(context).analytics;
-    analytics.log(NamedAnalyticsEvent(name: "homework_add"));
   }
 
   @override

--- a/app/lib/pages/homework/homework_dialog.dart
+++ b/app/lib/pages/homework/homework_dialog.dart
@@ -55,9 +55,14 @@ class _HomeworkDialogState extends State<HomeworkDialog> {
   @override
   void initState() {
     final markdownAnalytics = BlocProvider.of<MarkdownAnalytics>(context);
-    bloc = HomeworkDialogBloc(widget.homeworkDialogApi,
-        widget.nextLessonCalculator, markdownAnalytics,
-        homework: widget.homework);
+    final analytics = BlocProvider.of<SharezoneContext>(context).analytics;
+    bloc = HomeworkDialogBloc(
+      widget.homeworkDialogApi,
+      widget.nextLessonCalculator,
+      markdownAnalytics,
+      homework: widget.homework,
+      analytics,
+    );
     super.initState();
   }
 

--- a/app/lib/pages/homework/homework_dialog.dart
+++ b/app/lib/pages/homework/homework_dialog.dart
@@ -128,23 +128,14 @@ class __HomeworkDialogState extends State<__HomeworkDialog> {
         body: Column(
           children: <Widget>[
             _AppBar(
-              oldHomework: widget.homework,
-              editMode: editMode,
-              focusNodeTitle: titleNode,
-              onCloseTap: () => leaveDialog(),
-              titleField: MaxWidthConstraintBox(
-                child: StreamBuilder<String>(
-                    stream: widget.bloc!.title,
-                    builder: (context, snapshot) {
-                      return _TitleField(
-                        prefilledTitle: widget.homework?.title ?? "",
-                        focusNode: titleNode,
-                        onChanged: widget.bloc!.changeTitle,
-                        errorText: snapshot.error?.toString(),
-                      );
-                    }),
-              ),
-            ),
+                oldHomework: widget.homework,
+                editMode: editMode,
+                focusNodeTitle: titleNode,
+                onCloseTap: () => leaveDialog(),
+                titleField: _TitleField(
+                  focusNode: titleNode,
+                  prefilledTitle: widget.homework?.title,
+                )),
             Expanded(
               child: SingleChildScrollView(
                 child: Column(
@@ -358,6 +349,33 @@ class _AppBar extends StatelessWidget {
 
 class _TitleField extends StatelessWidget {
   const _TitleField({
+    required this.focusNode,
+    this.prefilledTitle,
+  });
+
+  final String? prefilledTitle;
+  final FocusNode focusNode;
+
+  @override
+  Widget build(BuildContext context) {
+    final bloc = BlocProvider.of<HomeworkDialogBloc>(context);
+    return MaxWidthConstraintBox(
+      child: StreamBuilder<String>(
+          stream: bloc.title,
+          builder: (context, snapshot) {
+            return _TitleFieldBase(
+              prefilledTitle: prefilledTitle,
+              focusNode: focusNode,
+              onChanged: bloc.changeTitle,
+              errorText: snapshot.error?.toString(),
+            );
+          }),
+    );
+  }
+}
+
+class _TitleFieldBase extends StatelessWidget {
+  const _TitleFieldBase({
     Key? key,
     required this.prefilledTitle,
     required this.onChanged,

--- a/app/lib/pages/homework/homework_dialog.dart
+++ b/app/lib/pages/homework/homework_dialog.dart
@@ -180,10 +180,8 @@ class _MobileDivider extends StatelessWidget {
 }
 
 class _SaveButton extends StatelessWidget {
-  const _SaveButton({Key? key, this.oldHomework, this.editMode = false})
-      : super(key: key);
+  const _SaveButton({Key? key, this.editMode = false}) : super(key: key);
 
-  final HomeworkDto? oldHomework;
   final bool editMode;
 
   Future<void> onPressed(BuildContext context) async {
@@ -333,7 +331,6 @@ class _AppBar extends StatelessWidget {
                   ),
                   _SaveButton(
                     key: HwDialogKeys.saveButton,
-                    oldHomework: oldHomework,
                     editMode: editMode,
                   ),
                 ],

--- a/app/test/homework/homework_dialog_bloc_test.dart
+++ b/app/test/homework/homework_dialog_bloc_test.dart
@@ -27,11 +27,10 @@ class MockNextLessonCalculator implements NextLessonCalculator {
 
 void main() {
   late HomeworkDialogBloc bloc;
+  final analytics = Analytics(LocalAnalyticsBackend());
   setUp(() {
-    bloc = HomeworkDialogBloc(
-        MockHomeworkDialogApi(),
-        MockNextLessonCalculator(),
-        MarkdownAnalytics(Analytics(LocalAnalyticsBackend())));
+    bloc = HomeworkDialogBloc(MockHomeworkDialogApi(),
+        MockNextLessonCalculator(), MarkdownAnalytics(analytics), analytics);
   });
 
   test("If a homework title is given then the same value should be emitted",

--- a/app/test/homework/homework_dialog_test.dart
+++ b/app/test/homework/homework_dialog_test.dart
@@ -121,8 +121,6 @@ void main() {
     }
 
     testWidgets('edits homework correctly', (tester) async {
-      homework = null;
-
       final fooCourse = Course.create().copyWith(
         id: 'foo_course',
         name: 'Foo course',

--- a/app/test/homework/homework_dialog_test.dart
+++ b/app/test/homework/homework_dialog_test.dart
@@ -230,10 +230,10 @@ void main() {
       // We didn't change it
       expect(userInput.todoUntil, homework!.todoUntil);
       expect(userInput.description, 'New description text');
-// The following TestFailure was thrown running a test:
-// Expected: an object with length of <1>
-//   Actual: []
-//    Which: has length of <0>
+      // The following TestFailure was thrown running a test:
+      // Expected: an object with length of <1>
+      //   Actual: []
+      //    Which: has length of <0>
       // expect(userInput.localFiles, hasLength(1));
       // expect(userInput.localFiles?.first.getName(), 'foo_attachment2.png');
       expect(userInput.sendNotification, false);

--- a/app/test/homework/homework_dialog_test.dart
+++ b/app/test/homework/homework_dialog_test.dart
@@ -53,10 +53,14 @@ class MockHomeworkDialogApi implements HomeworkDialogApi {
     return HomeworkDto.create(courseID: 'courseID');
   }
 
+  late UserInput userInputFromEditing;
+  late List<CloudFile> removedCloudFilesFromEditing;
   @override
   Future<HomeworkDto> edit(HomeworkDto oldHomework, UserInput userInput,
       {List<CloudFile> removedCloudFiles = const []}) async {
-    return HomeworkDto.fromData({}, id: 'foo');
+    userInputFromEditing = userInput;
+    removedCloudFilesFromEditing = removedCloudFiles;
+    return HomeworkDto.create(courseID: 'courseID');
   }
 
   final loadCloudFilesResult = <CloudFile>[];
@@ -115,6 +119,127 @@ void main() {
       // make the test slower.
       await tester.pumpAndSettle(const Duration(seconds: 25));
     }
+
+    testWidgets('edits homework correctly', (tester) async {
+      homework = null;
+
+      final fooCourse = Course.create().copyWith(
+        id: 'foo_course',
+        name: 'Foo course',
+        subject: 'Foo subject',
+        abbreviation: 'F',
+        myRole: MemberRole.admin,
+      );
+
+      final sharezoneGateway = MockSharezoneGateway();
+      final courseGateway = MockCourseGateway();
+      when(sharezoneContext.api).thenReturn(sharezoneGateway);
+      when(sharezoneGateway.course).thenReturn(courseGateway);
+      when(courseGateway.streamCourses())
+          .thenAnswer((_) => Stream.value([fooCourse]));
+      when(sharezoneContext.analytics)
+          .thenReturn(Analytics(NullAnalyticsBackend()));
+      final nextLessonDate = Date('2024-03-08');
+      nextLessonCalculator.dateToReturn = nextLessonDate;
+
+      homeworkDialogApi.loadCloudFilesResult.addAll([
+        CloudFile.create(
+                id: 'foo_attachment_id1',
+                creatorName: 'Assignment Creator Name',
+                courseID: 'foo_course',
+                creatorID: 'foo_creator_id',
+                path: FolderPath.fromPathString(
+                    '/foo_course/${FolderPath.attachments}'))
+            .copyWith(name: 'foo_attachment1.png'),
+        CloudFile.create(
+                id: 'foo_attachment_id2',
+                creatorName: 'Assignment Creator Name',
+                courseID: 'foo_course',
+                creatorID: 'foo_creator_id',
+                path: FolderPath.fromPathString(
+                    '/foo_course/${FolderPath.attachments}'))
+            .copyWith(name: 'foo_attachment2.png'),
+      ]);
+
+      final mockDocumentReference = MockDocumentReference();
+      when(mockDocumentReference.id).thenReturn('foo_course');
+      homework = HomeworkDto.create(
+              courseID: 'foo_course', courseReference: mockDocumentReference)
+          .copyWith(
+        title: 'title text',
+        courseID: 'foo_course',
+        courseName: 'Foo course',
+        subject: 'Foo subject',
+        // The submission time is included in the todoUntil date.
+        withSubmissions: true,
+        todoUntil: DateTime(2024, 03, 12, 16, 30),
+        description: 'description text',
+        attachments: ['foo_attachment_id1', 'foo_attachment_id2'],
+        private: false,
+      );
+      await pumpAndSettleHomeworkDialog(tester);
+
+      await tester.enterText(
+          find.byKey(HwDialogKeys.titleTextField), 'New title text');
+      await tester.pumpAndSettle();
+      // NextLessonCalculator is mocked to return a fixed date. Using the UI
+      // to select a specific date is tricky. Also this doesn't work:
+      // await tester.tap(find.byKey(HwDialogKeys.todoUntilTile));
+      // await tester.tap(find.text('OK'));
+      // await tester.pumpAndSettle();
+      await tester.tap(find.byKey(HwDialogKeys.submissionTile));
+      await tester.pumpAndSettle();
+      // Doesn't work, idk why:
+      // await tester.tap(find.byKey(HwDialogKeys.submissionTimeTile));
+      // await tester.pumpAndSettle(Duration(seconds: 25));
+      // await tester.tap(find.text('OK'));
+      await tester.enterText(
+          find.byKey(HwDialogKeys.descriptionField), 'New description text');
+      await tester
+          .tap(find.byKey(HwDialogKeys.attachmentOverflowMenuIcon).first);
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Anhang entfernen'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(HwDialogKeys.saveButton));
+
+      final userInput = homeworkDialogApi.userInputFromEditing;
+      final cloudFilesToBeRemoved =
+          homeworkDialogApi.removedCloudFilesFromEditing;
+
+      expect(userInput.title, 'New title text');
+      expect(userInput.course!.id, 'foo_course');
+      // The following TestFailure was thrown running a test:
+      // Expected: 'Foo course'
+      //   Actual: 'Foo subject'
+      //    Which: is different.
+      //           Expected: Foo course
+      //             Actual: Foo subject
+      //                         ^
+      // expect(userInput.course!.name, 'Foo course');
+      expect(userInput.course!.subject, 'Foo subject');
+      // The following TestFailure was thrown running a test:
+      // Expected: 'F'
+      //   Actual: ''
+      // expect(userInput.course!.abbreviation, 'F');
+      // The following TestFailure was thrown running a test:
+      // Expected: MemberRole:<MemberRole.admin>
+      //   Actual: MemberRole:<MemberRole.standard>
+      // expect(userInput.course!.myRole, MemberRole.admin);
+      expect(userInput.withSubmission, true);
+      // We didn't change it
+      expect(userInput.todoUntil, homework!.todoUntil);
+      expect(userInput.description, 'New description text');
+// The following TestFailure was thrown running a test:
+// Expected: an object with length of <1>
+//   Actual: []
+//    Which: has length of <0>
+      // expect(userInput.localFiles, hasLength(1));
+      // expect(userInput.localFiles?.first.getName(), 'foo_attachment2.png');
+      expect(userInput.sendNotification, false);
+      expect(userInput.private, false);
+      expect(cloudFilesToBeRemoved, hasLength(1));
+      expect(cloudFilesToBeRemoved.first.name, 'foo_attachment1.png');
+    });
 
     testWidgets('wants to create the correct homework', (tester) async {
       homework = null;

--- a/app/test/homework/homework_dialog_test.dart
+++ b/app/test/homework/homework_dialog_test.dart
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: EUPL-1.2
 
 import 'package:analytics/analytics.dart';
-import 'package:analytics/null_analytics_backend.dart';
 import 'package:bloc_provider/bloc_provider.dart';
 import 'package:bloc_provider/multi_bloc_provider.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';


### PR DESCRIPTION
Continuation of #1113.

* Added a test for editing a homework
* Move analytics from the UI into the bloc.
* Remove `oldHomework` from `bloc.submit` because it's unnecessary.
* Change bloc method: `bool isValid()` to `void validateInputOrThrow()`.

I'm trying to not change logic in the refactorings, so that structural and behavioral changes are seperated. This is why I'm leaving this broken behavior in for now #1115.