### PR TITLE
Remove "app/macos" path as an exception for alpha updates

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -37,9 +37,6 @@ on:
       - "!**/*.md"
       - "!**/*.mdx"
       - "!**/*.gitignore"
-      # The macOS version of our app has no alpha program. Therefore, we don't
-      # need to build it.
-      - "!app/macos/**"
       # Test files are not relevant for the alpha program.
       - "!**/test/**"
       - "!**/test_driver/**"


### PR DESCRIPTION
At the time I added these paths, we didn't have an Alpha programme. But now we do.