### PR TITLE
Remove `timestampFromDateTime` method

### DIFF
--- a/lib/authentification/authentification_qrcode/lib/src/models/qr_sign_in_document.dart
+++ b/lib/authentification/authentification_qrcode/lib/src/models/qr_sign_in_document.dart
@@ -39,7 +39,7 @@ class QrSignInDocument {
     return {
       'qrId': qrId,
       'publicKey': publicKey,
-      'created': timestampFromDateTime(created),
+      'created': created,
     };
   }
 

--- a/lib/filesharing/filesharing_logic/lib/src/models/change_activity.dart
+++ b/lib/filesharing/filesharing_logic/lib/src/models/change_activity.dart
@@ -30,7 +30,7 @@ class ChangeActivity {
     return {
       'authorID': authorID,
       'authorName': authorName,
-      'changedOn': timestampFromDateTime(changedOn),
+      'changedOn': changedOn,
     };
   }
 

--- a/lib/group_domain_models/lib/src/models/member.dart
+++ b/lib/group_domain_models/lib/src/models/member.dart
@@ -66,7 +66,7 @@ class MemberData {
       'abbreviation': abbreviation,
       'typeOfUser': typeOfUser.name,
       'role': role.name,
-      'joinedOn': timestampFromDateTime(joinedOn),
+      'joinedOn': joinedOn,
     };
   }
 

--- a/lib/sharezone_common/lib/src/firebase_helper.dart
+++ b/lib/sharezone_common/lib/src/firebase_helper.dart
@@ -44,8 +44,3 @@ DateTime? dateTimeFromTimestampOrNull(Timestamp? timestamp) {
   if (timestamp == null) return null;
   return timestamp.toDate();
 }
-
-Timestamp? timestampFromDateTime(DateTime? dateTime) {
-  if (dateTime == null) return null;
-  return Timestamp.fromDate(dateTime);
-}


### PR DESCRIPTION
It's not necessary to convert a `DateTime` to a `Timestamp`. The `cloud_firestore` package already does this for you. The background for removing this method is because I want to get rid of the `cloud_firestore` dependency in `firebase_helper.dart` to avoid having the Firebase dependencies on our website.