### PR TITLE
Fix: Select already existing due date chip when creating a custom chip.

### DIFF
--- a/app/lib/homework/homework_dialog/homework_dialog.dart
+++ b/app/lib/homework/homework_dialog/homework_dialog.dart
@@ -13,6 +13,7 @@ import 'package:analytics/analytics.dart';
 import 'package:bloc_presentation/bloc_presentation.dart';
 import 'package:bloc_provider/bloc_provider.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:collection/collection.dart';
 import 'package:common_domain_models/common_domain_models.dart';
 import 'package:date/date.dart';
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
@@ -23,6 +24,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart' as bloc_lib show BlocProvider;
 import 'package:flutter_bloc/flutter_bloc.dart' hide BlocProvider;
+import 'package:platform_check/platform_check.dart';
 import 'package:sharezone/filesharing/dialog/attach_file.dart';
 import 'package:sharezone/filesharing/dialog/course_tile.dart';
 import 'package:sharezone/holidays/holiday_bloc.dart';
@@ -35,7 +37,6 @@ import 'package:sharezone/timetable/src/edit_time.dart';
 import 'package:sharezone/util/next_lesson_calculator/next_lesson_calculator.dart';
 import 'package:sharezone/widgets/material/list_tile_with_description.dart';
 import 'package:sharezone/widgets/material/save_button.dart';
-import 'package:platform_check/platform_check.dart';
 import 'package:sharezone_widgets/sharezone_widgets.dart';
 import 'package:time/time.dart';
 
@@ -512,11 +513,17 @@ class _DueDateChipsController extends ChangeNotifier {
   }
 
   void addInXLessonsChip(InXLessonsDueDateSelection inXLessons) {
-    chips = chips.add(_DueDateChip(
-      label: '${inXLessons.inXLessons}.-nächste Stunde',
-      dueDate: inXLessons,
-      isDeletable: true,
-    ));
+    final alreadyExists = chips.firstWhereOrNull(
+          (chip) => chip.dueDate == inXLessons,
+        ) !=
+        null;
+    if (!alreadyExists) {
+      chips = chips.add(_DueDateChip(
+        label: '${inXLessons.inXLessons}.-nächste Stunde',
+        dueDate: inXLessons,
+        isDeletable: true,
+      ));
+    }
     selectChip(inXLessons);
     notifyListeners();
   }

--- a/app/test/homework/homework_dialog_test.dart
+++ b/app/test/homework/homework_dialog_test.dart
@@ -633,6 +633,45 @@ void main() {
       expect(controller.getSelectedDueDate(), Date('2023-11-08'));
     });
     testWidgets(
+        'Regression test: When creating a "in 2 lesson" custom chip the "übernächste Stunde" chip will be selected and no custom chip will be created',
+        (tester) async {
+      // https://github.com/SharezoneApp/sharezone-app/issues/1272
+
+      final controller = createController(tester);
+      controller.addCourse(courseWith(id: 'foo_course'));
+      controller.addNextLessonDates(
+          'foo_course', [Date('2023-11-06'), Date('2023-11-08')]);
+      await pumpAndSettleHomeworkDialog(tester,
+          showDueDateSelectionChips: true);
+
+      final nrOfChipsBefore = controller.getLessonChips().length;
+      await controller.selectCourse('foo_course');
+      await controller.createCustomChip(inXLessons: 2);
+      final nrOfChipsAfter = controller.getLessonChips().length;
+
+      expect(controller.getSelectedLessonChips(), ['Übernächste Stunde']);
+      expect(nrOfChipsBefore, nrOfChipsAfter);
+    });
+    testWidgets(
+        'Regression test: When creating a "in 1 lesson" custom chip the "Nächste Stunde" chip will be selected and no custom chip will be created',
+        (tester) async {
+      // https://github.com/SharezoneApp/sharezone-app/issues/1272
+
+      final controller = createController(tester);
+      controller.addCourse(courseWith(id: 'foo_course'));
+      controller.addNextLessonDates('foo_course', [Date('2023-11-06')]);
+      await pumpAndSettleHomeworkDialog(tester,
+          showDueDateSelectionChips: true);
+
+      final nrOfChipsBefore = controller.getLessonChips().length;
+      await controller.selectCourse('foo_course');
+      await controller.createCustomChip(inXLessons: 1);
+      final nrOfChipsAfter = controller.getLessonChips().length;
+
+      expect(controller.getSelectedLessonChips(), ['Nächste Stunde']);
+      expect(nrOfChipsBefore, nrOfChipsAfter);
+    });
+    testWidgets(
         'when creating a "in 5 lessons" custom chip it will be selected and the correct date will be selected',
         (tester) async {
       final controller = createController(tester);


### PR DESCRIPTION
When trying to create a custom chip with the value of the already pre-existing chips, the pre-existing chips should be selected instead creating a custom chip and selecting both the pre-existing and new chip.

Fixes https://github.com/SharezoneApp/sharezone-app/issues/1272

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced homework dialog to prevent duplicate lesson chips.

- **Tests**
  - Added regression tests for homework dialog chip creation and selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->