### PR TITLE
Fix flaky test using mockito by using `provideDummy`.

### DIFF
--- a/app/test_goldens/calendrical_events/page/past_calendrical_events_page_test.dart
+++ b/app/test_goldens/calendrical_events/page/past_calendrical_events_page_test.dart
@@ -104,11 +104,15 @@ void main() {
 
     group('without Sharezone Plus', () {
       setUp(() {
-        when(controller.state).thenReturn(
-          const PastCalendricalEventsPageNotUnlockedState(
-            sortingOrder: EventsSortingOrder.descending,
-          ),
+        const state = PastCalendricalEventsPageNotUnlockedState(
+          sortingOrder: EventsSortingOrder.descending,
         );
+        // Mockito does not support mocking sealed classes yet, so we have to
+        // provide a dummy implementation of the state.
+        //
+        // Ticket: https://github.com/dart-lang/mockito/issues/675
+        provideDummy<PastCalendricalEventsPageState>(state);
+        when(controller.state).thenReturn(state);
       });
 
       testGoldens('renders correctly (light theme)', (tester) async {


### PR DESCRIPTION
This test was failing when using #1318 with the ` --test-randomize-ordering-seed 1`.

Required for #1318 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated the setup for `Past Calendrical Events Page` tests to use a dummy implementation for state testing due to limitations with mocking frameworks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->