### PR TITLE
Remove `-s` option from `which` command

### DIFF
--- a/tools/sz_repo_cli/lib/src/common/src/throw_if_command_is_not_installed.dart
+++ b/tools/sz_repo_cli/lib/src/common/src/throw_if_command_is_not_installed.dart
@@ -16,7 +16,7 @@ import 'package:sz_repo_cli/src/common/src/process_runner_utils.dart';
 /// Optionally, you can pass [instructionsToInstall] to throw an helpful
 /// exception.
 ///
-/// Currently, we skip this method for [Platform.isWindows] because "which -s"
+/// Currently, we skip this method for [Platform.isWindows] because "which"
 /// is not available for Windows.
 Future<void> throwIfCommandIsNotInstalled(
   ProcessRunner processRunner, {
@@ -24,13 +24,13 @@ Future<void> throwIfCommandIsNotInstalled(
   String? instructionsToInstall,
 }) async {
   if (Platform.isWindows) {
-    // We skip on Windows the check because "which -s" is not available for
+    // We skip on Windows the check because "which" is not available for
     // Windows.
     return;
   }
 
   final result = await processRunner.run(
-    ['which', '-s', command],
+    ['which', command],
     failOk: true,
   );
   if (result.exitCode != 0) {


### PR DESCRIPTION
The `-s` (stands for "silent output") argument is not available 

```
Running "which -s fvm" in /home/runner/work/sharezone-app/sharezone-app.
Illegal option -s
Usage: /usr/bin/which.debianutils [-a] args
```

https://github.com/SharezoneApp/sharezone-app/actions/runs/7426917764/job/20211601925?pr=1223