### PR TITLE
Always ask the user with Google account to use

### DIFF
--- a/lib/authentification/authentification_base/lib/src/google/google_sign_in_logic.dart
+++ b/lib/authentification/authentification_base/lib/src/google/google_sign_in_logic.dart
@@ -31,6 +31,8 @@ class GoogleSignInLogic {
     // the user wasn't sure which Google account was the right one, signs in
     // with the wrong account, and then wants to sign in with the correct
     // account.
+    //
+    // From: https://stackoverflow.com/a/58509980/8358501
     await _googleSignIn.disconnect();
 
     final GoogleSignInAccount? googleUser = await _googleSignIn.signIn();

--- a/lib/authentification/authentification_base/lib/src/google/google_sign_in_logic.dart
+++ b/lib/authentification/authentification_base/lib/src/google/google_sign_in_logic.dart
@@ -23,14 +23,14 @@ class GoogleSignInLogic {
   }
 
   Future<AuthCredential> _getCredentials() async {
-    // Disconnect the user before signing in again to ensure that the user
-    // selects the account again.
+    // Disconnect the user before signing in again to ensure that the user can
+    // select other Google accounts.
     //
     // Otherwise, the user would be signed in with the last selected account
-    // without the possibility to select another account. This is a problem when
-    // the user wasn't sure which Google account was the right one, signs in
-    // with the wrong account, and then wants to sign in with the correct
-    // account. Especially on Android is this a problem.
+    // without the possibility to select another Google account. This is a
+    // problem when the user wasn't sure which Google account was the right one,
+    // signs in with the wrong account, and then wants to sign in with the
+    // correct account. Especially on Android is this a problem.
     //
     // From: https://stackoverflow.com/a/58509980/8358501
     await _googleSignIn.disconnect();

--- a/lib/authentification/authentification_base/lib/src/google/google_sign_in_logic.dart
+++ b/lib/authentification/authentification_base/lib/src/google/google_sign_in_logic.dart
@@ -23,6 +23,16 @@ class GoogleSignInLogic {
   }
 
   Future<AuthCredential> _getCredentials() async {
+    // Disconnect the user before signing in again to ensure that the user
+    // selects the account again.
+    //
+    // Otherwise, the user would be signed in with the last selected account
+    // without the possibility to select another account. This is a problem when
+    // the user wasn't sure which Google account was the right one, signs in
+    // with the wrong account, and then wants to sign in with the correct
+    // account.
+    await _googleSignIn.disconnect();
+
     final GoogleSignInAccount? googleUser = await _googleSignIn.signIn();
     if (googleUser == null) throw NoGoogleSignAccountSelected();
 

--- a/lib/authentification/authentification_base/lib/src/google/google_sign_in_logic.dart
+++ b/lib/authentification/authentification_base/lib/src/google/google_sign_in_logic.dart
@@ -30,7 +30,7 @@ class GoogleSignInLogic {
     // without the possibility to select another account. This is a problem when
     // the user wasn't sure which Google account was the right one, signs in
     // with the wrong account, and then wants to sign in with the correct
-    // account.
+    // account. Especially on Android is this a problem.
     //
     // From: https://stackoverflow.com/a/58509980/8358501
     await _googleSignIn.disconnect();


### PR DESCRIPTION
When a user isn't sure which Google account was the right one, signs in with the wrong account, and then wants to sign in with the correct account, Android just used the same Google account as used before. The only workaround is to delete the cache. This PR changes the behavior to ask always for the Google Account.

I couldn't test it because I don't have the right signing key and therefore can't use the Google Sign In. However, I will test it on the alpha branch later.