### PR TITLE
Fix `sz test --update-goldens` command

### DIFF
--- a/tools/sz_repo_cli/lib/src/commands/src/test_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/test_command.dart
@@ -29,8 +29,7 @@ class TestCommand extends ConcurrentCommand {
     );
     argParser.addFlag(
       'update-goldens',
-      help:
-          'Update golden tests. Is not used if "exclude-goldens" is set to "true".',
+      help: 'Update golden tests.',
       defaultsTo: false,
       negatable: false,
     );
@@ -126,7 +125,7 @@ Future<void> _runTestsFlutter(
   required bool onlyGoldens,
   required bool updateGoldens,
 }) async {
-  if (onlyGoldens) {
+  if (onlyGoldens || !excludeGoldens) {
     if (!package.hasGoldenTestsDirectory) {
       return;
     }


### PR DESCRIPTION
When you executed `sz test --update-goldens` the CLI ignored `--update-goldens` and executed the tests. You had to explicitly add the `--only-goldens` flag, so

```sh
sz test --update-goldens --only-goldens
```

After this PR you need

```sh
sz test --update-goldens
```