### PR TITLE
Remove "lints" as dev dependency in "holidays"

### DIFF
--- a/lib/holidays/pubspec.lock
+++ b/lib/holidays/pubspec.lock
@@ -397,7 +397,7 @@ packages:
     source: path
     version: "0.0.1"
   lints:
-    dependency: "direct dev"
+    dependency: transitive
     description:
       name: lints
       sha256: "0a217c6c989d21039f1498c3ed9f3ed71b354e69873f13a8dfc3c9fe76f1b452"

--- a/lib/holidays/pubspec.yaml
+++ b/lib/holidays/pubspec.yaml
@@ -37,6 +37,5 @@ dev_dependencies:
   mockito: ^5.0.7
   build_runner: ^2.1.4
   built_value_generator: ^8.1.1
-  lints: ^2.0.1
   sharezone_lints:
     path: ../sharezone_lints


### PR DESCRIPTION
We already use `sharezone_lints` as lint dependency.