### PR TITLE
Add abbreviation for '--only-goldens' and '--update-goldens'

### DIFF
--- a/tools/sz_repo_cli/lib/src/commands/src/test_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/test_command.dart
@@ -33,6 +33,7 @@ class TestCommand extends ConcurrentCommand {
       help: 'Update golden tests.',
       defaultsTo: false,
       negatable: false,
+      abbr: 'u',
     );
   }
 

--- a/tools/sz_repo_cli/lib/src/commands/src/test_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/test_command.dart
@@ -26,6 +26,7 @@ class TestCommand extends ConcurrentCommand {
       help: 'Run only golden tests.',
       defaultsTo: false,
       negatable: false,
+      abbr: 'g',
     );
     argParser.addFlag(
       'update-goldens',


### PR DESCRIPTION
When changing the UI, I often have to type 'sz test --only-goldens --update-goldens'. With this PR, you can just type 'sz test -gu' to save time.