### PR TITLE
Add `createdOn` for calendrical events

### DIFF
--- a/app/lib/calendrical_events/models/calendrical_event.dart
+++ b/app/lib/calendrical_events/models/calendrical_event.dart
@@ -6,6 +6,7 @@
 //
 // SPDX-License-Identifier: EUPL-1.2
 
+import 'package:cloud_firestore_helper/cloud_firestore_helper.dart';
 import 'package:date/date.dart';
 import 'package:group_domain_models/group_domain_models.dart';
 import 'package:sharezone/timetable/src/models/lesson.dart';
@@ -15,6 +16,13 @@ import 'package:time/time.dart';
 import 'calendrical_event_types.dart';
 
 class CalendricalEvent {
+  /// The date and time when the event was created.
+  ///
+  /// Clients with a lower version than 1.7.9 will not have this field.
+  /// Therefore, we will always have events without a [createdOn] field in the
+  /// database.
+  final DateTime? createdOn;
+
   final String eventID, groupID, authorID;
   final GroupType groupType;
   final CalendricalEventType eventType;
@@ -26,6 +34,7 @@ class CalendricalEvent {
   final String? latestEditor;
 
   CalendricalEvent({
+    required this.createdOn,
     required this.eventID,
     required this.groupID,
     required this.groupType,
@@ -46,6 +55,7 @@ class CalendricalEvent {
     required String id,
   }) {
     return CalendricalEvent(
+      createdOn: dateTimeFromTimestampOrNull(data['createdOn']),
       eventID: id,
       groupID: data['groupID'] as String,
       authorID: data['authorID'] as String,
@@ -95,6 +105,7 @@ class CalendricalEvent {
     String? latestEditor,
   }) {
     return CalendricalEvent(
+      createdOn: createdOn,
       authorID: authorID ?? this.authorID,
       eventID: eventID ?? this.eventID,
       groupID: groupID ?? this.groupID,

--- a/app/lib/calendrical_events/models/calendrical_event.dart
+++ b/app/lib/calendrical_events/models/calendrical_event.dart
@@ -74,6 +74,7 @@ class CalendricalEvent {
 
   Map<String, dynamic> toJson() {
     return {
+      'createdOn': createdOn,
       'groupID': groupID,
       'groupType': groupType.name,
       'eventType': getEventTypeToString(eventType),

--- a/app/lib/calendrical_events/page/past_calendrical_events_page.dart
+++ b/app/lib/calendrical_events/page/past_calendrical_events_page.dart
@@ -168,6 +168,7 @@ class _SharezonePlusAd extends StatelessWidget {
       title: title,
       courseName: courseName,
       event: CalendricalEvent(
+        createdOn: DateTime(2023, 1, 1),
         authorID: 'authorId',
         groupID: 'groupId',
         title: 'title',

--- a/app/lib/timetable/timetable_add_event/bloc/timetable_add_event_bloc.dart
+++ b/app/lib/timetable/timetable_add_event/bloc/timetable_add_event_bloc.dart
@@ -176,6 +176,9 @@ Time _calculateEndTime(Time startTime, int lessonsLength) {
       log("isValid: true; ${course.toString()}; $startTime; $endTime; $place $date $sendNotification");
 
       final event = CalendricalEvent(
+        // The 'createdOn' field will be added in the gateway because we use
+        // serverTimestamp().
+        createdOn: null,
         groupID: course.id,
         groupType: GroupType.course,
         eventType: eventType,

--- a/app/lib/util/api/timetable_gateway.dart
+++ b/app/lib/util/api/timetable_gateway.dart
@@ -44,6 +44,7 @@ class TimetableGateway {
     Map<String, dynamic> data =
         event.copyWith(eventID: eventID, authorID: memberID).toJson();
     data['users'] = [memberID];
+    data['createdOn'] = FieldValue.serverTimestamp();
     return references.events
         .doc(eventID)
         .set(data, SetOptions(merge: true))

--- a/app/test/timetable/timetable_bloc_test.dart
+++ b/app/test/timetable/timetable_bloc_test.dart
@@ -61,6 +61,7 @@ void main() {
 
     CalendricalEvent createEvent(String groupId) {
       return CalendricalEvent(
+        createdOn: DateTime(2021, 1, 1),
         startTime: Time(hour: 9, minute: 0),
         endTime: Time(hour: 10, minute: 0),
         groupID: groupId,


### PR DESCRIPTION
Closes #1280 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a "Created On" date for calendrical events, enhancing event tracking and organization.
- **Refactor**
	- Improved the handling of event creation times across the app for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->