### PR TITLE
Upgrade CI/CD pipelines from `macos-13` to `macos-14`

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -204,7 +204,7 @@ jobs:
             --release-notes "$LAST_COMMIT_MESSAGE"
 
   deploy-alpha-ios-app:
-    runs-on: macos-13
+    runs-on: macos-14
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
@@ -263,7 +263,7 @@ jobs:
             --export-options-plist=$HOME/export_options.plist
 
   deploy-alpha-macos-app:
-    runs-on: macos-13
+    runs-on: macos-14
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -63,7 +63,7 @@ jobs:
     # We skip the deployment if no changelog is provided because we assume that
     # nothing has changed in the iOS app and therefore no new version is needed.
     if: github.event.inputs.ios-changelog != ''
-    runs-on: macos-13
+    runs-on: macos-14
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
@@ -210,7 +210,7 @@ jobs:
     # We skip the deployment if no changelog is provided because we assume that
     # nothing has changed in the macOS app and therefore no new version is needed.
     if: github.event.inputs.macos-changelog != ''
-    runs-on: macos-13
+    runs-on: macos-14
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11

--- a/.github/workflows/integration_tests_app_ci.yml
+++ b/.github/workflows/integration_tests_app_ci.yml
@@ -170,12 +170,7 @@ jobs:
 
   ios-integration-test:
     needs: changes
-    # We are using macos-12 instead macos-13 because with macos-13 we have job
-    # times of 40 - 120 minutes.
-    #
-    # Before switching back to macos-13, we should check if the job times are
-    # still that long by running the job with a matrix (3 runs).
-    runs-on: macos-12
+    runs-on: macos-14
     if: ${{ needs.changes.outputs.changesFound == 'true' }}
     timeout-minutes: 60
     steps:
@@ -189,12 +184,6 @@ jobs:
         with:
           flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
           channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
-
-      # Because macos-12 doesn't have Metal support, we need to disable Impeller
-      # https://github.com/flutter/flutter/issues/126768
-      - name: Disable Impeller
-        working-directory: app/ios/Runner
-        run: /usr/libexec/PlistBuddy -c "Add :FLTEnableImpeller bool false" Info.plist
 
       - uses: futureware-tech/simulator-action@427329dea8e4d6417cba1273ebb5c9ad4720082d
         id: simulator
@@ -269,7 +258,7 @@ jobs:
   # macOS app.
   macos-build-test:
     needs: changes
-    runs-on: macos-13
+    runs-on: macos-14
     if: ${{ needs.changes.outputs.changesFound == 'true' }}
     timeout-minutes: 60
     defaults:

--- a/.github/workflows/integration_tests_app_ci.yml
+++ b/.github/workflows/integration_tests_app_ci.yml
@@ -185,6 +185,12 @@ jobs:
           flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
           channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
 
+      # Because GitHub Action runners don't have Metal support, we need to
+      # disable Impeller https://github.com/flutter/flutter/issues/126768
+      - name: Disable Impeller
+        working-directory: app/ios/Runner
+        run: /usr/libexec/PlistBuddy -c "Add :FLTEnableImpeller bool false" Info.plist
+
       - uses: futureware-tech/simulator-action@427329dea8e4d6417cba1273ebb5c9ad4720082d
         id: simulator
         with:

--- a/.github/workflows/integration_tests_app_ci.yml
+++ b/.github/workflows/integration_tests_app_ci.yml
@@ -188,7 +188,7 @@ jobs:
       - uses: futureware-tech/simulator-action@427329dea8e4d6417cba1273ebb5c9ad4720082d
         id: simulator
         with:
-          model: "iPhone 13"
+          model: "iPhone 14"
 
       - name: Run integration tests
         working-directory: app

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -63,7 +63,7 @@ jobs:
     # We skip the deployment if no changelog is provided because we assume that
     # nothing has changed in the iOS app and therefore no new version is needed.
     if: github.event.inputs.ios-changelog != ''
-    runs-on: macos-13
+    runs-on: macos-14
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
@@ -212,7 +212,7 @@ jobs:
     # We skip the deployment if no changelog is provided because we assume that
     # nothing has changed in the macOS app and therefore no new version is needed.
     if: github.event.inputs.macos-changelog != ''
-    runs-on: macos-13
+    runs-on: macos-14
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11


### PR DESCRIPTION
`macos-14` runner are using M1 CPUs: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories.

This change also allows us to run our Flutter golden tests with GitHub Actions instead of Codemagic.