### PR TITLE
Remove `pull_request` permission for `website-cd` workflow

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -60,6 +60,7 @@ env:
 # Using the broad default permissions is considered a bad security practice
 # and would cause alerts from our scanning tools.
 permissions: {}
+
 jobs:
   deploy-alpha-web-app:
     runs-on: ubuntu-22.04

--- a/.github/workflows/website_cd.yml
+++ b/.github/workflows/website_cd.yml
@@ -28,8 +28,7 @@ jobs:
   deploy:
     runs-on: ubuntu-22.04
     permissions:
-      pull-requests: write # for FirebaseExtended/action-hosting-deploy to comment on PRs
-      checks: write # for FirebaseExtended/action-hosting-deploy to comment on PRs (without write permissions for checks the action doesn't post a comment to the PR, we don't know why)
+      checks: write # for FirebaseExtended/action-hosting-deploy
     strategy:
       matrix:
         environment:


### PR DESCRIPTION
The 'pull_request' permission is not needed for this workflow.
