### PR TITLE
Add missing `CI_CD_DART_SCRIPTS_PACKAGE_PATH` in `unsafe-app-ci` workflow

### DIFF
--- a/.github/workflows/unsafe_app_ci.yml
+++ b/.github/workflows/unsafe_app_ci.yml
@@ -43,6 +43,9 @@ on:
     types:
       - checks_requested
 
+env:
+  CI_CD_DART_SCRIPTS_PACKAGE_PATH: "tools/sz_repo_cli/"
+
 # Set permissions to none.
 #
 # Using the broad default permissions is considered a bad security practice


### PR DESCRIPTION
#1290 added the `flutter pub global activate --source path "$CI_CD_DART_SCRIPTS_PACKAGE_PATH"` command but without defining `CI_CD_DART_SCRIPTS_PACKAGE_PATH`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Chores**
	- Updated CI/CD workflow settings for enhanced operations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->