### PR TITLE
Use `canvaskit` as web renderer for pull request previews

### DIFF
--- a/.github/workflows/unsafe_app_ci.yml
+++ b/.github/workflows/unsafe_app_ci.yml
@@ -165,6 +165,7 @@ jobs:
         run: |
           fvm flutter build web \
             --release \
+            --web-renderer canvaskit \
             --target=lib/main_dev.dart
 
       - name: Deploy to Firebase Hosting (sharezone-debug)


### PR DESCRIPTION
Since we also use the CanvasKit renderer for production, we should also use it for our pull request previews.