### PR TITLE
Add `go_router` to our website and use path URL strategy instead of hash URL strategy

### DIFF
--- a/website/firebase.json
+++ b/website/firebase.json
@@ -121,28 +121,23 @@
       },
       {
         "source": "/impressum",
-        "destination": "https://sharezone.net/#imprint-page",
+        "destination": "https://sharezone.net/imprint",
         "type": 302
       },
       {
         "source": "/datenschutzerklaerung",
-        "destination": "https://sharezone.net/privacy-app#privacy-app",
+        "destination": "https://sharezone.net/privacy-policy",
         "type": 302
       },
       {
         "source": "/dse",
-        "destination": "https://sharezone.net/privacy-app#privacy-app",
+        "destination": "https://sharezone.net/privacy-policy",
         "type": 302
       },
       {
         "source": "/dse-v1-0-0-pdf",
         "destination": "https://firebasestorage.googleapis.com/v0/b/sharezone-c2bd8.appspot.com/o/Legal%2FDatenschutzerkl%C3%A4rung%20Sharezone%20v1.0.0.pdf?alt=media&token=b48bcd88-013f-4d69-9501-e55ef8d10719",
         "type": 302
-      },
-      {
-        "source": "/support",
-        "destination": "https://sharezone.net/#support-page",
-        "type": 301
       },
       {
         "source": "/macos-direct",
@@ -156,7 +151,7 @@
       },
       {
         "source": "/imprint#privacy-app",
-        "destination": "https://sharezone.net/#privacy-app",
+        "destination": "https://sharezone.net/privacy-policy",
         "type": 302
       },
       {

--- a/website/lib/footer.dart
+++ b/website/lib/footer.dart
@@ -8,6 +8,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:go_router/go_router.dart';
 import 'package:sharezone_website/legal/imprint_page.dart';
 import 'package:sharezone_website/legal/privacy_policy.dart';
 import 'package:sharezone_website/support_page.dart';
@@ -263,7 +264,7 @@ class _FooterSection extends StatelessWidget {
                 text: l.title,
                 onTap: () {
                   if (l.link == null) {
-                    Navigator.pushNamed(context, l.tag!);
+                    context.go('/${l.tag}');
                   } else {
                     launchUrl(l.link!);
                   }

--- a/website/lib/home/home_page.dart
+++ b/website/lib/home/home_page.dart
@@ -31,8 +31,6 @@ bool isPhone(BuildContext context) {
 class HomePage extends StatelessWidget {
   const HomePage({super.key});
 
-  static const tag = "home-page";
-
   @override
   Widget build(BuildContext context) {
     return const PageTemplate(

--- a/website/lib/home/src/support.dart
+++ b/website/lib/home/src/support.dart
@@ -8,6 +8,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:go_router/go_router.dart';
 import 'package:sharezone_website/widgets/headline.dart';
 import 'package:sharezone_website/widgets/image_text.dart';
 import 'package:sharezone_website/widgets/section_action_button.dart';
@@ -40,7 +41,7 @@ class Support extends StatelessWidget {
             const SizedBox(height: 20),
             SectionActionButton(
               text: "Support kontaktieren",
-              onTap: () => Navigator.pushNamed(context, SupportPage.tag),
+              onTap: () => context.go('/$SupportPage.tag'),
             ),
           ],
         ),

--- a/website/lib/legal/imprint_page.dart
+++ b/website/lib/legal/imprint_page.dart
@@ -18,7 +18,7 @@ import 'imprint.dart';
 class ImprintPage extends StatelessWidget {
   const ImprintPage({super.key});
 
-  static const tag = 'imprint-page';
+  static const tag = 'imprint';
 
   @override
   Widget build(BuildContext context) {

--- a/website/lib/legal/privacy_policy.dart
+++ b/website/lib/legal/privacy_policy.dart
@@ -14,7 +14,7 @@ import 'package:sharezone_website/widgets/max_width_constraint_box.dart';
 class PrivacyPolicyPage extends StatelessWidget {
   const PrivacyPolicyPage({super.key});
 
-  static const tag = "privacy-app";
+  static const tag = "privacy-policy";
 
   @override
   Widget build(BuildContext context) {

--- a/website/lib/main.dart
+++ b/website/lib/main.dart
@@ -7,32 +7,63 @@
 // SPDX-License-Identifier: EUPL-1.2
 
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:sharezone_website/support_page.dart';
+// ignore: depend_on_referenced_packages
+import 'package:flutter_web_plugins/url_strategy.dart';
 
 import 'home/home_page.dart';
 import 'legal/imprint_page.dart';
 import 'legal/privacy_policy.dart';
 
-void main() => runApp(const MyApp());
+void main() {
+  usePathUrlStrategy();
+  runApp(const MyApp());
+}
 
 class SharezoneStyle {
   static const primaryColor = Color(0xFF68B3E9);
   static const font = 'Rubik';
 }
 
+/// The route configuration.
+final GoRouter _router = GoRouter(
+  routes: <RouteBase>[
+    GoRoute(
+      path: '/',
+      builder: (BuildContext context, GoRouterState state) => const HomePage(),
+      routes: <RouteBase>[
+        GoRoute(
+          path: ImprintPage.tag,
+          builder: (BuildContext context, GoRouterState state) {
+            return const ImprintPage();
+          },
+        ),
+        GoRoute(
+          path: SupportPage.tag,
+          builder: (BuildContext context, GoRouterState state) {
+            return const SupportPage();
+          },
+        ),
+        GoRoute(
+          path: PrivacyPolicyPage.tag,
+          builder: (BuildContext context, GoRouterState state) {
+            return const PrivacyPolicyPage();
+          },
+        ),
+      ],
+    ),
+  ],
+);
+
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return MaterialApp.router(
+      routerConfig: _router,
       title: 'Sharezone - Vernetzter Schulplaner',
-      routes: {
-        HomePage.tag: (context) => const HomePage(),
-        ImprintPage.tag: (context) => const ImprintPage(),
-        SupportPage.tag: (context) => const SupportPage(),
-        PrivacyPolicyPage.tag: (context) => const PrivacyPolicyPage(),
-      },
       theme: ThemeData(
         useMaterial3: false,
         primaryColor: SharezoneStyle.primaryColor,
@@ -44,7 +75,6 @@ class MyApp extends StatelessWidget {
           },
         ),
       ),
-      home: const HomePage(),
     );
   }
 }

--- a/website/lib/page.dart
+++ b/website/lib/page.dart
@@ -7,6 +7,7 @@
 // SPDX-License-Identifier: EUPL-1.2
 
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:sharezone_website/support_page.dart';
 import 'package:sharezone_website/utils.dart';
 import 'package:sharezone_website/widgets/column_spacing.dart';
@@ -38,8 +39,7 @@ class PageTemplate extends StatelessWidget {
                     ListTile(
                       leading: const Icon(Icons.home),
                       title: const Text("Hauptseite"),
-                      onTap: () =>
-                          Navigator.popAndPushNamed(context, HomePage.tag),
+                      onTap: () => context.go('/'),
                     ),
                     ListTile(
                       leading: const Icon(Icons.question_answer),
@@ -49,8 +49,7 @@ class PageTemplate extends StatelessWidget {
                     ListTile(
                       leading: const Icon(Icons.help),
                       title: const Text("Support"),
-                      onTap: () =>
-                          Navigator.pushNamed(context, SupportPage.tag),
+                      onTap: () => context.go('/$SupportPage.tag'),
                     ),
                   ],
                 ),
@@ -116,8 +115,7 @@ class _AppBarTitle extends StatelessWidget implements PreferredSizeWidget {
                     )
                   else
                     TransparentButton(
-                      onTap: () =>
-                          Navigator.popAndPushNamed(context, HomePage.tag),
+                      onTap: () => context.go('/'),
                       child: const SharezoneLogo(
                         logoColor: LogoColor.blueShort,
                         height: 50,
@@ -131,8 +129,7 @@ class _AppBarTitle extends StatelessWidget implements PreferredSizeWidget {
                         if (!isPhone(context)) ...[
                           TransparentButton(
                             child: const Text("Support"),
-                            onTap: () =>
-                                Navigator.pushNamed(context, SupportPage.tag),
+                            onTap: () => context.go('/${SupportPage.tag}'),
                           ),
                           const SizedBox(width: 30),
                           TransparentButton.openLink(

--- a/website/lib/support_page.dart
+++ b/website/lib/support_page.dart
@@ -21,7 +21,7 @@ const phoneNumber = '+49 1516 7754541';
 class SupportPage extends StatelessWidget {
   const SupportPage({super.key});
 
-  static const String tag = 'support-page';
+  static const String tag = 'support';
 
   @override
   Widget build(BuildContext context) {

--- a/website/pubspec.lock
+++ b/website/pubspec.lock
@@ -112,6 +112,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  go_router:
+    dependency: "direct main"
+    description:
+      name: go_router
+      sha256: c5fa45fa502ee880839e3b2152d987c44abae26d064a2376d4aad434cf0f7b15
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.1.3"
   http_parser:
     dependency: transitive
     description:
@@ -128,6 +136,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
+  logging:
+    dependency: transitive
+    description:
+      name: logging
+      sha256: "623a88c9594aa774443aa3eb2d41807a48486b5613e67599fb4c41c0ad47c340"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.0"
   markdown:
     dependency: transitive
     description:

--- a/website/pubspec.yaml
+++ b/website/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   flutter_markdown: ^0.6.18+2
   flutter_staggered_animations: ^1.1.1
   flutter_svg: ^2.0.9
+  go_router: ^12.1.3
   number_slide_animation: ^0.2.1
   url_launcher: ^6.2.2
 


### PR DESCRIPTION
This PR adds `go_router` as a navigation package to our website. This is required for better query parameter passing (used for the "parents buy their children Sharezone Plus" feature. Additionally, this PR changes the URL strategy from hash to path (`sharezone.net/#/` to `sharezone.net/`).