### PR TITLE
Fix displaying course name when editing homework.

### DIFF
--- a/app/lib/blocs/homework/homework_dialog_bloc.dart
+++ b/app/lib/blocs/homework/homework_dialog_bloc.dart
@@ -65,7 +65,7 @@ class HomeworkDialogBloc extends BlocBase with HomeworkValidators {
 
       final c = Course.create().copyWith(
         subject: homework.subject,
-        name: homework.subject,
+        name: homework.courseName,
         sharecode: "000000",
         abbreviation: homework.subjectAbbreviation,
         id: homework.courseReference!.id,

--- a/app/test/homework/homework_dialog_test.dart
+++ b/app/test/homework/homework_dialog_test.dart
@@ -209,14 +209,7 @@ void main() {
 
       expect(userInput.title, 'New title text');
       expect(userInput.course!.id, 'foo_course');
-      // The following TestFailure was thrown running a test:
-      // Expected: 'Foo course'
-      //   Actual: 'Foo subject'
-      //    Which: is different.
-      //           Expected: Foo course
-      //             Actual: Foo subject
-      //                         ^
-      // expect(userInput.course!.name, 'Foo course');
+      expect(userInput.course!.name, 'Foo course');
       expect(userInput.course!.subject, 'Foo subject');
       // The following TestFailure was thrown running a test:
       // Expected: 'F'
@@ -379,7 +372,7 @@ void main() {
       await pumpAndSettleHomeworkDialog(tester);
 
       expect(find.text('title text', findRichText: true), findsOneWidget);
-      expect(find.text('Foo subject'), findsOneWidget);
+      expect(find.text('Foo course'), findsOneWidget);
       // Not found, idk why:
       // expect(find.text('12. März 2024'), findsOneWidget);
       expect(find.text('Mit Abgabe'), findsOneWidget);


### PR DESCRIPTION
**Before**
| ![grafik](https://github.com/SharezoneApp/sharezone-app/assets/29028262/b979f3f6-ac12-4af6-993a-a6588541fc4a) | ![grafik](https://github.com/SharezoneApp/sharezone-app/assets/29028262/1f3de2a7-4a95-4b4b-85fb-d9c4592897cb) |
|---|---|

**After**
| ![grafik](https://github.com/SharezoneApp/sharezone-app/assets/29028262/1a229d7b-9c92-48dd-8eca-478fd38dd6f2) | ![grafik](https://github.com/SharezoneApp/sharezone-app/assets/29028262/cdb1c1e3-cba4-466a-95a3-9ff5cc90c4c0) |
|---|---|