### PR TITLE
Add `--max-find-build-wait` when publishing to App Store Connect

### DIFF
--- a/tools/sz_repo_cli/lib/src/common/src/app_store_connect_utils.dart
+++ b/tools/sz_repo_cli/lib/src/common/src/app_store_connect_utils.dart
@@ -203,6 +203,8 @@ Future<void> publishToAppStoreConnect({
       // See: https://github.com/codemagic-ci-cd/cli-tools/blob/master/docs/app-store-connect/publish.md#--max-build-processing-wait--wmax_build_processing_wait
       '--max-build-processing-wait',
       '60',
+      '--max-find-build-wait',
+      '60',
       // Cancels previous submissions for the application in App Store Connect
       // before creating a new submission if the submissions are in a state
       // where it is possible.


### PR DESCRIPTION
When publishing to App Store Connect, finding the build sometimes takes longer than the default 10 minutes. This results in a failed deployment. Therefore, we set the `--max-find-build-wait` to 60 minutes.