### PR TITLE
Use outputs of `flutter-fvm-config-action` in GitHub Actions

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -73,7 +73,7 @@ jobs:
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
           channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting
@@ -114,7 +114,7 @@ jobs:
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
           channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting
@@ -223,7 +223,7 @@ jobs:
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
           channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting
@@ -291,7 +291,7 @@ jobs:
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
           channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting

--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -68,12 +68,13 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Set Flutter version from FVM config file to environment variables
+        id: fvm-config-action
         uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: ${{ env.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting
           # '.../flutter' as the FVM Flutter version cache folder.
@@ -108,12 +109,13 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Set Flutter version from FVM config file to environment variables
+        id: fvm-config-action
         uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: ${{ env.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting
           # '.../flutter' as the FVM Flutter version cache folder.
@@ -216,12 +218,13 @@ jobs:
         run: pip3 install codemagic-cli-tools==0.47.0
 
       - name: Set Flutter version from FVM config file to environment variables
+        id: fvm-config-action
         uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: ${{ env.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting
           # '.../flutter' as the FVM Flutter version cache folder.
@@ -283,12 +286,13 @@ jobs:
         run: pip3 install codemagic-cli-tools==0.47.0
 
       - name: Set Flutter version from FVM config file to environment variables
+        id: fvm-config-action
         uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: ${{ env.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting
           # '.../flutter' as the FVM Flutter version cache folder.

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -77,7 +77,7 @@ jobs:
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
           channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting
@@ -125,7 +125,7 @@ jobs:
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
           channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting
@@ -187,7 +187,7 @@ jobs:
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
           channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting
@@ -241,7 +241,7 @@ jobs:
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
           channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -72,12 +72,13 @@ jobs:
         run: pip3 install codemagic-cli-tools==0.47.0
 
       - name: Set Flutter version from FVM config file to environment variables
+        id: fvm-config-action
         uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: ${{ env.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting
           # '.../flutter' as the FVM Flutter version cache folder.
@@ -119,12 +120,13 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Set Flutter version from FVM config file to environment variables
+        id: fvm-config-action
         uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: ${{ env.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting
           # '.../flutter' as the FVM Flutter version cache folder.
@@ -180,12 +182,13 @@ jobs:
           echo "storeFile=key.jks" >> key.properties
 
       - name: Set Flutter version from FVM config file to environment variables
+        id: fvm-config-action
         uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: ${{ env.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting
           # '.../flutter' as the FVM Flutter version cache folder.
@@ -233,12 +236,13 @@ jobs:
         run: pip3 install codemagic-cli-tools==0.47.0
 
       - name: Set Flutter version from FVM config file to environment variables
+        id: fvm-config-action
         uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: ${{ env.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting
           # '.../flutter' as the FVM Flutter version cache folder.

--- a/.github/workflows/cli_ci.yml
+++ b/.github/workflows/cli_ci.yml
@@ -89,7 +89,7 @@ jobs:
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
           channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting
@@ -141,7 +141,7 @@ jobs:
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
           channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting

--- a/.github/workflows/cli_ci.yml
+++ b/.github/workflows/cli_ci.yml
@@ -84,12 +84,13 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Set Flutter version from FVM config file to environment variables
+        id: fvm-config-action
         uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: ${{ env.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting
           # '.../flutter' as the FVM Flutter version cache folder.
@@ -135,12 +136,13 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Set Flutter version from FVM config file to environment variables
+        id: fvm-config-action
         uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: ${{ env.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting
           # '.../flutter' as the FVM Flutter version cache folder.

--- a/.github/workflows/integration_tests_app_ci.yml
+++ b/.github/workflows/integration_tests_app_ci.yml
@@ -97,7 +97,7 @@ jobs:
 
       - uses: subosito/flutter-action@main
         with:
-          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
           channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
 
       - name: Install patrol cli
@@ -187,7 +187,7 @@ jobs:
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
           channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting
@@ -248,7 +248,7 @@ jobs:
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
           channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting
@@ -332,7 +332,7 @@ jobs:
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
           channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
 
       # We need to install the FlutterFire CLI because we have Build Phases in

--- a/.github/workflows/integration_tests_app_ci.yml
+++ b/.github/workflows/integration_tests_app_ci.yml
@@ -92,12 +92,13 @@ jobs:
           java-version: "11"
 
       - name: Set Flutter version from FVM config file to environment variables
+        id: fvm-config-action
         uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b
 
       - uses: subosito/flutter-action@main
         with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: ${{ env.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
 
       - name: Install patrol cli
         run: flutter pub global activate patrol_cli 2.3.1+1
@@ -181,12 +182,13 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Set Flutter version from FVM config file to environment variables
+        id: fvm-config-action
         uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: ${{ env.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting
           # '.../flutter' as the FVM Flutter version cache folder.
@@ -241,12 +243,13 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Set Flutter version from FVM config file to environment variables
+        id: fvm-config-action
         uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: ${{ env.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting
           # '.../flutter' as the FVM Flutter version cache folder.
@@ -324,12 +327,13 @@ jobs:
           xcode-project use-profiles
 
       - name: Set Flutter version from FVM config file to environment variables
+        id: fvm-config-action
         uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: ${{ env.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
 
       # We need to install the FlutterFire CLI because we have Build Phases in
       # XCode configured which are using the FlutterFire CLI. Without the CLI,

--- a/.github/workflows/licence.yml
+++ b/.github/workflows/licence.yml
@@ -47,7 +47,7 @@ jobs:
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
           channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting

--- a/.github/workflows/licence.yml
+++ b/.github/workflows/licence.yml
@@ -42,12 +42,13 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Set Flutter version from FVM config file to environment variables
+        id: fvm-config-action
         uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: ${{ env.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting
           # '.../flutter' as the FVM Flutter version cache folder.

--- a/.github/workflows/safe_app_ci.yml
+++ b/.github/workflows/safe_app_ci.yml
@@ -101,12 +101,13 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Set Flutter version from FVM config file to environment variables
+        id: fvm-config-action
         uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: ${{ env.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting
           # '.../flutter' as the FVM Flutter version cache folder.
@@ -150,12 +151,13 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Set Flutter version from FVM config file to environment variables
+        id: fvm-config-action
         uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: ${{ env.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting
           # '.../flutter' as the FVM Flutter version cache folder.
@@ -188,12 +190,13 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Set Flutter version from FVM config file to environment variables
+        id: fvm-config-action
         uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: ${{ env.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting
           # '.../flutter' as the FVM Flutter version cache folder.

--- a/.github/workflows/safe_app_ci.yml
+++ b/.github/workflows/safe_app_ci.yml
@@ -106,7 +106,7 @@ jobs:
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
           channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting
@@ -156,7 +156,7 @@ jobs:
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
           channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting
@@ -195,7 +195,7 @@ jobs:
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
           channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting

--- a/.github/workflows/safe_website_ci.yml
+++ b/.github/workflows/safe_website_ci.yml
@@ -100,12 +100,13 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Set Flutter version from FVM config file to environment variables
+        id: fvm-config-action
         uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: ${{ env.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting
           # '.../flutter' as the FVM Flutter version cache folder.

--- a/.github/workflows/safe_website_ci.yml
+++ b/.github/workflows/safe_website_ci.yml
@@ -105,7 +105,7 @@ jobs:
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
           channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -72,12 +72,13 @@ jobs:
         run: pip3 install codemagic-cli-tools==0.47.0
 
       - name: Set Flutter version from FVM config file to environment variables
+        id: fvm-config-action
         uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: ${{ env.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting
           # '.../flutter' as the FVM Flutter version cache folder.
@@ -120,12 +121,13 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Set Flutter version from FVM config file to environment variables
+        id: fvm-config-action
         uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: ${{ env.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting
           # '.../flutter' as the FVM Flutter version cache folder.
@@ -182,12 +184,13 @@ jobs:
           echo "storeFile=key.jks" >> key.properties
 
       - name: Set Flutter version from FVM config file to environment variables
+        id: fvm-config-action
         uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: ${{ env.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting
           # '.../flutter' as the FVM Flutter version cache folder.
@@ -235,12 +238,13 @@ jobs:
         run: pip3 install codemagic-cli-tools==0.47.0
 
       - name: Set Flutter version from FVM config file to environment variables
+        id: fvm-config-action
         uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: ${{ env.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting
           # '.../flutter' as the FVM Flutter version cache folder.

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -77,7 +77,7 @@ jobs:
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
           channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting
@@ -126,7 +126,7 @@ jobs:
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
           channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting
@@ -189,7 +189,7 @@ jobs:
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
           channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting
@@ -243,7 +243,7 @@ jobs:
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
           channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting

--- a/.github/workflows/unsafe_app_ci.yml
+++ b/.github/workflows/unsafe_app_ci.yml
@@ -144,12 +144,13 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set Flutter version from FVM config file to environment variables
+        id: fvm-config-action
         uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: ${{ env.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting
           # '.../flutter' as the FVM Flutter version cache folder.

--- a/.github/workflows/unsafe_app_ci.yml
+++ b/.github/workflows/unsafe_app_ci.yml
@@ -149,7 +149,7 @@ jobs:
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
           channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting

--- a/.github/workflows/unsafe_website_ci.yml
+++ b/.github/workflows/unsafe_website_ci.yml
@@ -148,7 +148,7 @@ jobs:
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
           channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting

--- a/.github/workflows/unsafe_website_ci.yml
+++ b/.github/workflows/unsafe_website_ci.yml
@@ -143,12 +143,13 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set Flutter version from FVM config file to environment variables
+        id: fvm-config-action
         uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: ${{ env.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
           # Use format expected by FVM.
           # Else this won't be recognized as an installed version when setting
           # '.../flutter' as the FVM Flutter version cache folder.

--- a/.github/workflows/website_cd.yml
+++ b/.github/workflows/website_cd.yml
@@ -43,12 +43,13 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Set Flutter version from FVM config file to environment variables
+        id: fvm-config-action
         uses: kuhnroyal/flutter-fvm-config-action@6ffa30473b346f7d7c63cf9e03e6a886f940a72b
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: ${{ env.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
 
       - name: Build
         working-directory: website

--- a/.github/workflows/website_cd.yml
+++ b/.github/workflows/website_cd.yml
@@ -48,7 +48,7 @@ jobs:
 
       - uses: subosito/flutter-action@2783a3f08e1baf891508463f8c6653c258246225
         with:
-          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
           channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
 
       - name: Build


### PR DESCRIPTION
## Description

With https://github.com/kuhnroyal/flutter-fvm-config-action/pull/15 the `flutter-fvm-config-action` supports outputs. This is great because the GitHub Actions Extension detects the context now.

### Before

<img width="631" alt="Screenshot 2023-12-31 at 14 48 40" src="https://github.com/SharezoneApp/sharezone-app/assets/24459435/c44b4bc2-c9da-4ed5-b39f-6a56a6308551">

### After

<img width="667" alt="Screenshot 2023-12-31 at 14 50 44" src="https://github.com/SharezoneApp/sharezone-app/assets/24459435/fed085cd-0d3e-4630-89f4-f6f6ab7942d8">
