### PR TITLE
Fix wrong abbreviation use in the homework diary

### DIFF
--- a/lib/firebase_hausaufgabenheft_logik/lib/src/homework_transformation.dart
+++ b/lib/firebase_hausaufgabenheft_logik/lib/src/homework_transformation.dart
@@ -59,9 +59,16 @@ Future<HomeworkReadModel?> tryToConvertToHomework(
     }
     Subject subject;
     if (courseColorHex != null) {
-      subject = Subject(homework.subject, color: Color(courseColorHex));
+      subject = Subject(
+        homework.subject,
+        color: Color(courseColorHex),
+        abbreviation: homework.subjectAbbreviation,
+      );
     } else {
-      subject = Subject(homework.subject);
+      subject = Subject(
+        homework.subject,
+        abbreviation: homework.subjectAbbreviation,
+      );
     }
 
     converted = HomeworkReadModel(

--- a/lib/firebase_hausaufgabenheft_logik/test/lazy_loading_controller_test.dart
+++ b/lib/firebase_hausaufgabenheft_logik/test/lazy_loading_controller_test.dart
@@ -33,7 +33,7 @@ List<HomeworkReadModel> listOfHomeworksWithLength(int length) => List.generate(
           id: HomeworkId("$index"),
           todoDate: DateTime.now(),
           status: CompletionStatus.completed,
-          subject: Subject("Mathe"),
+          subject: Subject("Mathe", abbreviation: 'Ma'),
           title: const Title("ABC"),
           withSubmissions: false),
     );

--- a/lib/hausaufgabenheft_logik/lib/src/models/subject.dart
+++ b/lib/hausaufgabenheft_logik/lib/src/models/subject.dart
@@ -11,15 +11,14 @@ import 'package:hausaufgabenheft_logik/src/views/color.dart';
 class Subject {
   final String name;
   final Color? color;
+  final String abbreviation;
 
-  Subject(this.name, {this.color}) {
+  Subject(this.name, {this.color, required this.abbreviation}) {
     if (name.isEmpty) {
       throw ArgumentError.value(
           name, 'name', "The subject name can't be empty");
     }
   }
-
-  String get abbreviation => name.length >= 2 ? name.substring(0, 2) : name;
 
   @override
   int get hashCode => name.hashCode;

--- a/lib/hausaufgabenheft_logik/test/create_homework_util.dart
+++ b/lib/hausaufgabenheft_logik/test/create_homework_util.dart
@@ -20,12 +20,13 @@ HomeworkReadModel createHomework(
     String id = 'willBeRandom',
     bool done = false,
     bool withSubmissions = false,
-    Color? subjectColor}) {
+    Color? subjectColor,
+    String abbreviation = 'Abb'}) {
   id = id == 'willBeRandom' ? randomString(5) : id;
   return HomeworkReadModel(
     id: HomeworkId(id),
     todoDate: todoDate.asDateTime(),
-    subject: Subject(subject, color: subjectColor),
+    subject: Subject(subject, color: subjectColor, abbreviation: abbreviation),
     title: Title(title),
     withSubmissions: withSubmissions,
     status: done ? CompletionStatus.completed : CompletionStatus.open,

--- a/lib/hausaufgabenheft_logik/test/create_student_homework_view_test.dart
+++ b/lib/hausaufgabenheft_logik/test/create_student_homework_view_test.dart
@@ -35,7 +35,11 @@ void main() {
         id: HomeworkId('Id'),
         status: CompletionStatus.open,
         todoDate: const Date(year: 2019, month: 1, day: 28).asDateTime(),
-        subject: Subject('Mathematik', color: white),
+        subject: Subject(
+          'Mathematik',
+          color: white,
+          abbreviation: 'Ma',
+        ),
         withSubmissions: false,
         title: const Title('S. 35 6a) und 8c)'),
       );

--- a/lib/hausaufgabenheft_logik/test/homework_list_test.dart
+++ b/lib/hausaufgabenheft_logik/test/homework_list_test.dart
@@ -74,9 +74,9 @@ void main() {
     });
   });
   test('getDistinctSubjects', () {
-    var mathe = Subject('Mathe');
-    var englisch = Subject('Englisch');
-    var deutsch = Subject('Deutsch');
+    var mathe = Subject('Mathe', abbreviation: 'Ma');
+    var englisch = Subject('Englisch', abbreviation: 'En');
+    var deutsch = Subject('Deutsch', abbreviation: 'De');
     final subjects = [mathe, englisch, mathe, mathe, deutsch];
     final homeworks = [
       for (final subject in subjects) createHomework(subject: subject.name)

--- a/lib/hausaufgabenheft_logik/test/subject_test.dart
+++ b/lib/hausaufgabenheft_logik/test/subject_test.dart
@@ -13,26 +13,18 @@ import 'package:test/test.dart';
 void main() {
   group('Subject', () {
     Subject createValidSubjectWith({Color? color}) {
-      return Subject('SomeSubjectName', color: color);
+      return Subject('SomeSubjectName', color: color, abbreviation: 'SSN');
     }
 
     test('A Subject cant be constructed with an empty subject name', () {
-      expect(() => Subject(''), throwsArgumentError);
+      expect(() => Subject('', abbreviation: ''), throwsArgumentError);
     });
-    test(
-        'generates an own subject abreviation from the given subject if no abbreviation is specified',
-        () {
-      expect(Subject('Mathematik').abbreviation, 'Ma');
-    });
-    test(
-        'If the subject name is shorter than two characters it uses the subject name as an abbreviation',
-        () {
-      expect(Subject('M').abbreviation, 'M');
-    });
+
     test('has no color of not given', () {
       final subject = createValidSubjectWith(color: null);
       expect(subject.color, isNull);
     });
+
     test('sets the optional color to the given color', () {
       final subject = createValidSubjectWith(color: const Color(1337));
       expect(subject.color, const Color(1337));


### PR DESCRIPTION
* Instead of generating the subject abbreviation, we use the subject abbreviation from the homework document now.
* Removes the tests for generating the subject abbreviation.

Closes #124