### PR TITLE
Add weekdays to homework card

### DIFF
--- a/lib/hausaufgabenheft_logik/lib/src/views/student_homework_view_factory.dart
+++ b/lib/hausaufgabenheft_logik/lib/src/views/student_homework_view_factory.dart
@@ -47,26 +47,38 @@ class StudentHomeworkViewFactory {
 
   String _getLocaleDateString(Date date, {String? time}) {
     final months = {
-      1: 'Januar',
-      2: 'Februar',
-      3: 'März',
-      4: 'April',
+      1: 'Jan',
+      2: 'Feb',
+      3: 'Mär',
+      4: 'Apr',
       5: 'Mai',
-      6: 'Juni',
-      7: 'Juli',
-      8: 'August',
-      9: 'September',
-      10: 'Oktober',
-      11: 'November',
-      12: 'Dezember',
+      6: 'Jun',
+      7: 'Jul',
+      8: 'Aug',
+      9: 'Sep',
+      10: 'Okt',
+      11: 'Nov',
+      12: 'Dez',
     };
     assert(months.containsKey(date.month));
 
     final day = date.day.toString();
     final month = months[date.month];
-    final year = date.year.toString();
+    // The year suffix is the last two digits of the year, e.g. 2019 -> 19
+    final yearSuffix = date.year.toString().substring(2);
 
-    final dateString = '$day. $month $year';
+    final weekdays = {
+      1: 'Mo',
+      2: 'Di',
+      3: 'Mi',
+      4: 'Do',
+      5: 'Fr',
+      6: 'Sa',
+      7: 'So',
+    };
+    final weekday = weekdays[date.asDateTime().weekday];
+
+    final dateString = '$weekday, $day. $month $yearSuffix';
     if (time == null) return dateString;
     return '$dateString - $time Uhr';
   }

--- a/lib/hausaufgabenheft_logik/test/create_student_homework_view_test.dart
+++ b/lib/hausaufgabenheft_logik/test/create_student_homework_view_test.dart
@@ -46,7 +46,7 @@ void main() {
         colorDate: false,
         subjectColor: white,
         subject: 'Mathematik',
-        todoDate: '28. Januar 2019',
+        todoDate: 'Mo, 28. Jan 19',
         withSubmissions: false,
         title: 'S. 35 6a) und 8c)',
       );
@@ -82,7 +82,7 @@ void main() {
 
       final view = viewFactory.createFrom(hw);
 
-      expect(view.todoDate, '3. Dezember 2018');
+      expect(view.todoDate, 'Mo, 3. Dez 18');
     });
 
     test(


### PR DESCRIPTION
| Before | After |
|--------|--------|
| <img width="1197" alt="image" src="https://github.com/SharezoneApp/sharezone-app/assets/24459435/05f3d6ac-dcef-4246-bdad-8cce0b43d1e7"> | <img width="1197" alt="image" src="https://github.com/SharezoneApp/sharezone-app/assets/24459435/67683e83-cb08-49ed-92ae-989cb80cb06d"> | 

Adds the weekday to the due date, since it's import for students because they don't think in dates (like December 27th). Instead, they in "I need to get this done by Wednesday".

Additionally, this PR shortens the month to the first 3 characters and the year to the last two to make it more compact.