### PR TITLE
Fix event dialog golden by using `withClock`.

### DIFF
--- a/app/test_goldens/timetable/timetable_dialog/timetable_dialog_test.dart
+++ b/app/test_goldens/timetable/timetable_dialog/timetable_dialog_test.dart
@@ -58,10 +58,13 @@ void main() {
         final dt = createDialogTester(tester);
         dt.addCourse(courseWith(id: 'fooId', name: 'Foo course'));
 
-        await dt.pumpDialog(
-          isExam: testConfig.isExam,
-          theme: testConfig.theme.data,
-        );
+        await withClock(Clock.fixed(DateTime(2024, 2, 22)), () async {
+          await dt.pumpDialog(
+            isExam: testConfig.isExam,
+            theme: testConfig.theme.data,
+          );
+        });
+
         await multiScreenGolden(
           tester,
           'event_dialog_add_empty_${testConfig.theme.name}_${testConfig.isExam ? 'exam' : 'event'}',
@@ -74,10 +77,13 @@ void main() {
         final dt = createDialogTester(tester);
         dt.addCourse(courseWith(id: 'fooId', name: 'Foo course'));
 
-        await dt.pumpDialog(
-          isExam: testConfig.isExam,
-          theme: testConfig.theme.data,
-        );
+        await withClock(Clock.fixed(DateTime(2024, 2, 22)), () async {
+          await dt.pumpDialog(
+            isExam: testConfig.isExam,
+            theme: testConfig.theme.data,
+          );
+        });
+
         await dt.enterTitle('Test title');
         await dt.selectCourse('Foo course');
         await withClock(
@@ -102,10 +108,13 @@ void main() {
           'renders error event dialog as expected (${testConfig.theme.name}, isExam: ${testConfig.isExam})',
           (tester) async {
         final dt = createDialogTester(tester);
-        await dt.pumpDialog(
-          isExam: testConfig.isExam,
-          theme: testConfig.theme.data,
-        );
+
+        await withClock(Clock.fixed(DateTime(2024, 2, 22)), () async {
+          await dt.pumpDialog(
+            isExam: testConfig.isExam,
+            theme: testConfig.theme.data,
+          );
+        });
 
         // Set end time before start time.
         await dt.selectStartTime(const TimeOfDay(hour: 12, minute: 0));


### PR DESCRIPTION
Golden tests were failing because `DateTime.now` was implicitly used in the tests, thus the UI changed in the golden tests after I merged #1301.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Improved consistency in test results by controlling the timing behavior within timetable dialog tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->