### PR TITLE
Use `super.packagesToProcess` so that `ConcurrentCommand` filters are automatically applied.

### DIFF
--- a/tools/sz_repo_cli/lib/src/commands/src/test_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/test_command.dart
@@ -53,13 +53,13 @@ class TestCommand extends ConcurrentCommand {
   @override
   Stream<Package> get packagesToProcess {
     if (argResults!['only-goldens'] as bool) {
-      return repo.streamPackages().where(
+      return super.packagesToProcess.where(
             (package) =>
                 package.isFlutterPackage && package.hasGoldenTestsDirectory,
           );
     }
 
-    return repo.streamPackages().where((package) => package.hasTestDirectory);
+    return super.packagesToProcess.where((package) => package.hasTestDirectory);
   }
 
   @override


### PR DESCRIPTION
Use `super.packagesToProcess` so that #1292 also applies to `sz test`