### PR TITLE
Change `_DashboardPageFAB` from `StatefulWidget` to `StatelessWidget`

### DIFF
--- a/app/lib/dashboard/dashboard_page.dart
+++ b/app/lib/dashboard/dashboard_page.dart
@@ -99,7 +99,7 @@ class _DashboardPageState extends State<DashboardPage> {
       ),
       navigationItem: NavigationItem.overview,
       body: const DashboardPageBody(),
-      floatingActionButton: _DashboardPageFAB(),
+      floatingActionButton: const _DashboardPageFAB(),
     );
   }
 }

--- a/app/lib/dashboard/widgets/dashboard_fab.dart
+++ b/app/lib/dashboard/widgets/dashboard_fab.dart
@@ -10,30 +10,10 @@ part of '../dashboard_page.dart';
 
 enum _DashboardFabResult { homework, exam, event, lesson, blackboard }
 
-class _DashboardPageFAB extends StatefulWidget {
-  @override
-  _DashboardPageFABState createState() => _DashboardPageFABState();
-}
+class _DashboardPageFAB extends StatelessWidget {
+  const _DashboardPageFAB();
 
-class _DashboardPageFABState extends State<_DashboardPageFAB> {
-  bool open = false;
-
-  @override
-  Widget build(BuildContext context) {
-    return MatchingTypeOfUserBuilder(
-      expectedTypeOfUser: TypeOfUser.parent,
-      matchesTypeOfUserWidget: Container(),
-      notMatchingWidget: ModalFloatingActionButton(
-        heroTag: 'sharezone-fab',
-        tooltip: 'Neue Elemente hinzufügen',
-        label: 'Hinzufügen',
-        icon: const Icon(Icons.add),
-        onPressed: () => openDashboardFabSheet(context),
-      ),
-    );
-  }
-
-  Future<void> openDashboardFabSheet(BuildContext buildContext) async {
+  Future<void> openDashboardFabSheet(BuildContext context) async {
     final analytics = DashboardAnalytics(Analytics(getBackend()));
     analytics.logOpenFabSheet();
 
@@ -69,6 +49,21 @@ class _DashboardPageFABState extends State<_DashboardPageFAB> {
       default:
         break;
     }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MatchingTypeOfUserBuilder(
+      expectedTypeOfUser: TypeOfUser.parent,
+      matchesTypeOfUserWidget: Container(),
+      notMatchingWidget: ModalFloatingActionButton(
+        heroTag: 'sharezone-fab',
+        tooltip: 'Neue Elemente hinzufügen',
+        label: 'Hinzufügen',
+        icon: const Icon(Icons.add),
+        onPressed: () => openDashboardFabSheet(context),
+      ),
+    );
   }
 }
 


### PR DESCRIPTION
The widget `_DashboardPageFAB` was a `StatefulWidget` but never used `setState` or similar. It could also maybe fix the [issue with the context](https://console.firebase.google.com/u/0/project/sharezone-c2bd8/crashlytics/app/ios:de.codingbrain.sharezone.app/issues/03874eb9a8392a1e6308fa7f3c040db2) that we have tracked in Crashlytics.

Related to: https://github.com/flutter/flutter/issues/135389