### PR TITLE
Add `dart pub cache repair` to our CI pipeline

### DIFF
--- a/.github/workflows/cli_ci.yml
+++ b/.github/workflows/cli_ci.yml
@@ -106,6 +106,11 @@ jobs:
       # So we can just use "sz COMMAND" instead of "dart ../path/to/script.dart ..."
       - run: echo $(realpath ./bin) >> $GITHUB_PATH
 
+      # Sometimes, the Dart dependencies are broken. See
+      # https://github.com/SharezoneApp/sharezone-app/issues/1195.
+      - name: Dart Dependencies Repair
+        run: dart pub cache repair
+
       - name: Run code analysis via "sz analyze" (formatting, issues, spacing ...)
         run: sz analyze --max-concurrent-packages 3 --package-timeout-minutes 15
 

--- a/.github/workflows/safe_app_ci.yml
+++ b/.github/workflows/safe_app_ci.yml
@@ -126,6 +126,11 @@ jobs:
       - name: Run code analysis via "sz analyze" (formatting, issues, spacing ...)
         run: sz analyze --max-concurrent-packages 3 --package-timeout-minutes 15
 
+      # Sometimes, the Dart dependencies are broken. See
+      # https://github.com/SharezoneApp/sharezone-app/issues/1195.
+      - name: Dart Dependencies Repair
+        run: dart pub cache repair
+
       # It can easily happen that a dependency changed but the .lock file is not
       # updated. Or other cases where files are changed during a build.
       # Therefore, fails this check if there are Git changes.

--- a/.github/workflows/safe_website_ci.yml
+++ b/.github/workflows/safe_website_ci.yml
@@ -122,6 +122,11 @@ jobs:
       # So we can just use "sz COMMAND" instead of "dart ../path/to/script.dart ..."
       - run: echo $(realpath ./bin) >> $GITHUB_PATH
 
+      # Sometimes, the Dart dependencies are broken. See
+      # https://github.com/SharezoneApp/sharezone-app/issues/1195.
+      - name: Dart Dependencies Repair
+        run: dart pub cache repair
+
       - name: Run code analysis via "sz analyze" (formatting, issues, spacing ...)
         run: sz analyze --max-concurrent-packages 3 --package-timeout-minutes 15
 


### PR DESCRIPTION
Sometimes the GitHub Actions pull different package dependencies compared to the local `dart pub get` command (see #1195). Adding `dart pub cache repair` to the CI seems to fix this.

Closes #1195