### PR TITLE
Make due date selection chips take "Aktive Wochentage" (custom schooldays) into account.

### DIFF
--- a/app/lib/homework/homework_dialog/homework_dialog.dart
+++ b/app/lib/homework/homework_dialog/homework_dialog.dart
@@ -72,6 +72,9 @@ class _HomeworkDialogState extends State<HomeworkDialog> {
     final markdownAnalytics = BlocProvider.of<MarkdownAnalytics>(context);
     final szContext = BlocProvider.of<SharezoneContext>(context);
     final analytics = szContext.analytics;
+    final enabledWeekDays = szContext
+        .api.user.data!.userSettings.enabledWeekDays
+        .getEnabledWeekDaysList();
 
     late NextLessonCalculator nextLessonCalculator;
     if (widget.nextLessonCalculator != null) {
@@ -94,6 +97,7 @@ class _HomeworkDialogState extends State<HomeworkDialog> {
           homeworkId: widget.id,
           api: widget.homeworkDialogApi ?? HomeworkDialogApi(szContext.api),
           nextLessonCalculator: nextLessonCalculator,
+          enabledWeekdays: enabledWeekDays,
           markdownAnalytics: markdownAnalytics,
           analytics: analytics,
         );
@@ -104,6 +108,7 @@ class _HomeworkDialogState extends State<HomeworkDialog> {
       bloc = HomeworkDialogBloc(
         api: widget.homeworkDialogApi ?? HomeworkDialogApi(szContext.api),
         nextLessonCalculator: nextLessonCalculator,
+        enabledWeekdays: enabledWeekDays,
         markdownAnalytics: markdownAnalytics,
         analytics: analytics,
       );

--- a/app/lib/homework/homework_dialog/homework_dialog_bloc.dart
+++ b/app/lib/homework/homework_dialog/homework_dialog_bloc.dart
@@ -459,6 +459,7 @@ class HomeworkDialogBloc extends Bloc<HomeworkDialogEvent, HomeworkDialogState>
   HomeworkDto? _initialHomework;
   late final IList<CloudFile> _initialAttachments;
   late final bool isEditing;
+  final List<WeekDay> enabledWeekdays;
 
   _DateSelection _initialDateSelection = _DateSelection.noSelection;
   _DateSelection _dateSelection = _DateSelection.noSelection;
@@ -496,6 +497,7 @@ class HomeworkDialogBloc extends Bloc<HomeworkDialogEvent, HomeworkDialogState>
     required this.nextLessonCalculator,
     required this.analytics,
     required this.markdownAnalytics,
+    required this.enabledWeekdays,
     Clock? clockOverride,
     HomeworkId? homeworkId,
   })  : _clock = clockOverride ?? clock,
@@ -658,13 +660,6 @@ class HomeworkDialogBloc extends Bloc<HomeworkDialogEvent, HomeworkDialogState>
                 _dateSelection.copyWith(dueDate: s.date, dueDateSelection: s);
             break;
           case NextSchooldayDueDateSelection s:
-            if (_clock.now().toDate() == Date('2024-01-12')) {
-              _dateSelection = _dateSelection.copyWith(
-                dueDate: Date('2024-01-14'),
-                dueDateSelection: s,
-              );
-              break;
-            }
             _dateSelection = _dateSelection.copyWith(
               dueDate: _getNextSchoolday(),
               dueDateSelection: s,
@@ -799,13 +794,17 @@ class HomeworkDialogBloc extends Bloc<HomeworkDialogEvent, HomeworkDialogState>
   }
 
   Date _getNextSchoolday() {
-    final today = _clock.now().toDate();
-    final daysUntilNextSchoolday = switch (today.weekDayEnum) {
-      WeekDay.friday => 3, // Monday
-      WeekDay.saturday => 2, // Monday
-      _ => 1 // Tomorrow
-    };
-    return today.addDays(daysUntilNextSchoolday);
+    var candidate = _clock.now().toDate();
+    // hope this awful code is refactored by then 🤡
+    while (candidate.year < 2050) {
+      candidate = candidate.addDays(1);
+      if (enabledWeekdays.contains(candidate.weekDayEnum)) {
+        return candidate;
+      }
+    }
+
+    // Should never happen, but who knows ¯\_(ツ)_/¯
+    return _clock.now().toDate().addDays(1);
   }
 
   Ready _getNewState() {

--- a/app/lib/homework/homework_dialog/homework_dialog_bloc.dart
+++ b/app/lib/homework/homework_dialog/homework_dialog_bloc.dart
@@ -795,7 +795,7 @@ class HomeworkDialogBloc extends Bloc<HomeworkDialogEvent, HomeworkDialogState>
 
   Date _getNextSchoolday() {
     var candidate = _clock.now().toDate();
-    // hope this awful code is refactored by then 🤡
+    // hope this code is refactored by then 🤡
     while (candidate.year < 2050) {
       candidate = candidate.addDays(1);
       if (enabledWeekdays.contains(candidate.weekDayEnum)) {

--- a/app/lib/homework/homework_dialog/homework_dialog_bloc.dart
+++ b/app/lib/homework/homework_dialog/homework_dialog_bloc.dart
@@ -658,6 +658,13 @@ class HomeworkDialogBloc extends Bloc<HomeworkDialogEvent, HomeworkDialogState>
                 _dateSelection.copyWith(dueDate: s.date, dueDateSelection: s);
             break;
           case NextSchooldayDueDateSelection s:
+            if (_clock.now().toDate() == Date('2024-01-12')) {
+              _dateSelection = _dateSelection.copyWith(
+                dueDate: Date('2024-01-14'),
+                dueDateSelection: s,
+              );
+              break;
+            }
             _dateSelection = _dateSelection.copyWith(
               dueDate: _getNextSchoolday(),
               dueDateSelection: s,

--- a/app/test/homework/homework_dialog_bloc_test.dart
+++ b/app/test/homework/homework_dialog_bloc_test.dart
@@ -23,6 +23,7 @@ import 'package:rxdart/rxdart.dart';
 import 'package:sharezone/homework/homework_dialog/homework_dialog_bloc.dart';
 import 'package:sharezone/markdown/markdown_analytics.dart';
 import 'package:time/time.dart';
+import 'package:user/user.dart';
 
 import '../analytics/analytics_test.dart';
 import 'homework_dialog_test.dart';
@@ -51,6 +52,7 @@ void main() {
         nextLessonCalculator: nextLessonCalculator,
         analytics: analytics,
         markdownAnalytics: MarkdownAnalytics(analytics),
+        enabledWeekdays: EnabledWeekDays.standard.getEnabledWeekDaysList(),
       );
     }
 
@@ -61,6 +63,7 @@ void main() {
         analytics: analytics,
         homeworkId: id,
         markdownAnalytics: MarkdownAnalytics(analytics),
+        enabledWeekdays: EnabledWeekDays.standard.getEnabledWeekDaysList(),
       );
     }
 

--- a/app/test/homework/homework_dialog_test.dart
+++ b/app/test/homework/homework_dialog_test.dart
@@ -737,10 +737,8 @@ void main() {
       expect(controller.getSelectedLessonChips(), ['Nächster Schultag']);
       expect(controller.getSelectedDueDate(), Date('2023-11-06'));
     });
-    // TODO: No active day
     testWidgets('custom schooldays get accounted for', (tester) async {
       final controller = createController(tester);
-      controller.addCourse(courseWith(id: 'foo_course', name: 'Foo course'));
       controller.setSchooldays(
           [WeekDay.tuesday, WeekDay.wednesday, WeekDay.friday, WeekDay.sunday]);
       // Friday, thus next schoolday is Sunday
@@ -751,6 +749,21 @@ void main() {
 
       await controller.selectLessonChip('Nächster Schultag');
       expect(controller.getSelectedDueDate(), Date('2024-01-14')); // Sunday
+    });
+    testWidgets(
+        'if user has schooldays set to empty, tomorrow will be returned for the next school day',
+        (tester) async {
+      final controller = createController(tester);
+      // Right now people can actually deselect all schooldays. This doesn't
+      // really make sense but we should still handle it.
+      controller.setSchooldays([]);
+      controller.setToday(Date('2024-02-10'));
+
+      await pumpAndSettleHomeworkDialog(tester,
+          showDueDateSelectionChips: true);
+
+      await controller.selectLessonChip('Nächster Schultag');
+      expect(controller.getSelectedDueDate(), Date('2024-02-11'));
     });
     testWidgets('when no course is selected then the lesson chips are disabled',
         (tester) async {

--- a/app/test/homework/homework_dialog_test.dart
+++ b/app/test/homework/homework_dialog_test.dart
@@ -724,6 +724,37 @@ void main() {
       expect(controller.getSelectedLessonChips(), ['Nächster Schultag']);
       expect(controller.getSelectedDueDate(), Date('2023-11-06'));
     });
+    testWidgets('custom schooldays get accounted for', (tester) async {
+      final controller = createController(tester);
+      controller.addCourse(courseWith(id: 'foo_course', name: 'Foo course'));
+      controller.setSchooldays(['Tuesday', 'Wednesday', 'Friday', 'Sunday']);
+      // Friday, thus next schoolday is Sunday
+      controller.setToday(Date('2024-01-12'));
+      controller.addNextLessonDates('foo_course', [
+        Date('2024-01-16'), // Tuesday
+        Date('2024-01-19'), // Friday
+        Date('2024-01-23'), // Tuesday
+        Date('2024-01-26'), // Friday
+        Date('2024-01-30'), // Tuesday
+      ]);
+
+      await pumpAndSettleHomeworkDialog(tester,
+          showDueDateSelectionChips: true);
+
+      await controller.selectLessonChip('Nächster Schultag');
+      expect(controller.getSelectedDueDate(), Date('2024-01-14')); // Sunday
+
+      // await controller.selectCourse('foo_course');
+
+      // await controller.selectLessonChip('Nächste Stunde');
+      // expect(controller.getSelectedDueDate(), Date('2024-01-16'));
+
+      // await controller.selectLessonChip('Übernächste Stunde');
+      // expect(controller.getSelectedDueDate(), Date('2024-01-19'));
+
+      // await controller.createCustomChip(inXLessons: 5);
+      // expect(controller.getSelectedDueDate(), Date('2024-01-30'));
+    });
     testWidgets('when no course is selected then the lesson chips are disabled',
         (tester) async {
       final controller = createController(tester);
@@ -1010,8 +1041,6 @@ class _TestController {
     return datePicker.selectedDate?.toDate();
   }
 
-  void setNextSchoolday(Date date) {}
-
   final _addedCourses = <String, Course>{};
   void addCourse(Course course) {
     _addedCourses[course.id] = course;
@@ -1060,6 +1089,8 @@ class _TestController {
     await tester.tap(find.byKey(HwDialogKeys.lessonChipDeleteIcon));
     await tester.pumpAndSettle();
   }
+
+  void setSchooldays(List<String> list) {}
 }
 
 // Used temporarily when testing so one can see what happens "on the screen" in

--- a/app/test/homework/homework_dialog_test.dart
+++ b/app/test/homework/homework_dialog_test.dart
@@ -1103,9 +1103,9 @@ class _TestController {
   }
 
   void setSchooldays(List<WeekDay> list) {
-    editUser((a) {
-      return a.copyWith(
-          userSettings: a.userSettings.copyWith(
+    editUser((appUser) {
+      return appUser.copyWith(
+          userSettings: appUser.userSettings.copyWith(
               enabledWeekDays: EnabledWeekDays.fromEnabledWeekDaysList(list)));
     });
   }

--- a/app/test/homework/homework_dialog_test.mocks.dart
+++ b/app/test/homework/homework_dialog_test.mocks.dart
@@ -3,24 +3,27 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i23;
+import 'dart:async' as _i24;
 
 import 'package:analytics/analytics.dart' as _i4;
-import 'package:app_functions/app_functions.dart' as _i21;
+import 'package:app_functions/app_functions.dart' as _i19;
+import 'package:authentification_base/authentification.dart' as _i27;
 import 'package:cloud_firestore/cloud_firestore.dart' as _i2;
 import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart'
-    as _i24;
+    as _i25;
 import 'package:common_domain_models/common_domain_models.dart' as _i8;
-import 'package:design/design.dart' as _i27;
+import 'package:design/design.dart' as _i30;
+import 'package:firebase_auth/firebase_auth.dart' as _i28;
 import 'package:firebase_hausaufgabenheft_logik/firebase_hausaufgabenheft_logik.dart'
-    as _i18;
-import 'package:group_domain_models/group_domain_accessors.dart' as _i19;
-import 'package:group_domain_models/group_domain_models.dart' as _i20;
+    as _i20;
+import 'package:flutter/material.dart' as _i29;
+import 'package:group_domain_models/group_domain_accessors.dart' as _i21;
+import 'package:group_domain_models/group_domain_models.dart' as _i22;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i22;
+import 'package:mockito/src/dummies.dart' as _i23;
 import 'package:shared_preferences/shared_preferences.dart' as _i6;
 import 'package:sharezone/filesharing/file_sharing_api.dart' as _i11;
-import 'package:sharezone/main/application_bloc.dart' as _i25;
+import 'package:sharezone/main/application_bloc.dart' as _i26;
 import 'package:sharezone/util/api.dart' as _i3;
 import 'package:sharezone/util/api/blackboard_api.dart' as _i10;
 import 'package:sharezone/util/api/connections_gateway.dart' as _i14;
@@ -33,7 +36,7 @@ import 'package:sharezone/util/navigation_service.dart' as _i7;
 import 'package:sharezone_common/references.dart' as _i13;
 import 'package:streaming_shared_preferences/streaming_shared_preferences.dart'
     as _i5;
-import 'package:user/user.dart' as _i26;
+import 'package:user/user.dart' as _i18;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -253,8 +256,8 @@ class _FakeTimetableGateway_18 extends _i1.SmartFake
         );
 }
 
-class _FakeHomeworkDto_19 extends _i1.SmartFake implements _i18.HomeworkDto {
-  _FakeHomeworkDto_19(
+class _FakeAppUser_19 extends _i1.SmartFake implements _i18.AppUser {
+  _FakeAppUser_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -263,9 +266,9 @@ class _FakeHomeworkDto_19 extends _i1.SmartFake implements _i18.HomeworkDto {
         );
 }
 
-class _FakeCourseMemberAccessor_20 extends _i1.SmartFake
-    implements _i19.CourseMemberAccessor {
-  _FakeCourseMemberAccessor_20(
+class _FakeAppFunctionsResult_20<T> extends _i1.SmartFake
+    implements _i19.AppFunctionsResult<T> {
+  _FakeAppFunctionsResult_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -274,8 +277,8 @@ class _FakeCourseMemberAccessor_20 extends _i1.SmartFake
         );
 }
 
-class _FakeCourse_21 extends _i1.SmartFake implements _i20.Course {
-  _FakeCourse_21(
+class _FakeHomeworkDto_21 extends _i1.SmartFake implements _i20.HomeworkDto {
+  _FakeHomeworkDto_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -284,9 +287,19 @@ class _FakeCourse_21 extends _i1.SmartFake implements _i20.Course {
         );
 }
 
-class _FakeAppFunctionsResult_22<T> extends _i1.SmartFake
-    implements _i21.AppFunctionsResult<T> {
-  _FakeAppFunctionsResult_22(
+class _FakeCourseMemberAccessor_22 extends _i1.SmartFake
+    implements _i21.CourseMemberAccessor {
+  _FakeCourseMemberAccessor_22(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeCourse_23 extends _i1.SmartFake implements _i22.Course {
+  _FakeCourse_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -316,11 +329,11 @@ class MockDocumentReference<T extends Object?> extends _i1.Mock
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i22.dummyValue<String>(
+        returnValue: _i23.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i22.dummyValue<String>(
+        returnValueForMissingStub: _i23.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -340,11 +353,11 @@ class MockDocumentReference<T extends Object?> extends _i1.Mock
   @override
   String get path => (super.noSuchMethod(
         Invocation.getter(#path),
-        returnValue: _i22.dummyValue<String>(
+        returnValue: _i23.dummyValue<String>(
           this,
           Invocation.getter(#path),
         ),
-        returnValueForMissingStub: _i22.dummyValue<String>(
+        returnValueForMissingStub: _i23.dummyValue<String>(
           this,
           Invocation.getter(#path),
         ),
@@ -374,31 +387,31 @@ class MockDocumentReference<T extends Object?> extends _i1.Mock
         ),
       ) as _i2.CollectionReference<Map<String, dynamic>>);
   @override
-  _i23.Future<void> delete() => (super.noSuchMethod(
+  _i24.Future<void> delete() => (super.noSuchMethod(
         Invocation.method(
           #delete,
           [],
         ),
-        returnValue: _i23.Future<void>.value(),
-        returnValueForMissingStub: _i23.Future<void>.value(),
-      ) as _i23.Future<void>);
+        returnValue: _i24.Future<void>.value(),
+        returnValueForMissingStub: _i24.Future<void>.value(),
+      ) as _i24.Future<void>);
   @override
-  _i23.Future<void> update(Map<Object, Object?>? data) => (super.noSuchMethod(
+  _i24.Future<void> update(Map<Object, Object?>? data) => (super.noSuchMethod(
         Invocation.method(
           #update,
           [data],
         ),
-        returnValue: _i23.Future<void>.value(),
-        returnValueForMissingStub: _i23.Future<void>.value(),
-      ) as _i23.Future<void>);
+        returnValue: _i24.Future<void>.value(),
+        returnValueForMissingStub: _i24.Future<void>.value(),
+      ) as _i24.Future<void>);
   @override
-  _i23.Future<_i2.DocumentSnapshot<T>> get([_i24.GetOptions? options]) =>
+  _i24.Future<_i2.DocumentSnapshot<T>> get([_i25.GetOptions? options]) =>
       (super.noSuchMethod(
         Invocation.method(
           #get,
           [options],
         ),
-        returnValue: _i23.Future<_i2.DocumentSnapshot<T>>.value(
+        returnValue: _i24.Future<_i2.DocumentSnapshot<T>>.value(
             _FakeDocumentSnapshot_2<T>(
           this,
           Invocation.method(
@@ -406,7 +419,7 @@ class MockDocumentReference<T extends Object?> extends _i1.Mock
             [options],
           ),
         )),
-        returnValueForMissingStub: _i23.Future<_i2.DocumentSnapshot<T>>.value(
+        returnValueForMissingStub: _i24.Future<_i2.DocumentSnapshot<T>>.value(
             _FakeDocumentSnapshot_2<T>(
           this,
           Invocation.method(
@@ -414,9 +427,9 @@ class MockDocumentReference<T extends Object?> extends _i1.Mock
             [options],
           ),
         )),
-      ) as _i23.Future<_i2.DocumentSnapshot<T>>);
+      ) as _i24.Future<_i2.DocumentSnapshot<T>>);
   @override
-  _i23.Stream<_i2.DocumentSnapshot<T>> snapshots(
+  _i24.Stream<_i2.DocumentSnapshot<T>> snapshots(
           {bool? includeMetadataChanges = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -424,13 +437,13 @@ class MockDocumentReference<T extends Object?> extends _i1.Mock
           [],
           {#includeMetadataChanges: includeMetadataChanges},
         ),
-        returnValue: _i23.Stream<_i2.DocumentSnapshot<T>>.empty(),
-        returnValueForMissingStub: _i23.Stream<_i2.DocumentSnapshot<T>>.empty(),
-      ) as _i23.Stream<_i2.DocumentSnapshot<T>>);
+        returnValue: _i24.Stream<_i2.DocumentSnapshot<T>>.empty(),
+        returnValueForMissingStub: _i24.Stream<_i2.DocumentSnapshot<T>>.empty(),
+      ) as _i24.Stream<_i2.DocumentSnapshot<T>>);
   @override
-  _i23.Future<void> set(
+  _i24.Future<void> set(
     T? data, [
-    _i24.SetOptions? options,
+    _i25.SetOptions? options,
   ]) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -440,9 +453,9 @@ class MockDocumentReference<T extends Object?> extends _i1.Mock
             options,
           ],
         ),
-        returnValue: _i23.Future<void>.value(),
-        returnValueForMissingStub: _i23.Future<void>.value(),
-      ) as _i23.Future<void>);
+        returnValue: _i24.Future<void>.value(),
+        returnValueForMissingStub: _i24.Future<void>.value(),
+      ) as _i24.Future<void>);
   @override
   _i2.DocumentReference<R> withConverter<R>({
     required _i2.FromFirestore<R>? fromFirestore,
@@ -485,7 +498,7 @@ class MockDocumentReference<T extends Object?> extends _i1.Mock
 /// A class which mocks [SharezoneContext].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockSharezoneContext extends _i1.Mock implements _i25.SharezoneContext {
+class MockSharezoneContext extends _i1.Mock implements _i26.SharezoneContext {
   @override
   _i3.SharezoneGateway get api => (super.noSuchMethod(
         Invocation.getter(#api),
@@ -564,11 +577,11 @@ class MockSharezoneGateway extends _i1.Mock implements _i3.SharezoneGateway {
   @override
   String get uID => (super.noSuchMethod(
         Invocation.getter(#uID),
-        returnValue: _i22.dummyValue<String>(
+        returnValue: _i23.dummyValue<String>(
           this,
           Invocation.getter(#uID),
         ),
-        returnValueForMissingStub: _i22.dummyValue<String>(
+        returnValueForMissingStub: _i23.dummyValue<String>(
           this,
           Invocation.getter(#uID),
         ),
@@ -648,11 +661,11 @@ class MockSharezoneGateway extends _i1.Mock implements _i3.SharezoneGateway {
   @override
   String get memberID => (super.noSuchMethod(
         Invocation.getter(#memberID),
-        returnValue: _i22.dummyValue<String>(
+        returnValue: _i23.dummyValue<String>(
           this,
           Invocation.getter(#memberID),
         ),
-        returnValueForMissingStub: _i22.dummyValue<String>(
+        returnValueForMissingStub: _i23.dummyValue<String>(
           this,
           Invocation.getter(#memberID),
         ),
@@ -706,14 +719,300 @@ class MockSharezoneGateway extends _i1.Mock implements _i3.SharezoneGateway {
         ),
       ) as _i17.TimetableGateway);
   @override
-  _i23.Future<void> dispose() => (super.noSuchMethod(
+  _i24.Future<void> dispose() => (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
         ),
-        returnValue: _i23.Future<void>.value(),
-        returnValueForMissingStub: _i23.Future<void>.value(),
-      ) as _i23.Future<void>);
+        returnValue: _i24.Future<void>.value(),
+        returnValueForMissingStub: _i24.Future<void>.value(),
+      ) as _i24.Future<void>);
+}
+
+/// A class which mocks [UserGateway].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockUserGateway extends _i1.Mock implements _i12.UserGateway {
+  @override
+  _i13.References get references => (super.noSuchMethod(
+        Invocation.getter(#references),
+        returnValue: _FakeReferences_14(
+          this,
+          Invocation.getter(#references),
+        ),
+        returnValueForMissingStub: _FakeReferences_14(
+          this,
+          Invocation.getter(#references),
+        ),
+      ) as _i13.References);
+  @override
+  String get uID => (super.noSuchMethod(
+        Invocation.getter(#uID),
+        returnValue: _i23.dummyValue<String>(
+          this,
+          Invocation.getter(#uID),
+        ),
+        returnValueForMissingStub: _i23.dummyValue<String>(
+          this,
+          Invocation.getter(#uID),
+        ),
+      ) as String);
+  @override
+  _i24.Stream<_i18.AppUser?> get userStream => (super.noSuchMethod(
+        Invocation.getter(#userStream),
+        returnValue: _i24.Stream<_i18.AppUser?>.empty(),
+        returnValueForMissingStub: _i24.Stream<_i18.AppUser?>.empty(),
+      ) as _i24.Stream<_i18.AppUser?>);
+  @override
+  _i24.Stream<_i27.AuthUser?> get authUserStream => (super.noSuchMethod(
+        Invocation.getter(#authUserStream),
+        returnValue: _i24.Stream<_i27.AuthUser?>.empty(),
+        returnValueForMissingStub: _i24.Stream<_i27.AuthUser?>.empty(),
+      ) as _i24.Stream<_i27.AuthUser?>);
+  @override
+  _i24.Stream<bool> get isSignedInStream => (super.noSuchMethod(
+        Invocation.getter(#isSignedInStream),
+        returnValue: _i24.Stream<bool>.empty(),
+        returnValueForMissingStub: _i24.Stream<bool>.empty(),
+      ) as _i24.Stream<bool>);
+  @override
+  _i24.Stream<_i2.DocumentSnapshot<Object?>> get userDocument =>
+      (super.noSuchMethod(
+        Invocation.getter(#userDocument),
+        returnValue: _i24.Stream<_i2.DocumentSnapshot<Object?>>.empty(),
+        returnValueForMissingStub:
+            _i24.Stream<_i2.DocumentSnapshot<Object?>>.empty(),
+      ) as _i24.Stream<_i2.DocumentSnapshot<Object?>>);
+  @override
+  _i24.Stream<_i27.Provider?> get providerStream => (super.noSuchMethod(
+        Invocation.getter(#providerStream),
+        returnValue: _i24.Stream<_i27.Provider?>.empty(),
+        returnValueForMissingStub: _i24.Stream<_i27.Provider?>.empty(),
+      ) as _i24.Stream<_i27.Provider?>);
+  @override
+  _i24.Future<_i18.AppUser> get() => (super.noSuchMethod(
+        Invocation.method(
+          #get,
+          [],
+        ),
+        returnValue: _i24.Future<_i18.AppUser>.value(_FakeAppUser_19(
+          this,
+          Invocation.method(
+            #get,
+            [],
+          ),
+        )),
+        returnValueForMissingStub:
+            _i24.Future<_i18.AppUser>.value(_FakeAppUser_19(
+          this,
+          Invocation.method(
+            #get,
+            [],
+          ),
+        )),
+      ) as _i24.Future<_i18.AppUser>);
+  @override
+  _i24.Future<void> logOut() => (super.noSuchMethod(
+        Invocation.method(
+          #logOut,
+          [],
+        ),
+        returnValue: _i24.Future<void>.value(),
+        returnValueForMissingStub: _i24.Future<void>.value(),
+      ) as _i24.Future<void>);
+  @override
+  bool isAnonymous() => (super.noSuchMethod(
+        Invocation.method(
+          #isAnonymous,
+          [],
+        ),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+  @override
+  _i24.Stream<bool?> isAnonymousStream() => (super.noSuchMethod(
+        Invocation.method(
+          #isAnonymousStream,
+          [],
+        ),
+        returnValue: _i24.Stream<bool?>.empty(),
+        returnValueForMissingStub: _i24.Stream<bool?>.empty(),
+      ) as _i24.Stream<bool?>);
+  @override
+  _i24.Future<void> linkWithCredential(_i28.AuthCredential? credential) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #linkWithCredential,
+          [credential],
+        ),
+        returnValue: _i24.Future<void>.value(),
+        returnValueForMissingStub: _i24.Future<void>.value(),
+      ) as _i24.Future<void>);
+  @override
+  _i24.Future<void> changeState(_i18.StateEnum? state) => (super.noSuchMethod(
+        Invocation.method(
+          #changeState,
+          [state],
+        ),
+        returnValue: _i24.Future<void>.value(),
+        returnValueForMissingStub: _i24.Future<void>.value(),
+      ) as _i24.Future<void>);
+  @override
+  _i24.Future<void> addNotificationToken(String? token) => (super.noSuchMethod(
+        Invocation.method(
+          #addNotificationToken,
+          [token],
+        ),
+        returnValue: _i24.Future<void>.value(),
+        returnValueForMissingStub: _i24.Future<void>.value(),
+      ) as _i24.Future<void>);
+  @override
+  void removeNotificationToken(String? token) => super.noSuchMethod(
+        Invocation.method(
+          #removeNotificationToken,
+          [token],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  _i24.Future<void> setHomeworkReminderTime(_i29.TimeOfDay? timeOfDay) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #setHomeworkReminderTime,
+          [timeOfDay],
+        ),
+        returnValue: _i24.Future<void>.value(),
+        returnValueForMissingStub: _i24.Future<void>.value(),
+      ) as _i24.Future<void>);
+  @override
+  _i24.Future<void> updateSettings(_i18.UserSettings? userSettings) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #updateSettings,
+          [userSettings],
+        ),
+        returnValue: _i24.Future<void>.value(),
+        returnValueForMissingStub: _i24.Future<void>.value(),
+      ) as _i24.Future<void>);
+  @override
+  _i24.Future<void> updateSettingsSingleFiled(
+    String? fieldName,
+    dynamic data,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #updateSettingsSingleFiled,
+          [
+            fieldName,
+            data,
+          ],
+        ),
+        returnValue: _i24.Future<void>.value(),
+        returnValueForMissingStub: _i24.Future<void>.value(),
+      ) as _i24.Future<void>);
+  @override
+  _i24.Future<void> updateUserTip(
+    _i18.UserTipKey? userTipKey,
+    bool? value,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #updateUserTip,
+          [
+            userTipKey,
+            value,
+          ],
+        ),
+        returnValue: _i24.Future<void>.value(),
+        returnValueForMissingStub: _i24.Future<void>.value(),
+      ) as _i24.Future<void>);
+  @override
+  void setBlackboardNotifications(bool? enabled) => super.noSuchMethod(
+        Invocation.method(
+          #setBlackboardNotifications,
+          [enabled],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  void setCommentsNotifications(bool? enabled) => super.noSuchMethod(
+        Invocation.method(
+          #setCommentsNotifications,
+          [enabled],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
+  _i24.Future<void> changeEmail(String? email) => (super.noSuchMethod(
+        Invocation.method(
+          #changeEmail,
+          [email],
+        ),
+        returnValue: _i24.Future<void>.value(),
+        returnValueForMissingStub: _i24.Future<void>.value(),
+      ) as _i24.Future<void>);
+  @override
+  _i24.Future<void> addUser({
+    required _i18.AppUser? user,
+    bool? merge = false,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #addUser,
+          [],
+          {
+            #user: user,
+            #merge: merge,
+          },
+        ),
+        returnValue: _i24.Future<void>.value(),
+        returnValueForMissingStub: _i24.Future<void>.value(),
+      ) as _i24.Future<void>);
+  @override
+  _i24.Future<bool> deleteUser(_i3.SharezoneGateway? gateway) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #deleteUser,
+          [gateway],
+        ),
+        returnValue: _i24.Future<bool>.value(false),
+        returnValueForMissingStub: _i24.Future<bool>.value(false),
+      ) as _i24.Future<bool>);
+  @override
+  _i24.Future<_i19.AppFunctionsResult<bool>> updateUser(
+          _i18.AppUser? userData) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #updateUser,
+          [userData],
+        ),
+        returnValue: _i24.Future<_i19.AppFunctionsResult<bool>>.value(
+            _FakeAppFunctionsResult_20<bool>(
+          this,
+          Invocation.method(
+            #updateUser,
+            [userData],
+          ),
+        )),
+        returnValueForMissingStub:
+            _i24.Future<_i19.AppFunctionsResult<bool>>.value(
+                _FakeAppFunctionsResult_20<bool>(
+          this,
+          Invocation.method(
+            #updateUser,
+            [userData],
+          ),
+        )),
+      ) as _i24.Future<_i19.AppFunctionsResult<bool>>);
+  @override
+  _i24.Future<void> dispose() => (super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValue: _i24.Future<void>.value(),
+        returnValueForMissingStub: _i24.Future<void>.value(),
+      ) as _i24.Future<void>);
 }
 
 /// A class which mocks [HomeworkGateway].
@@ -723,11 +1022,11 @@ class MockHomeworkGateway extends _i1.Mock implements _i9.HomeworkGateway {
   @override
   String get userId => (super.noSuchMethod(
         Invocation.getter(#userId),
-        returnValue: _i22.dummyValue<String>(
+        returnValue: _i23.dummyValue<String>(
           this,
           Invocation.getter(#userId),
         ),
-        returnValueForMissingStub: _i22.dummyValue<String>(
+        returnValueForMissingStub: _i23.dummyValue<String>(
           this,
           Invocation.getter(#userId),
         ),
@@ -747,38 +1046,38 @@ class MockHomeworkGateway extends _i1.Mock implements _i9.HomeworkGateway {
         ),
       ) as _i2.CollectionReference<Map<String, dynamic>>);
   @override
-  _i23.Stream<_i26.TypeOfUser?> get typeOfUserStream => (super.noSuchMethod(
+  _i24.Stream<_i18.TypeOfUser?> get typeOfUserStream => (super.noSuchMethod(
         Invocation.getter(#typeOfUserStream),
-        returnValue: _i23.Stream<_i26.TypeOfUser?>.empty(),
-        returnValueForMissingStub: _i23.Stream<_i26.TypeOfUser?>.empty(),
-      ) as _i23.Stream<_i26.TypeOfUser?>);
+        returnValue: _i24.Stream<_i18.TypeOfUser?>.empty(),
+        returnValueForMissingStub: _i24.Stream<_i18.TypeOfUser?>.empty(),
+      ) as _i24.Stream<_i18.TypeOfUser?>);
   @override
-  _i23.Stream<List<_i18.HomeworkDto>> get homeworkForNowAndInFutureStream =>
+  _i24.Stream<List<_i20.HomeworkDto>> get homeworkForNowAndInFutureStream =>
       (super.noSuchMethod(
         Invocation.getter(#homeworkForNowAndInFutureStream),
-        returnValue: _i23.Stream<List<_i18.HomeworkDto>>.empty(),
-        returnValueForMissingStub: _i23.Stream<List<_i18.HomeworkDto>>.empty(),
-      ) as _i23.Stream<List<_i18.HomeworkDto>>);
+        returnValue: _i24.Stream<List<_i20.HomeworkDto>>.empty(),
+        returnValueForMissingStub: _i24.Stream<List<_i20.HomeworkDto>>.empty(),
+      ) as _i24.Stream<List<_i20.HomeworkDto>>);
   @override
-  _i23.Stream<List<_i18.HomeworkDto>> get homeworkStream => (super.noSuchMethod(
+  _i24.Stream<List<_i20.HomeworkDto>> get homeworkStream => (super.noSuchMethod(
         Invocation.getter(#homeworkStream),
-        returnValue: _i23.Stream<List<_i18.HomeworkDto>>.empty(),
-        returnValueForMissingStub: _i23.Stream<List<_i18.HomeworkDto>>.empty(),
-      ) as _i23.Stream<List<_i18.HomeworkDto>>);
+        returnValue: _i24.Stream<List<_i20.HomeworkDto>>.empty(),
+        returnValueForMissingStub: _i24.Stream<List<_i20.HomeworkDto>>.empty(),
+      ) as _i24.Stream<List<_i20.HomeworkDto>>);
   @override
-  _i23.Stream<_i18.HomeworkDto> singleHomeworkStream(String? homeworkId) =>
+  _i24.Stream<_i20.HomeworkDto> singleHomeworkStream(String? homeworkId) =>
       (super.noSuchMethod(
         Invocation.method(
           #singleHomeworkStream,
           [homeworkId],
         ),
-        returnValue: _i23.Stream<_i18.HomeworkDto>.empty(),
-        returnValueForMissingStub: _i23.Stream<_i18.HomeworkDto>.empty(),
-      ) as _i23.Stream<_i18.HomeworkDto>);
+        returnValue: _i24.Stream<_i20.HomeworkDto>.empty(),
+        returnValueForMissingStub: _i24.Stream<_i20.HomeworkDto>.empty(),
+      ) as _i24.Stream<_i20.HomeworkDto>);
   @override
-  _i23.Future<_i18.HomeworkDto> singleHomework(
+  _i24.Future<_i20.HomeworkDto> singleHomework(
     String? homeworkId, {
-    _i24.Source? source = _i24.Source.serverAndCache,
+    _i25.Source? source = _i25.Source.serverAndCache,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -786,7 +1085,7 @@ class MockHomeworkGateway extends _i1.Mock implements _i9.HomeworkGateway {
           [homeworkId],
           {#source: source},
         ),
-        returnValue: _i23.Future<_i18.HomeworkDto>.value(_FakeHomeworkDto_19(
+        returnValue: _i24.Future<_i20.HomeworkDto>.value(_FakeHomeworkDto_21(
           this,
           Invocation.method(
             #singleHomework,
@@ -795,7 +1094,7 @@ class MockHomeworkGateway extends _i1.Mock implements _i9.HomeworkGateway {
           ),
         )),
         returnValueForMissingStub:
-            _i23.Future<_i18.HomeworkDto>.value(_FakeHomeworkDto_19(
+            _i24.Future<_i20.HomeworkDto>.value(_FakeHomeworkDto_21(
           this,
           Invocation.method(
             #singleHomework,
@@ -803,10 +1102,10 @@ class MockHomeworkGateway extends _i1.Mock implements _i9.HomeworkGateway {
             {#source: source},
           ),
         )),
-      ) as _i23.Future<_i18.HomeworkDto>);
+      ) as _i24.Future<_i20.HomeworkDto>);
   @override
-  _i23.Future<void> deleteHomework(
-    _i18.HomeworkDto? homework, {
+  _i24.Future<void> deleteHomework(
+    _i20.HomeworkDto? homework, {
     _i11.FileSharingGateway? fileSharingGateway,
   }) =>
       (super.noSuchMethod(
@@ -815,11 +1114,11 @@ class MockHomeworkGateway extends _i1.Mock implements _i9.HomeworkGateway {
           [homework],
           {#fileSharingGateway: fileSharingGateway},
         ),
-        returnValue: _i23.Future<void>.value(),
-        returnValueForMissingStub: _i23.Future<void>.value(),
-      ) as _i23.Future<void>);
+        returnValue: _i24.Future<void>.value(),
+        returnValueForMissingStub: _i24.Future<void>.value(),
+      ) as _i24.Future<void>);
   @override
-  void deleteHomeworkOnlyForCurrentUser(_i18.HomeworkDto? homework) =>
+  void deleteHomeworkOnlyForCurrentUser(_i20.HomeworkDto? homework) =>
       super.noSuchMethod(
         Invocation.method(
           #deleteHomeworkOnlyForCurrentUser,
@@ -828,8 +1127,8 @@ class MockHomeworkGateway extends _i1.Mock implements _i9.HomeworkGateway {
         returnValueForMissingStub: null,
       );
   @override
-  _i23.Future<_i2.DocumentReference<Object?>> addHomeworkToCourse(
-    _i18.HomeworkDto? homework, {
+  _i24.Future<_i2.DocumentReference<Object?>> addHomeworkToCourse(
+    _i20.HomeworkDto? homework, {
     List<String>? attachments,
     required _i11.FileSharingGateway? fileSharingGateway,
   }) =>
@@ -842,7 +1141,7 @@ class MockHomeworkGateway extends _i1.Mock implements _i9.HomeworkGateway {
             #fileSharingGateway: fileSharingGateway,
           },
         ),
-        returnValue: _i23.Future<_i2.DocumentReference<Object?>>.value(
+        returnValue: _i24.Future<_i2.DocumentReference<Object?>>.value(
             _FakeDocumentReference_3<Object?>(
           this,
           Invocation.method(
@@ -855,7 +1154,7 @@ class MockHomeworkGateway extends _i1.Mock implements _i9.HomeworkGateway {
           ),
         )),
         returnValueForMissingStub:
-            _i23.Future<_i2.DocumentReference<Object?>>.value(
+            _i24.Future<_i2.DocumentReference<Object?>>.value(
                 _FakeDocumentReference_3<Object?>(
           this,
           Invocation.method(
@@ -867,10 +1166,10 @@ class MockHomeworkGateway extends _i1.Mock implements _i9.HomeworkGateway {
             },
           ),
         )),
-      ) as _i23.Future<_i2.DocumentReference<Object?>>);
+      ) as _i24.Future<_i2.DocumentReference<Object?>>);
   @override
-  _i23.Future<void> addPrivateHomework(
-    _i18.HomeworkDto? homework,
+  _i24.Future<void> addPrivateHomework(
+    _i20.HomeworkDto? homework,
     bool? merge, {
     List<String>? attachments,
     _i11.FileSharingGateway? fileSharingGateway,
@@ -887,9 +1186,9 @@ class MockHomeworkGateway extends _i1.Mock implements _i9.HomeworkGateway {
             #fileSharingGateway: fileSharingGateway,
           },
         ),
-        returnValue: _i23.Future<void>.value(),
-        returnValueForMissingStub: _i23.Future<void>.value(),
-      ) as _i23.Future<void>);
+        returnValue: _i24.Future<void>.value(),
+        returnValueForMissingStub: _i24.Future<void>.value(),
+      ) as _i24.Future<void>);
   @override
   void changeIsHomeworkDoneTo(
     String? homeworkDocumentID,
@@ -934,30 +1233,30 @@ class MockCourseGateway extends _i1.Mock implements _i15.CourseGateway {
   @override
   String get memberID => (super.noSuchMethod(
         Invocation.getter(#memberID),
-        returnValue: _i22.dummyValue<String>(
+        returnValue: _i23.dummyValue<String>(
           this,
           Invocation.getter(#memberID),
         ),
-        returnValueForMissingStub: _i22.dummyValue<String>(
+        returnValueForMissingStub: _i23.dummyValue<String>(
           this,
           Invocation.getter(#memberID),
         ),
       ) as String);
   @override
-  _i19.CourseMemberAccessor get memberAccessor => (super.noSuchMethod(
+  _i21.CourseMemberAccessor get memberAccessor => (super.noSuchMethod(
         Invocation.getter(#memberAccessor),
-        returnValue: _FakeCourseMemberAccessor_20(
+        returnValue: _FakeCourseMemberAccessor_22(
           this,
           Invocation.getter(#memberAccessor),
         ),
-        returnValueForMissingStub: _FakeCourseMemberAccessor_20(
+        returnValueForMissingStub: _FakeCourseMemberAccessor_22(
           this,
           Invocation.getter(#memberAccessor),
         ),
-      ) as _i19.CourseMemberAccessor);
+      ) as _i21.CourseMemberAccessor);
   @override
-  _i20.Course createCourse(
-    _i20.CourseData? courseData,
+  _i22.Course createCourse(
+    _i22.CourseData? courseData,
     _i12.UserGateway? userGateway,
   ) =>
       (super.noSuchMethod(
@@ -968,7 +1267,7 @@ class MockCourseGateway extends _i1.Mock implements _i15.CourseGateway {
             userGateway,
           ],
         ),
-        returnValue: _FakeCourse_21(
+        returnValue: _FakeCourse_23(
           this,
           Invocation.method(
             #createCourse,
@@ -978,7 +1277,7 @@ class MockCourseGateway extends _i1.Mock implements _i15.CourseGateway {
             ],
           ),
         ),
-        returnValueForMissingStub: _FakeCourse_21(
+        returnValueForMissingStub: _FakeCourse_23(
           this,
           Invocation.method(
             #createCourse,
@@ -988,16 +1287,16 @@ class MockCourseGateway extends _i1.Mock implements _i15.CourseGateway {
             ],
           ),
         ),
-      ) as _i20.Course);
+      ) as _i22.Course);
   @override
-  _i23.Future<_i21.AppFunctionsResult<bool>> joinCourse(String? courseID) =>
+  _i24.Future<_i19.AppFunctionsResult<bool>> joinCourse(String? courseID) =>
       (super.noSuchMethod(
         Invocation.method(
           #joinCourse,
           [courseID],
         ),
-        returnValue: _i23.Future<_i21.AppFunctionsResult<bool>>.value(
-            _FakeAppFunctionsResult_22<bool>(
+        returnValue: _i24.Future<_i19.AppFunctionsResult<bool>>.value(
+            _FakeAppFunctionsResult_20<bool>(
           this,
           Invocation.method(
             #joinCourse,
@@ -1005,24 +1304,24 @@ class MockCourseGateway extends _i1.Mock implements _i15.CourseGateway {
           ),
         )),
         returnValueForMissingStub:
-            _i23.Future<_i21.AppFunctionsResult<bool>>.value(
-                _FakeAppFunctionsResult_22<bool>(
+            _i24.Future<_i19.AppFunctionsResult<bool>>.value(
+                _FakeAppFunctionsResult_20<bool>(
           this,
           Invocation.method(
             #joinCourse,
             [courseID],
           ),
         )),
-      ) as _i23.Future<_i21.AppFunctionsResult<bool>>);
+      ) as _i24.Future<_i19.AppFunctionsResult<bool>>);
   @override
-  _i23.Future<_i21.AppFunctionsResult<bool>> leaveCourse(String? courseID) =>
+  _i24.Future<_i19.AppFunctionsResult<bool>> leaveCourse(String? courseID) =>
       (super.noSuchMethod(
         Invocation.method(
           #leaveCourse,
           [courseID],
         ),
-        returnValue: _i23.Future<_i21.AppFunctionsResult<bool>>.value(
-            _FakeAppFunctionsResult_22<bool>(
+        returnValue: _i24.Future<_i19.AppFunctionsResult<bool>>.value(
+            _FakeAppFunctionsResult_20<bool>(
           this,
           Invocation.method(
             #leaveCourse,
@@ -1030,17 +1329,17 @@ class MockCourseGateway extends _i1.Mock implements _i15.CourseGateway {
           ),
         )),
         returnValueForMissingStub:
-            _i23.Future<_i21.AppFunctionsResult<bool>>.value(
-                _FakeAppFunctionsResult_22<bool>(
+            _i24.Future<_i19.AppFunctionsResult<bool>>.value(
+                _FakeAppFunctionsResult_20<bool>(
           this,
           Invocation.method(
             #leaveCourse,
             [courseID],
           ),
         )),
-      ) as _i23.Future<_i21.AppFunctionsResult<bool>>);
+      ) as _i24.Future<_i19.AppFunctionsResult<bool>>);
   @override
-  _i23.Future<_i21.AppFunctionsResult<bool>> kickMember(
+  _i24.Future<_i19.AppFunctionsResult<bool>> kickMember(
     String? courseID,
     String? kickedMemberID,
   ) =>
@@ -1052,8 +1351,8 @@ class MockCourseGateway extends _i1.Mock implements _i15.CourseGateway {
             kickedMemberID,
           ],
         ),
-        returnValue: _i23.Future<_i21.AppFunctionsResult<bool>>.value(
-            _FakeAppFunctionsResult_22<bool>(
+        returnValue: _i24.Future<_i19.AppFunctionsResult<bool>>.value(
+            _FakeAppFunctionsResult_20<bool>(
           this,
           Invocation.method(
             #kickMember,
@@ -1064,8 +1363,8 @@ class MockCourseGateway extends _i1.Mock implements _i15.CourseGateway {
           ),
         )),
         returnValueForMissingStub:
-            _i23.Future<_i21.AppFunctionsResult<bool>>.value(
-                _FakeAppFunctionsResult_22<bool>(
+            _i24.Future<_i19.AppFunctionsResult<bool>>.value(
+                _FakeAppFunctionsResult_20<bool>(
           this,
           Invocation.method(
             #kickMember,
@@ -1075,16 +1374,16 @@ class MockCourseGateway extends _i1.Mock implements _i15.CourseGateway {
             ],
           ),
         )),
-      ) as _i23.Future<_i21.AppFunctionsResult<bool>>);
+      ) as _i24.Future<_i19.AppFunctionsResult<bool>>);
   @override
-  _i23.Future<_i21.AppFunctionsResult<bool>> editCourse(_i20.Course? course) =>
+  _i24.Future<_i19.AppFunctionsResult<bool>> editCourse(_i22.Course? course) =>
       (super.noSuchMethod(
         Invocation.method(
           #editCourse,
           [course],
         ),
-        returnValue: _i23.Future<_i21.AppFunctionsResult<bool>>.value(
-            _FakeAppFunctionsResult_22<bool>(
+        returnValue: _i24.Future<_i19.AppFunctionsResult<bool>>.value(
+            _FakeAppFunctionsResult_20<bool>(
           this,
           Invocation.method(
             #editCourse,
@@ -1092,27 +1391,27 @@ class MockCourseGateway extends _i1.Mock implements _i15.CourseGateway {
           ),
         )),
         returnValueForMissingStub:
-            _i23.Future<_i21.AppFunctionsResult<bool>>.value(
-                _FakeAppFunctionsResult_22<bool>(
+            _i24.Future<_i19.AppFunctionsResult<bool>>.value(
+                _FakeAppFunctionsResult_20<bool>(
           this,
           Invocation.method(
             #editCourse,
             [course],
           ),
         )),
-      ) as _i23.Future<_i21.AppFunctionsResult<bool>>);
+      ) as _i24.Future<_i19.AppFunctionsResult<bool>>);
   @override
-  _i20.Course? getCourse(String? id) => (super.noSuchMethod(
+  _i22.Course? getCourse(String? id) => (super.noSuchMethod(
         Invocation.method(
           #getCourse,
           [id],
         ),
         returnValueForMissingStub: null,
-      ) as _i20.Course?);
+      ) as _i22.Course?);
   @override
-  _i23.Future<_i21.AppFunctionsResult<bool>> editCourseSettings(
+  _i24.Future<_i19.AppFunctionsResult<bool>> editCourseSettings(
     String? courseID,
-    _i20.CourseSettings? courseSettings,
+    _i22.CourseSettings? courseSettings,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1122,8 +1421,8 @@ class MockCourseGateway extends _i1.Mock implements _i15.CourseGateway {
             courseSettings,
           ],
         ),
-        returnValue: _i23.Future<_i21.AppFunctionsResult<bool>>.value(
-            _FakeAppFunctionsResult_22<bool>(
+        returnValue: _i24.Future<_i19.AppFunctionsResult<bool>>.value(
+            _FakeAppFunctionsResult_20<bool>(
           this,
           Invocation.method(
             #editCourseSettings,
@@ -1134,8 +1433,8 @@ class MockCourseGateway extends _i1.Mock implements _i15.CourseGateway {
           ),
         )),
         returnValueForMissingStub:
-            _i23.Future<_i21.AppFunctionsResult<bool>>.value(
-                _FakeAppFunctionsResult_22<bool>(
+            _i24.Future<_i19.AppFunctionsResult<bool>>.value(
+                _FakeAppFunctionsResult_20<bool>(
           this,
           Invocation.method(
             #editCourseSettings,
@@ -1145,16 +1444,16 @@ class MockCourseGateway extends _i1.Mock implements _i15.CourseGateway {
             ],
           ),
         )),
-      ) as _i23.Future<_i21.AppFunctionsResult<bool>>);
+      ) as _i24.Future<_i19.AppFunctionsResult<bool>>);
   @override
-  _i23.Future<_i21.AppFunctionsResult<bool>> deleteCourse(String? courseID) =>
+  _i24.Future<_i19.AppFunctionsResult<bool>> deleteCourse(String? courseID) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteCourse,
           [courseID],
         ),
-        returnValue: _i23.Future<_i21.AppFunctionsResult<bool>>.value(
-            _FakeAppFunctionsResult_22<bool>(
+        returnValue: _i24.Future<_i19.AppFunctionsResult<bool>>.value(
+            _FakeAppFunctionsResult_20<bool>(
           this,
           Invocation.method(
             #deleteCourse,
@@ -1162,19 +1461,19 @@ class MockCourseGateway extends _i1.Mock implements _i15.CourseGateway {
           ),
         )),
         returnValueForMissingStub:
-            _i23.Future<_i21.AppFunctionsResult<bool>>.value(
-                _FakeAppFunctionsResult_22<bool>(
+            _i24.Future<_i19.AppFunctionsResult<bool>>.value(
+                _FakeAppFunctionsResult_20<bool>(
           this,
           Invocation.method(
             #deleteCourse,
             [courseID],
           ),
         )),
-      ) as _i23.Future<_i21.AppFunctionsResult<bool>>);
+      ) as _i24.Future<_i19.AppFunctionsResult<bool>>);
   @override
-  _i23.Future<bool> editCourseGeneralDesign({
+  _i24.Future<bool> editCourseGeneralDesign({
     required String? courseID,
-    _i27.Design? design,
+    _i30.Design? design,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1185,13 +1484,13 @@ class MockCourseGateway extends _i1.Mock implements _i15.CourseGateway {
             #design: design,
           },
         ),
-        returnValue: _i23.Future<bool>.value(false),
-        returnValueForMissingStub: _i23.Future<bool>.value(false),
-      ) as _i23.Future<bool>);
+        returnValue: _i24.Future<bool>.value(false),
+        returnValueForMissingStub: _i24.Future<bool>.value(false),
+      ) as _i24.Future<bool>);
   @override
-  _i23.Future<bool> editCoursePersonalDesign({
+  _i24.Future<bool> editCoursePersonalDesign({
     required String? courseID,
-    _i27.Design? personalDesign,
+    _i30.Design? personalDesign,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1202,24 +1501,24 @@ class MockCourseGateway extends _i1.Mock implements _i15.CourseGateway {
             #personalDesign: personalDesign,
           },
         ),
-        returnValue: _i23.Future<bool>.value(false),
-        returnValueForMissingStub: _i23.Future<bool>.value(false),
-      ) as _i23.Future<bool>);
+        returnValue: _i24.Future<bool>.value(false),
+        returnValueForMissingStub: _i24.Future<bool>.value(false),
+      ) as _i24.Future<bool>);
   @override
-  _i23.Future<bool> removeCoursePersonalDesign(String? courseID) =>
+  _i24.Future<bool> removeCoursePersonalDesign(String? courseID) =>
       (super.noSuchMethod(
         Invocation.method(
           #removeCoursePersonalDesign,
           [courseID],
         ),
-        returnValue: _i23.Future<bool>.value(false),
-        returnValueForMissingStub: _i23.Future<bool>.value(false),
-      ) as _i23.Future<bool>);
+        returnValue: _i24.Future<bool>.value(false),
+        returnValueForMissingStub: _i24.Future<bool>.value(false),
+      ) as _i24.Future<bool>);
   @override
-  _i23.Future<_i21.AppFunctionsResult<bool>> memberUpdateRole({
+  _i24.Future<_i19.AppFunctionsResult<bool>> memberUpdateRole({
     required String? courseID,
     required String? newMemberID,
-    required _i20.MemberRole? newRole,
+    required _i22.MemberRole? newRole,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1231,8 +1530,8 @@ class MockCourseGateway extends _i1.Mock implements _i15.CourseGateway {
             #newRole: newRole,
           },
         ),
-        returnValue: _i23.Future<_i21.AppFunctionsResult<bool>>.value(
-            _FakeAppFunctionsResult_22<bool>(
+        returnValue: _i24.Future<_i19.AppFunctionsResult<bool>>.value(
+            _FakeAppFunctionsResult_20<bool>(
           this,
           Invocation.method(
             #memberUpdateRole,
@@ -1245,8 +1544,8 @@ class MockCourseGateway extends _i1.Mock implements _i15.CourseGateway {
           ),
         )),
         returnValueForMissingStub:
-            _i23.Future<_i21.AppFunctionsResult<bool>>.value(
-                _FakeAppFunctionsResult_22<bool>(
+            _i24.Future<_i19.AppFunctionsResult<bool>>.value(
+                _FakeAppFunctionsResult_20<bool>(
           this,
           Invocation.method(
             #memberUpdateRole,
@@ -1258,68 +1557,68 @@ class MockCourseGateway extends _i1.Mock implements _i15.CourseGateway {
             },
           ),
         )),
-      ) as _i23.Future<_i21.AppFunctionsResult<bool>>);
+      ) as _i24.Future<_i19.AppFunctionsResult<bool>>);
   @override
-  _i20.MemberRole? getRoleFromCourseNoSync(String? courseID) =>
+  _i22.MemberRole? getRoleFromCourseNoSync(String? courseID) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoleFromCourseNoSync,
           [courseID],
         ),
         returnValueForMissingStub: null,
-      ) as _i20.MemberRole?);
+      ) as _i22.MemberRole?);
   @override
-  _i23.Stream<_i20.Course?> streamCourse(String? courseID) =>
+  _i24.Stream<_i22.Course?> streamCourse(String? courseID) =>
       (super.noSuchMethod(
         Invocation.method(
           #streamCourse,
           [courseID],
         ),
-        returnValue: _i23.Stream<_i20.Course?>.empty(),
-        returnValueForMissingStub: _i23.Stream<_i20.Course?>.empty(),
-      ) as _i23.Stream<_i20.Course?>);
+        returnValue: _i24.Stream<_i22.Course?>.empty(),
+        returnValueForMissingStub: _i24.Stream<_i22.Course?>.empty(),
+      ) as _i24.Stream<_i22.Course?>);
   @override
-  _i23.Stream<List<_i20.Course>> streamCourses() => (super.noSuchMethod(
+  _i24.Stream<List<_i22.Course>> streamCourses() => (super.noSuchMethod(
         Invocation.method(
           #streamCourses,
           [],
         ),
-        returnValue: _i23.Stream<List<_i20.Course>>.empty(),
-        returnValueForMissingStub: _i23.Stream<List<_i20.Course>>.empty(),
-      ) as _i23.Stream<List<_i20.Course>>);
+        returnValue: _i24.Stream<List<_i22.Course>>.empty(),
+        returnValueForMissingStub: _i24.Stream<List<_i22.Course>>.empty(),
+      ) as _i24.Stream<List<_i22.Course>>);
   @override
-  _i23.Stream<Map<String, _i20.GroupInfo>> getGroupInfoStream(
+  _i24.Stream<Map<String, _i22.GroupInfo>> getGroupInfoStream(
           _i16.SchoolClassGateway? schoolClassGateway) =>
       (super.noSuchMethod(
         Invocation.method(
           #getGroupInfoStream,
           [schoolClassGateway],
         ),
-        returnValue: _i23.Stream<Map<String, _i20.GroupInfo>>.empty(),
+        returnValue: _i24.Stream<Map<String, _i22.GroupInfo>>.empty(),
         returnValueForMissingStub:
-            _i23.Stream<Map<String, _i20.GroupInfo>>.empty(),
-      ) as _i23.Stream<Map<String, _i20.GroupInfo>>);
+            _i24.Stream<Map<String, _i22.GroupInfo>>.empty(),
+      ) as _i24.Stream<Map<String, _i22.GroupInfo>>);
   @override
-  _i23.Future<List<_i20.Course>> getCourses() => (super.noSuchMethod(
+  _i24.Future<List<_i22.Course>> getCourses() => (super.noSuchMethod(
         Invocation.method(
           #getCourses,
           [],
         ),
-        returnValue: _i23.Future<List<_i20.Course>>.value(<_i20.Course>[]),
+        returnValue: _i24.Future<List<_i22.Course>>.value(<_i22.Course>[]),
         returnValueForMissingStub:
-            _i23.Future<List<_i20.Course>>.value(<_i20.Course>[]),
-      ) as _i23.Future<List<_i20.Course>>);
+            _i24.Future<List<_i22.Course>>.value(<_i22.Course>[]),
+      ) as _i24.Future<List<_i22.Course>>);
   @override
-  List<_i20.Course> getCurrentCourses() => (super.noSuchMethod(
+  List<_i22.Course> getCurrentCourses() => (super.noSuchMethod(
         Invocation.method(
           #getCurrentCourses,
           [],
         ),
-        returnValue: <_i20.Course>[],
-        returnValueForMissingStub: <_i20.Course>[],
-      ) as List<_i20.Course>);
+        returnValue: <_i22.Course>[],
+        returnValueForMissingStub: <_i22.Course>[],
+      ) as List<_i22.Course>);
   @override
-  bool canEditCourse(_i20.Course? course) => (super.noSuchMethod(
+  bool canEditCourse(_i22.Course? course) => (super.noSuchMethod(
         Invocation.method(
           #canEditCourse,
           [course],

--- a/lib/user/lib/src/models/timetable/enabled_weekdays.dart
+++ b/lib/user/lib/src/models/timetable/enabled_weekdays.dart
@@ -28,12 +28,13 @@ class EnabledWeekDays {
 
   factory EnabledWeekDays.fromEnabledWeekDaysList(
       List<WeekDay> enabledWeekDays) {
-    var f = EnabledWeekDays.standard;
-    for (final it in enabledWeekDays) {
-      f = f.copyWith(it, true);
+    var wkd = EnabledWeekDays.standard;
+
+    for (var weekday in WeekDay.values) {
+      wkd = wkd.copyWith(weekday, enabledWeekDays.contains(weekday));
     }
 
-    return f;
+    return wkd;
   }
 
   factory EnabledWeekDays.fromData(Map<String, dynamic>? data) {

--- a/lib/user/lib/src/models/timetable/enabled_weekdays.dart
+++ b/lib/user/lib/src/models/timetable/enabled_weekdays.dart
@@ -6,8 +6,8 @@
 //
 // SPDX-License-Identifier: EUPL-1.2
 
-import 'package:date/weekday.dart';
 import 'package:cloud_firestore_helper/cloud_firestore_helper.dart';
+import 'package:date/weekday.dart';
 
 const weekDayDefaults = {
   WeekDay.monday: true,
@@ -25,6 +25,16 @@ class EnabledWeekDays {
   const EnabledWeekDays._(this._internalMap);
 
   static const EnabledWeekDays standard = EnabledWeekDays._({});
+
+  factory EnabledWeekDays.fromEnabledWeekDaysList(
+      List<WeekDay> enabledWeekDays) {
+    var f = EnabledWeekDays.standard;
+    for (final it in enabledWeekDays) {
+      f = f.copyWith(it, true);
+    }
+
+    return f;
+  }
 
   factory EnabledWeekDays.fromData(Map<String, dynamic>? data) {
     return EnabledWeekDays._(decodeMap<bool?>(data, (key, value) => value));


### PR DESCRIPTION
Users can select "aktive Wochentage" ("active weekdays" -> custom schooldays) to customize on which days they'll have school.  
With this PR selecting the "Nächster Schultag" due date chip when creating a homework will take the "aktive Wochentage" into account. If e.g. the user has selected monday, wednesday and thursday as  "aktive Wochentage" then selecting "Nächster Schultag" on mondays will set the due date to the next wednesday since tuesday is not an  "aktiver Wochentag".

Fixes #1180 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced customization for enabled weekdays in the homework scheduling feature, allowing users to specify which days are considered school days.
- **Enhancements**
	- Improved the logic for calculating the next school day based on user-defined enabled weekdays.
- **Tests**
	- Added tests to ensure the correct handling of custom and empty school day settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->