### PR TITLE
Add `createdOn` field for lessons

### DIFF
--- a/app/lib/timetable/src/bloc/timetable_selection_bloc.dart
+++ b/app/lib/timetable/src/bloc/timetable_selection_bloc.dart
@@ -60,6 +60,9 @@ class TimetableSelectionBloc extends BlocBase {
     Course course,
   ) {
     final lesson = Lesson(
+      // The 'createdOn' field will be added in the gateway because we use
+      // serverTimestamp().
+      createdOn: null,
       weekday: emptyPeriodSelection.date.weekDayEnum,
       weektype: emptyPeriodSelection.weekType,
       startTime: emptyPeriodSelection.period.startTime,

--- a/app/lib/timetable/src/models/lesson.dart
+++ b/app/lib/timetable/src/models/lesson.dart
@@ -6,6 +6,7 @@
 //
 // SPDX-License-Identifier: EUPL-1.2
 
+import 'package:cloud_firestore_helper/cloud_firestore_helper.dart';
 import 'package:date/date.dart';
 import 'package:date/weekday.dart';
 import 'package:date/weektype.dart';
@@ -14,6 +15,13 @@ import 'package:sharezone/timetable/src/models/lesson_length/lesson_length.dart'
 import 'package:time/time.dart';
 
 class Lesson {
+  /// The date and time when the event was created.
+  ///
+  /// Clients with a lower version than 1.7.9 will not have this field.
+  /// Therefore, we will always have events without a [createdOn] field in the
+  /// database.
+  final DateTime? createdOn;
+
   final String? lessonID;
   final String groupID;
   final GroupType groupType;
@@ -26,6 +34,7 @@ class Lesson {
   LessonLength get length => calculateLessonLength(startTime, endTime);
 
   Lesson({
+    required this.createdOn,
     required this.lessonID,
     required this.groupID,
     required this.groupType,
@@ -42,6 +51,7 @@ class Lesson {
 
   factory Lesson.fromData(Map<String, dynamic> data, {required String id}) {
     return Lesson(
+      createdOn: dateTimeFromTimestampOrNull(data['createdOn']),
       lessonID: id,
       groupID: data['groupID'] as String,
       groupType: GroupType.values.byName(data['groupType'] as String),
@@ -74,6 +84,7 @@ class Lesson {
   }
 
   Lesson copyWith({
+    DateTime? createdOn,
     String? lessonID,
     String? groupID,
     GroupType? groupType,
@@ -88,6 +99,7 @@ class Lesson {
     String? place,
   }) {
     return Lesson(
+      createdOn: createdOn ?? this.createdOn,
       groupType: groupType ?? this.groupType,
       lessonID: lessonID ?? this.lessonID,
       groupID: groupID ?? this.groupID,

--- a/app/lib/timetable/timetable_add/bloc/timetable_add_bloc.dart
+++ b/app/lib/timetable/timetable_add/bloc/timetable_add_bloc.dart
@@ -127,6 +127,9 @@ class TimetableAddBloc extends BlocBase {
       log("isValid: true; ${course.toString()}; $startTime; $endTime; $room $weekDay $period");
 
       final lesson = Lesson(
+        // The 'createdOn' field will be added in the gateway because we use
+        // serverTimestamp().
+        createdOn: null,
         groupID: course.id,
         groupType: GroupType.course,
         startDate: null,

--- a/app/lib/util/api/timetable_gateway.dart
+++ b/app/lib/util/api/timetable_gateway.dart
@@ -22,6 +22,7 @@ class TimetableGateway {
     String lessonID = references.lessons.doc().id;
     Map<String, dynamic> data = lesson.copyWith(lessonID: lessonID).toJson();
     data['users'] = [memberID];
+    data['createdOn'] = FieldValue.serverTimestamp();
     return references.lessons
         .doc(lessonID)
         .set(data, SetOptions(merge: true))

--- a/app/test/dashboard/current_lesson_index_test.dart
+++ b/app/test/dashboard/current_lesson_index_test.dart
@@ -25,6 +25,7 @@ void main() {
       abbreviation: "D",
       design: Design.standard(),
       lesson: Lesson(
+        createdOn: DateTime(2024, 1, 1),
         lessonID: "1",
         groupID: "1",
         groupType: GroupType.course,

--- a/app/test/timetable/timetable_bloc_test.dart
+++ b/app/test/timetable/timetable_bloc_test.dart
@@ -45,6 +45,7 @@ void main() {
 
     Lesson createLesson(String groupId) {
       return Lesson(
+        createdOn: DateTime(2024, 1, 1),
         startTime: Time(hour: 9, minute: 0),
         endTime: Time(hour: 10, minute: 0),
         groupID: groupId,


### PR DESCRIPTION
This time only not adding it to the DTO (https://github.com/SharezoneApp/sharezone-app/pull/1281#discussion_r1469143302). I'm open to change it 👍 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a timestamp (`createdOn`) for lessons, enhancing tracking and management.
- **Tests**
	- Updated tests to include the new `createdOn` field for lessons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->