### PR TITLE
Upgrade `pdfx` to `^2.6.0`.

### DIFF
--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -1605,12 +1605,11 @@ packages:
   pdfx:
     dependency: transitive
     description:
-      path: "packages/pdfx"
-      ref: "8b105a7dfc6b90220c1d79fcb805fb764cab00c5"
-      resolved-ref: "8b105a7dfc6b90220c1d79fcb805fb764cab00c5"
-      url: "https://github.com/ScerIO/packages.flutter"
-    source: git
-    version: "2.5.0"
+      name: pdfx
+      sha256: c0f70ab6691b7cde02c0c204763a1edb2689ce245ac34eb629c66273a6aa1caf
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.0"
   permission_handler:
     dependency: "direct main"
     description:

--- a/lib/abgabe/abgabe_client_lib/pubspec.lock
+++ b/lib/abgabe/abgabe_client_lib/pubspec.lock
@@ -956,12 +956,11 @@ packages:
   pdfx:
     dependency: transitive
     description:
-      path: "packages/pdfx"
-      ref: "8b105a7dfc6b90220c1d79fcb805fb764cab00c5"
-      resolved-ref: "8b105a7dfc6b90220c1d79fcb805fb764cab00c5"
-      url: "https://github.com/ScerIO/packages.flutter"
-    source: git
-    version: "2.5.0"
+      name: pdfx
+      sha256: c0f70ab6691b7cde02c0c204763a1edb2689ce245ac34eb629c66273a6aa1caf
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.0"
   permission_handler:
     dependency: transitive
     description:

--- a/lib/filesharing/files_usecases/pubspec.lock
+++ b/lib/filesharing/files_usecases/pubspec.lock
@@ -731,12 +731,11 @@ packages:
   pdfx:
     dependency: "direct main"
     description:
-      path: "packages/pdfx"
-      ref: "8b105a7dfc6b90220c1d79fcb805fb764cab00c5"
-      resolved-ref: "8b105a7dfc6b90220c1d79fcb805fb764cab00c5"
-      url: "https://github.com/ScerIO/packages.flutter"
-    source: git
-    version: "2.5.0"
+      name: pdfx
+      sha256: c0f70ab6691b7cde02c0c204763a1edb2689ce245ac34eb629c66273a6aa1caf
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.0"
   permission_handler:
     dependency: transitive
     description:

--- a/lib/filesharing/files_usecases/pubspec.yaml
+++ b/lib/filesharing/files_usecases/pubspec.yaml
@@ -43,11 +43,7 @@ dependencies:
   #
   # When a version >= 2.5.1 is published, we can remove the git dependency and
   # use the published version.
-  pdfx:
-    git:
-      url: https://github.com/ScerIO/packages.flutter
-      path: packages/pdfx
-      ref: 8b105a7dfc6b90220c1d79fcb805fb764cab00c5
+  pdfx: ^2.6.0
   open_file_plus: ^3.4.1
   path: ^1.8.3
   path_provider: ^2.0.11

--- a/lib/filesharing/filesharing_logic/pubspec.lock
+++ b/lib/filesharing/filesharing_logic/pubspec.lock
@@ -731,12 +731,11 @@ packages:
   pdfx:
     dependency: transitive
     description:
-      path: "packages/pdfx"
-      ref: "8b105a7dfc6b90220c1d79fcb805fb764cab00c5"
-      resolved-ref: "8b105a7dfc6b90220c1d79fcb805fb764cab00c5"
-      url: "https://github.com/ScerIO/packages.flutter"
-    source: git
-    version: "2.5.0"
+      name: pdfx
+      sha256: c0f70ab6691b7cde02c0c204763a1edb2689ce245ac34eb629c66273a6aa1caf
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.0"
   permission_handler:
     dependency: "direct main"
     description:


### PR DESCRIPTION
Should fix [this error](https://github.com/SharezoneApp/sharezone-app/actions/runs/8050488383/job/21986205978?pr=1313) in our analyze job:
```
ProcessRunnerException: Running "flutter pub get" in /home/runner/work/sharezone-app/sharezone-app/lib/filesharing/filesharing_logic exited with code 69
Resolving dependencies...
Package not available (the pubspec for pdfx 2.5.0 from git has version 2.6.0).
:
Package not available (the pubspec for pdfx 2.5.0 from git has version 2.6.0).
```