### PR TITLE
Add `git diff` again to our CI pipelines

### DIFF
--- a/.github/workflows/cli_ci.yml
+++ b/.github/workflows/cli_ci.yml
@@ -101,6 +101,17 @@ jobs:
       - name: Run code analysis via "sz analyze" (formatting, issues, spacing ...)
         run: sz analyze --max-concurrent-packages 3 --package-timeout-minutes 15
 
+      # It can easily happen that a dependency changed but the .lock file is not
+      # updated. Or other cases where files are changed during a build.
+      # Therefore, fails this check if there are Git changes.
+      - name: Fail if there are Git diffs
+        run: |
+          # Fail if there are Git diffs and print the diff.
+          git diff --exit-code
+          # Print the Git diff with the file names and their status as a
+          # summary. 
+          git diff --name-status
+
   test:
     needs: changes
     # Because we run our the tests for all packages for now, we need to use a

--- a/.github/workflows/safe_app_ci.yml
+++ b/.github/workflows/safe_app_ci.yml
@@ -118,6 +118,17 @@ jobs:
       - name: Run code analysis via "sz analyze" (formatting, issues, spacing ...)
         run: sz analyze --max-concurrent-packages 3 --package-timeout-minutes 15
 
+      # It can easily happen that a dependency changed but the .lock file is not
+      # updated. Or other cases where files are changed during a build.
+      # Therefore, fails this check if there are Git changes.
+      - name: Fail if there are Git diffs
+        run: |
+          # Fail if there are Git diffs and print the diff.
+          git diff --exit-code
+          # Print the Git diff with the file names and their status as a
+          # summary. 
+          git diff --name-status
+
   # We split the tests into two jobs, because we want to run the golden tests on
   # a macOS runner, because the golden tests were generated on macOS. To reduce
   # the time that macOS runner are used, we run the other tests on a Linux

--- a/.github/workflows/safe_website_ci.yml
+++ b/.github/workflows/safe_website_ci.yml
@@ -116,3 +116,14 @@ jobs:
 
       - name: Run code analysis via "sz analyze" (formatting, issues, spacing ...)
         run: sz analyze --max-concurrent-packages 3 --package-timeout-minutes 15
+
+      # It can easily happen that a dependency changed but the .lock file is not
+      # updated. Or other cases where files are changed during a build.
+      # Therefore, fails this check if there are Git changes.
+      - name: Fail if there are Git diffs
+        run: |
+          # Fail if there are Git diffs and print the diff.
+          git diff --exit-code
+          # Print the Git diff with the file names and their status as a
+          # summary. 
+          git diff --name-status


### PR DESCRIPTION
In #1210 we removed temporary the `git diff` commands. Since `pdfx` has been upgraded (in #1315), we can bring back the `git diff` checks. 