### PR TITLE
Only deploy website when "website/**" has changed

### DIFF
--- a/.github/workflows/website_cd.yml
+++ b/.github/workflows/website_cd.yml
@@ -17,6 +17,30 @@ on:
   push:
     branches:
       - main
+    paths:
+      # We only build and deploy a new version, when a user relevant files
+      # changed.
+      - "website/**"
+      # We trigger also this workflow, if this workflow is changed, so that new
+      # changes will be applied.
+      - ".github/workflows/website_cd.yml"
+      # The following paths are excluded from the above paths. It's important to
+      # list the paths at the end of the file, so that the exclude paths are
+      # applied.
+      #
+      # See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-and-excluding-paths.
+      - "!**/*.md"
+      - "!**/*.mdx"
+      - "!**/*.gitignore"
+      # The macOS version is only used for debugging.
+      - "!website/macos/**"
+      # Test files are not relevant for the website deployment.
+      - "!**/test/**"
+      - "!**/test_driver/**"
+      - "!**/integration_test/**"
+      # Example files are not relevant for the alpha program.
+      - "!**/analysis_options.yaml"
+      - "!**/dart_test.yaml"
 
 # Set permissions to none.
 #

--- a/.github/workflows/website_cd.yml
+++ b/.github/workflows/website_cd.yml
@@ -38,7 +38,6 @@ on:
       - "!**/test/**"
       - "!**/test_driver/**"
       - "!**/integration_test/**"
-      # Example files are not relevant for the alpha program.
       - "!**/analysis_options.yaml"
       - "!**/dart_test.yaml"
 

--- a/.github/workflows/website_cd.yml
+++ b/.github/workflows/website_cd.yml
@@ -41,6 +41,15 @@ on:
       - "!**/analysis_options.yaml"
       - "!**/dart_test.yaml"
 
+  # Allows you to run this workflow manually from the Actions tab.
+  #
+  # Since the website depends on the /lib folder, it could be that the website
+  # requires a new deployment. In this case, the developer needs to trigger the
+  # deployment manually or wait until the next change "website/**" is pushed. We
+  # do this to avoid unnecessary deployments since a new deployment invalidates
+  # the cache.
+  workflow_dispatch:
+
 # Set permissions to none.
 #
 # Using the broad default permissions is considered a bad security practice


### PR DESCRIPTION
This PR adds the "path" property to the website CD pipeline.

Although our website depends on the `lib/` folder, I think it's better to not always deploy a new version if only `lib/` changed and not `website/` to reduce the deployments (every deployment makes the cache invalid). It's very likely that in this case, nothing important changed on the website. In case it was important, you can always trigger a manual deployment.