### PR TITLE
Fix wrong section title for homeworks in next month.

### DIFF
--- a/lib/hausaufgabenheft_logik/lib/src/open_homeworks/sort_and_subcategorization/todo_date_subcategorizer.dart
+++ b/lib/hausaufgabenheft_logik/lib/src/open_homeworks/sort_and_subcategorization/todo_date_subcategorizer.dart
@@ -22,8 +22,8 @@ class TodoDateSubcategorizer extends Subcategorizer {
   List<HomeworkSectionView> subcategorize(HomeworkList homeworks) {
     final latestHomeworkList = homeworks;
     final now = currentDate;
-    final tomorrow = now.addDaysWithNoChecking(1);
-    final in2Days = tomorrow.addDaysWithNoChecking(1);
+    final tomorrow = now.addDays(1);
+    final in2Days = tomorrow.addDays(1);
 
     final List<HomeworkReadModel> overdueHomework = latestHomeworkList
         .where((h) => Date.fromDateTime(h.todoDate) < now)

--- a/lib/hausaufgabenheft_logik/test/homework_page_bloc_test.dart
+++ b/lib/hausaufgabenheft_logik/test/homework_page_bloc_test.dart
@@ -35,10 +35,11 @@ void main() {
     late HomeworkPageBloc bloc;
     late InMemoryHomeworkRepository repository;
     late HomeworkSortingCache homeworkSortingCache;
+    late KeyValueStore kvs;
 
     setUp(() {
       repository = createRepositoy();
-      final kvs = InMemoryKeyValueStore();
+      kvs = InMemoryKeyValueStore();
       bloc = createBloc(repository, keyValueStore: kvs);
       homeworkSortingCache = HomeworkSortingCache(kvs);
     });
@@ -57,21 +58,16 @@ void main() {
         // https://github.com/SharezoneApp/sharezone-app/issues/53
         'Regressions test: Shows "Morgen" as section title if today is end of month (e.g. 31.10) and tomorrow is first of next month (e.g. 01.11)',
         () async {
-      repository = createRepositoy();
-      final kvs = InMemoryKeyValueStore();
       bloc = createBloc(repository,
           keyValueStore: kvs, getCurrentDateTime: () => DateTime(2023, 10, 31));
-      homeworkSortingCache = HomeworkSortingCache(kvs);
-
       await addToRepository([
         createHomework(
             id: 'hw', todoDate: const Date(year: 2023, month: 11, day: 1))
-      ], repository);
+      ]);
 
       bloc.add(LoadHomeworks());
 
       Success success = await bloc.stream.whereType<Success>().first;
-
       expect(success.open.sections.first.title, 'Morgen');
     });
 

--- a/lib/hausaufgabenheft_logik/test/homework_page_bloc_test.dart
+++ b/lib/hausaufgabenheft_logik/test/homework_page_bloc_test.dart
@@ -54,6 +54,28 @@ void main() {
     }
 
     test(
+        // https://github.com/SharezoneApp/sharezone-app/issues/53
+        'Regressions test: Shows "Morgen" as section title if today is end of month (e.g. 31.10) and tomorrow is first of next month (e.g. 01.11)',
+        () async {
+      repository = createRepositoy();
+      final kvs = InMemoryKeyValueStore();
+      bloc = createBloc(repository,
+          keyValueStore: kvs, getCurrentDateTime: () => DateTime(2023, 10, 31));
+      homeworkSortingCache = HomeworkSortingCache(kvs);
+
+      await addToRepository([
+        createHomework(
+            id: 'hw', todoDate: const Date(year: 2023, month: 11, day: 1))
+      ], repository);
+
+      bloc.add(LoadHomeworks());
+
+      Success success = await bloc.stream.whereType<Success>().first;
+
+      expect(success.open.sections.first.title, 'Morgen');
+    });
+
+    test(
         'Regressions Test für #954 "Wenn man Hausaufgaben nach Fach sortiert und dann eine Aufgabe abhakt wechselt die App automatisch wieder in die Ansicht nach Datum."',
         () async {
       await addToRepository([createHomework(id: 'hw')]);
@@ -277,8 +299,8 @@ void main() {
     });
 
     test('date subcategory titles are only shown when necessary', () async {
-      final tomorrow = createHomework(
-          title: 'abc', todoDate: Date.now().addDaysWithNoChecking(1));
+      final tomorrow =
+          createHomework(title: 'abc', todoDate: Date.now().addDays(1));
       await addToRepository([tomorrow]);
       bloc.add(LoadHomeworks());
 

--- a/lib/hausaufgabenheft_logik/test/homework_page_bloc_test.dart
+++ b/lib/hausaufgabenheft_logik/test/homework_page_bloc_test.dart
@@ -56,6 +56,7 @@ void main() {
 
     test(
         // https://github.com/SharezoneApp/sharezone-app/issues/53
+        // https://github.com/SharezoneApp/sharezone-app/pull/1134
         'Regressions test: Shows "Morgen" as section title if today is end of month (e.g. 31.10) and tomorrow is first of next month (e.g. 01.11)',
         () async {
       bloc = createBloc(repository,


### PR DESCRIPTION
The heading "Später" (later) was wrongly shown if the current day is the end of month and the due date for the homework is the start of the next month. This was caused by using `date.addDaysWithNoChecking` instead of `date.addDays`.

Fixes https://github.com/SharezoneApp/sharezone-app/issues/53.
