### PR TITLE
Update Codemagic CLI Tools version to 0.46.2

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -124,7 +124,7 @@ jobs:
           fvm config --cache-path '${{ runner.tool_cache }}/flutter'
 
       - name: Install Codemagic CLI Tools
-        run: pip3 install codemagic-cli-tools==0.46.0
+        run: pip3 install codemagic-cli-tools==0.46.2
 
       - name: Setup signing
         working-directory: app/android
@@ -212,7 +212,7 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
 
       - name: Install Codemagic CLI Tools
-        run: pip3 install codemagic-cli-tools==0.46.0
+        run: pip3 install codemagic-cli-tools==0.46.2
 
       - name: Set Flutter version from FVM config file to environment variables
         uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b
@@ -279,7 +279,7 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
 
       - name: Install Codemagic CLI Tools
-        run: pip3 install codemagic-cli-tools==0.46.0
+        run: pip3 install codemagic-cli-tools==0.46.2
 
       - name: Set Flutter version from FVM config file to environment variables
         uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
 
       - name: Install Codemagic CLI Tools
-        run: pip3 install codemagic-cli-tools==0.46.0
+        run: pip3 install codemagic-cli-tools==0.46.2
 
       - name: Set Flutter version from FVM config file to environment variables
         uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b
@@ -163,7 +163,7 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
 
       - name: Install Codemagic CLI Tools
-        run: pip3 install codemagic-cli-tools==0.46.0
+        run: pip3 install codemagic-cli-tools==0.46.2
 
       - name: Setup signing
         working-directory: app/android
@@ -230,7 +230,7 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
 
       - name: Install Codemagic CLI Tools
-        run: pip3 install codemagic-cli-tools==0.46.0
+        run: pip3 install codemagic-cli-tools==0.46.2
 
       - name: Set Flutter version from FVM config file to environment variables
         uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b

--- a/.github/workflows/integration_tests_app_ci.yml
+++ b/.github/workflows/integration_tests_app_ci.yml
@@ -297,7 +297,7 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
 
       - name: Install Codemagic CLI Tools
-        run: pip3 install codemagic-cli-tools==0.46.0
+        run: pip3 install codemagic-cli-tools==0.46.2
 
       - name: Setup signing
         env:

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
 
       - name: Install Codemagic CLI Tools
-        run: pip3 install codemagic-cli-tools==0.46.0
+        run: pip3 install codemagic-cli-tools==0.46.2
 
       - name: Set Flutter version from FVM config file to environment variables
         uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b
@@ -165,7 +165,7 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
 
       - name: Install Codemagic CLI Tools
-        run: pip3 install codemagic-cli-tools==0.46.0
+        run: pip3 install codemagic-cli-tools==0.46.2
 
       - name: Setup signing
         working-directory: app/android
@@ -232,7 +232,7 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
 
       - name: Install Codemagic CLI Tools
-        run: pip3 install codemagic-cli-tools==0.46.0
+        run: pip3 install codemagic-cli-tools==0.46.2
 
       - name: Set Flutter version from FVM config file to environment variables
         uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b


### PR DESCRIPTION
Fixes the following error in the "Setup signing" step:
```
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/Current/bin/app-store-connect", line 5, in <module>
    from codemagic.tools import AppStoreConnect
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/codemagic/tools/__init__.py", line 1, in <module>
    from .android_app_bundle import AndroidAppBundle
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/codemagic/tools/android_app_bundle.py", line 12, in <module>
    from codemagic.models import AndroidSigningInfo
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/codemagic/models/__init__.py", line 6, in <module>
    from .code_sign_entitlements import CodeSignEntitlements
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/codemagic/models/code_sign_entitlements.py", line 8, in <module>
    from distutils.version import LooseVersion
ModuleNotFoundError: No module named 'distutils'
Error: Process completed with exit code 1.
```