### PR TITLE
Use more beautiful name for deploying the website

### DIFF
--- a/.github/workflows/website_cd.yml
+++ b/.github/workflows/website_cd.yml
@@ -27,6 +27,7 @@ permissions: {}
 jobs:
   deploy:
     runs-on: ubuntu-22.04
+    name: website-deploy-${{ matrix.environment.name }}
     permissions:
       checks: write # for FirebaseExtended/action-hosting-deploy
     strategy:


### PR DESCRIPTION
This PR changes the name of the deploying website job. Instead of "deploy (dev, sharezone-debug, FIREBASE_SERVICE_ACCOUNT_SHAREZONE_DEBUG)" the name will be "deploy-website-dev".