### PR TITLE
Rename `sz deploy web-app` to `sz deploy web`.

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -101,7 +101,7 @@ jobs:
           FIREBASE_HOSTING_KEY: ${{ secrets[matrix.environment.serviceAccountSecret] }}
         run: |
           echo $FIREBASE_HOSTING_KEY > firebase-hosting-key.json
-          sz deploy web-app \
+          sz deploy web \
             --stage alpha \
             --message "Workflow $GITHUB_JOB, commit $GITHUB_SHA" \
             --credentials firebase-hosting-key.json \

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -141,7 +141,7 @@ jobs:
           FIREBASE_HOSTING_KEY: ${{ secrets[matrix.environment.serviceAccountSecret] }}
         run: |
           echo $FIREBASE_HOSTING_KEY > firebase-hosting-key.json
-          sz deploy web-app \
+          sz deploy web \
             --stage beta \
             --message "Workflow $GITHUB_JOB, commit $GITHUB_SHA" \
             --credentials firebase-hosting-key.json \

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -143,7 +143,7 @@ jobs:
           FIREBASE_HOSTING_KEY: ${{ secrets[matrix.environment.serviceAccountSecret] }}
         run: |
           echo $FIREBASE_HOSTING_KEY > firebase-hosting-key.json
-          sz deploy web-app \
+          sz deploy web \
             --stage stable \
             --message "Workflow $GITHUB_JOB, commit $GITHUB_SHA" \
             --credentials firebase-hosting-key.json \

--- a/tools/sz_repo_cli/lib/src/commands/src/deploy_web_app_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/deploy_web_app_command.dart
@@ -76,7 +76,7 @@ class DeployWebAppCommand extends CommandBase {
       'Deploy the Sharezone web app in the given environment';
 
   @override
-  String get name => 'web-app';
+  String get name => 'web';
 
   @override
   Future<void> run() async {


### PR DESCRIPTION
This makes it consistent with `sz deploy android/ios/macos`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated deployment commands and parameters in CI/CD workflows to enhance deployment processes.
	- Modified internal command names to align with updated deployment strategies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->