### PR TITLE
Fix disconnecting Google account for signing in with Google.

### DIFF
--- a/lib/authentification/authentification_base/lib/src/google/google_sign_in_logic.dart
+++ b/lib/authentification/authentification_base/lib/src/google/google_sign_in_logic.dart
@@ -23,17 +23,22 @@ class GoogleSignInLogic {
   }
 
   Future<AuthCredential> _getCredentials() async {
-    // Disconnect the user before signing in again to ensure that the user can
-    // select other Google accounts.
-    //
-    // Otherwise, the user would be signed in with the last selected account
-    // without the possibility to select another Google account. This is a
-    // problem when the user wasn't sure which Google account was the right one,
-    // signs in with the wrong account, and then wants to sign in with the
-    // correct account. Especially on Android is this a problem.
-    //
-    // From: https://stackoverflow.com/a/58509980/8358501
-    await _googleSignIn.disconnect();
+    try {
+      // Disconnect the user before signing in again to ensure that the user can
+      // select other Google accounts.
+      //
+      // Otherwise, the user would be signed in with the last selected account
+      // without the possibility to select another Google account. This is a
+      // problem when the user wasn't sure which Google account was the right one,
+      // signs in with the wrong account, and then wants to sign in with the
+      // correct account. Especially on Android is this a problem.
+      //
+      // From: https://stackoverflow.com/a/58509980/8358501
+      await _googleSignIn.disconnect();
+    } catch (e) {
+      // Ignore the error because the user might not have selected an account
+      // yet. In this case, the error is expected.
+    }
 
     final GoogleSignInAccount? googleUser = await _googleSignIn.signIn();
     if (googleUser == null) throw NoGoogleSignAccountSelected();


### PR DESCRIPTION
Tested it locally 👍 When a user never signed in with Google, the `disconnect` method will throw an exception.

Fixes #1339