### PR TITLE
Install setuptools before codemagic-cli-tools

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -124,7 +124,9 @@ jobs:
           fvm config --cache-path '${{ runner.tool_cache }}/flutter'
 
       - name: Install Codemagic CLI Tools
-        run: pip3 install codemagic-cli-tools==0.46.2
+        run: |
+          pip3 install setuptools
+          pip3 install codemagic-cli-tools==0.46.2
 
       - name: Setup signing
         working-directory: app/android
@@ -212,7 +214,9 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
 
       - name: Install Codemagic CLI Tools
-        run: pip3 install codemagic-cli-tools==0.46.2
+        run: |
+          pip3 install setuptools
+          pip3 install codemagic-cli-tools==0.46.2
 
       - name: Set Flutter version from FVM config file to environment variables
         uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b
@@ -279,7 +283,9 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
 
       - name: Install Codemagic CLI Tools
-        run: pip3 install codemagic-cli-tools==0.46.2
+        run: |
+          pip3 install setuptools
+          pip3 install codemagic-cli-tools==0.46.2
 
       - name: Set Flutter version from FVM config file to environment variables
         uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -69,7 +69,9 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
 
       - name: Install Codemagic CLI Tools
-        run: pip3 install codemagic-cli-tools==0.46.2
+        run: |
+          pip3 install setuptools
+          pip3 install codemagic-cli-tools==0.46.2
 
       - name: Set Flutter version from FVM config file to environment variables
         uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b
@@ -163,7 +165,9 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
 
       - name: Install Codemagic CLI Tools
-        run: pip3 install codemagic-cli-tools==0.46.2
+        run: |
+          pip3 install setuptools
+          pip3 install codemagic-cli-tools==0.46.2
 
       - name: Setup signing
         working-directory: app/android
@@ -230,7 +234,9 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
 
       - name: Install Codemagic CLI Tools
-        run: pip3 install codemagic-cli-tools==0.46.2
+        run: |
+          pip3 install setuptools
+          pip3 install codemagic-cli-tools==0.46.2
 
       - name: Set Flutter version from FVM config file to environment variables
         uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b

--- a/.github/workflows/integration_tests_app_ci.yml
+++ b/.github/workflows/integration_tests_app_ci.yml
@@ -297,7 +297,9 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
 
       - name: Install Codemagic CLI Tools
-        run: pip3 install codemagic-cli-tools==0.46.2
+        run: |
+          pip3 install setuptools
+          pip3 install codemagic-cli-tools==0.46.2
 
       - name: Setup signing
         env:

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -69,7 +69,9 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
 
       - name: Install Codemagic CLI Tools
-        run: pip3 install codemagic-cli-tools==0.46.2
+        run: |
+          pip3 install setuptools
+          pip3 install codemagic-cli-tools==0.46.2
 
       - name: Set Flutter version from FVM config file to environment variables
         uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b
@@ -165,7 +167,9 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
 
       - name: Install Codemagic CLI Tools
-        run: pip3 install codemagic-cli-tools==0.46.2
+        run: |
+          pip3 install setuptools
+          pip3 install codemagic-cli-tools==0.46.2
 
       - name: Setup signing
         working-directory: app/android
@@ -232,7 +236,9 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
 
       - name: Install Codemagic CLI Tools
-        run: pip3 install codemagic-cli-tools==0.46.2
+        run: |
+          pip3 install setuptools
+          pip3 install codemagic-cli-tools==0.46.2
 
       - name: Set Flutter version from FVM config file to environment variables
         uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b


### PR DESCRIPTION
Try installing `setuptools` package to fix the codemagic-cli-tools errors.  
See https://github.com/codemagic-ci-cd/cli-tools/issues/369 for more information.