### PR TITLE
Remove temporarily "git diff" check for analyze jobs

### DIFF
--- a/.github/workflows/cli_ci.yml
+++ b/.github/workflows/cli_ci.yml
@@ -109,18 +109,6 @@ jobs:
       - name: Run code analysis via "sz analyze" (formatting, issues, spacing ...)
         run: sz analyze --max-concurrent-packages 3 --package-timeout-minutes 15
 
-      # It can easily happen that a dependency changed but the .lock file is not
-      # updated. Or other cases where files are changed during a build.
-      # Therefore, fails this check if there are Git changes.
-      - name: Fail if there are Git diffs
-        run: |
-          # Fail if there are Git diffs and print the diff.
-          git diff --exit-code
-
-          # Print the Git diff with the file names and their status as a
-          # summary. 
-          git diff --name-status
-
   test:
     needs: changes
     # Because we run our the tests for all packages for now, we need to use a

--- a/.github/workflows/safe_app_ci.yml
+++ b/.github/workflows/safe_app_ci.yml
@@ -126,18 +126,6 @@ jobs:
       - name: Run code analysis via "sz analyze" (formatting, issues, spacing ...)
         run: sz analyze --max-concurrent-packages 3 --package-timeout-minutes 15
 
-      # It can easily happen that a dependency changed but the .lock file is not
-      # updated. Or other cases where files are changed during a build.
-      # Therefore, fails this check if there are Git changes.
-      - name: Fail if there are Git diffs
-        run: |
-          # Fail if there are Git diffs and print the diff.
-          git diff --exit-code
-
-          # Print the Git diff with the file names and their status as a
-          # summary. 
-          git diff --name-status
-
   # We split the tests into two jobs, because we want to run the golden tests on
   # a macOS runner, because the golden tests were generated on macOS. To reduce
   # the time that macOS runner are used, we run the other tests on a Linux

--- a/.github/workflows/safe_website_ci.yml
+++ b/.github/workflows/safe_website_ci.yml
@@ -124,15 +124,3 @@ jobs:
 
       - name: Run code analysis via "sz analyze" (formatting, issues, spacing ...)
         run: sz analyze --max-concurrent-packages 3 --package-timeout-minutes 15
-
-      # It can easily happen that a dependency changed but the .lock file is not
-      # updated. Or other cases where files are changed during a build.
-      # Therefore, fails this check if there are Git changes.
-      - name: Fail if there are Git diffs
-        run: |
-          # Fail if there are Git diffs and print the diff.
-          git diff --exit-code
-
-          # Print the Git diff with the file names and their status as a
-          # summary. 
-          git diff --name-status


### PR DESCRIPTION
Because of #1195 is our CI currently, failing. I'm trying to fix but it takes too much time right now. Therefore, I would suggest temporarily removing the "git diff" check until we fixed #1195.

Workaround for #1195