### PR TITLE
Reduce text size of homework tile

### DIFF
--- a/app/lib/homework/shared/homework_tile_template.dart
+++ b/app/lib/homework/shared/homework_tile_template.dart
@@ -47,10 +47,7 @@ class HomeworkTileTemplate extends StatelessWidget {
             title,
             overflow: TextOverflow.ellipsis,
             maxLines: 2,
-            style: Theme.of(context)
-                .textTheme
-                .bodyLarge!
-                .apply(fontSizeFactor: 1.1),
+            style: Theme.of(context).textTheme.bodyLarge!,
           ),
           subtitle: Padding(
             padding: const EdgeInsets.only(bottom: 6),

--- a/app/lib/homework/shared/homework_tile_template.dart
+++ b/app/lib/homework/shared/homework_tile_template.dart
@@ -49,15 +49,11 @@ class HomeworkTileTemplate extends StatelessWidget {
             maxLines: 2,
             style: Theme.of(context).textTheme.bodyLarge!,
           ),
-          subtitle: Padding(
-            padding: const EdgeInsets.only(bottom: 6),
-            child: Text.rich(
-              TextSpan(children: <TextSpan>[
-                TextSpan(text: "$courseName\n"),
-                TextSpan(
-                    text: todoDate, style: TextStyle(color: todoDateColor)),
-              ], style: TextStyle(color: Colors.grey[600])),
-            ),
+          subtitle: Text.rich(
+            TextSpan(children: <TextSpan>[
+              TextSpan(text: "$courseName\n"),
+              TextSpan(text: todoDate, style: TextStyle(color: todoDateColor)),
+            ], style: TextStyle(color: Colors.grey[600])),
           ),
           leading: CircleAvatar(
             backgroundColor: courseColor.withOpacity(0.2),


### PR DESCRIPTION
| Before | After |
|--------|--------|
| ![Screenshot 2024-01-19 at 14 29 18](https://github.com/SharezoneApp/sharezone-app/assets/24459435/03be6edb-7c72-41d7-aa2a-13b9cb2efa6c) | ![image](https://github.com/SharezoneApp/sharezone-app/assets/24459435/5a5ef3d7-36d4-4912-b14a-0a8739dbde0b) | 

Homework tiles used too much space. I think this is better.