### PR TITLE
Add '--flavor' option to `BuildMacOsCommand`

### DIFF
--- a/tools/sz_repo_cli/lib/src/commands/src/build_macos_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/build_macos_command.dart
@@ -90,6 +90,8 @@ When none is specified, the value from pubspec.yaml is used.''')
           'macos',
           '--target',
           'lib/main_$flavor.dart',
+          '--flavor',
+          flavor,
           '--release',
           '--dart-define',
           'DEVELOPMENT_STAGE=${stage.toUpperCase()}',


### PR DESCRIPTION
This fixes the broken CI pipeline: https://github.com/SharezoneApp/sharezone-app/actions/runs/7420192678/job/20191105674