### PR TITLE
Add prefix `app` to `build` and `deploy` app commands

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -252,7 +252,7 @@ jobs:
           # parsing in the shell, potentially leading to incorrect handling of
           # the multiline string argument.
 
-          sz deploy ios \
+          sz deploy app:ios \
             --stage alpha \
             --whats-new "$SHORT_LAST_COMMIT_MESSAGE" \
             --export-options-plist=$HOME/export_options.plist
@@ -309,6 +309,6 @@ jobs:
           # longer than 4000 characters.
           SHORT_LAST_COMMIT_MESSAGE=${LAST_COMMIT_MESSAGE:0:4000}
 
-          sz deploy macos \
+          sz deploy app:macos \
             --stage alpha \
             --whats-new "$SHORT_LAST_COMMIT_MESSAGE"

--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -97,7 +97,7 @@ jobs:
         run: |
           echo $FIREBASE_HOSTING_KEY > firebase-hosting-key.json
           export GOOGLE_APPLICATION_CREDENTIALS=$(pwd)/firebase-hosting-key.json
-          sz deploy web \
+          sz deploy app web \
             --stage alpha \
             --message "Workflow $GITHUB_JOB, commit $GITHUB_SHA" \
             --flavor ${{ matrix.environment.flavor }}
@@ -252,7 +252,7 @@ jobs:
           # parsing in the shell, potentially leading to incorrect handling of
           # the multiline string argument.
 
-          sz deploy app:ios \
+          sz deploy app ios \
             --stage alpha \
             --whats-new "$SHORT_LAST_COMMIT_MESSAGE" \
             --export-options-plist=$HOME/export_options.plist
@@ -309,6 +309,6 @@ jobs:
           # longer than 4000 characters.
           SHORT_LAST_COMMIT_MESSAGE=${LAST_COMMIT_MESSAGE:0:4000}
 
-          sz deploy app:macos \
+          sz deploy app macos \
             --stage alpha \
             --whats-new "$SHORT_LAST_COMMIT_MESSAGE"

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -99,7 +99,7 @@ jobs:
           CHANGELOG="${{ github.event.inputs.ios-changelog }}"
           CHANGELOG_WITH_NEW_LINES=$(echo -e "$CHANGELOG" | sed 's/\\n/\\n/g')
 
-          sz deploy app:ios \
+          sz deploy app ios \
             --stage beta \
             --whats-new "$CHANGELOG_WITH_NEW_LINES" \
             --export-options-plist=$HOME/export_options.plist
@@ -142,7 +142,7 @@ jobs:
         run: |
           echo $FIREBASE_HOSTING_KEY > firebase-hosting-key.json
           export GOOGLE_APPLICATION_CREDENTIALS=$(pwd)/firebase-hosting-key.json
-          sz deploy web \
+          sz deploy app web \
             --stage beta \
             --message "Workflow $GITHUB_JOB, commit $GITHUB_SHA" \
             --flavor ${{ matrix.environment.flavor }}
@@ -201,7 +201,7 @@ jobs:
           CHANGELOG="${{ github.event.inputs.android-changelog }}"
           CHANGELOG_WITH_NEW_LINES=$(echo -e "$CHANGELOG" | sed 's/\\n/\\n/g')
 
-          sz deploy app:android \
+          sz deploy app android \
             --stage beta \
             --whats-new "$CHANGELOG_WITH_NEW_LINES" \
             --rollout-percentage ${{ github.event.inputs.android-rollout-percentage }}
@@ -252,6 +252,6 @@ jobs:
           CHANGELOG="${{ github.event.inputs.macos-changelog }}"
           CHANGELOG_WITH_NEW_LINES=$(echo -e "$CHANGELOG" | sed 's/\\n/\\n/g')
 
-          sz deploy app:macos \
+          sz deploy app macos \
             --stage beta \
             --whats-new "$CHANGELOG_WITH_NEW_LINES"

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -99,7 +99,7 @@ jobs:
           CHANGELOG="${{ github.event.inputs.ios-changelog }}"
           CHANGELOG_WITH_NEW_LINES=$(echo -e "$CHANGELOG" | sed 's/\\n/\\n/g')
 
-          sz deploy ios \
+          sz deploy app:ios \
             --stage beta \
             --whats-new "$CHANGELOG_WITH_NEW_LINES" \
             --export-options-plist=$HOME/export_options.plist
@@ -201,7 +201,7 @@ jobs:
           CHANGELOG="${{ github.event.inputs.android-changelog }}"
           CHANGELOG_WITH_NEW_LINES=$(echo -e "$CHANGELOG" | sed 's/\\n/\\n/g')
 
-          sz deploy android \
+          sz deploy app:android \
             --stage beta \
             --whats-new "$CHANGELOG_WITH_NEW_LINES" \
             --rollout-percentage ${{ github.event.inputs.android-rollout-percentage }}
@@ -252,6 +252,6 @@ jobs:
           CHANGELOG="${{ github.event.inputs.macos-changelog }}"
           CHANGELOG_WITH_NEW_LINES=$(echo -e "$CHANGELOG" | sed 's/\\n/\\n/g')
 
-          sz deploy macos \
+          sz deploy app:macos \
             --stage beta \
             --whats-new "$CHANGELOG_WITH_NEW_LINES"

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -100,7 +100,7 @@ jobs:
           CHANGELOG="${{ github.event.inputs.ios-changelog }}"
           CHANGELOG_WITH_NEW_LINES=$(echo -e "$CHANGELOG" | sed 's/\\n/\\n/g')
 
-          sz deploy app:ios \
+          sz deploy app ios \
             --stage stable \
             --whats-new "$CHANGELOG_WITH_NEW_LINES" \
             --export-options-plist=$HOME/export_options.plist
@@ -144,7 +144,7 @@ jobs:
         run: |
           echo $FIREBASE_HOSTING_KEY > firebase-hosting-key.json
           export GOOGLE_APPLICATION_CREDENTIALS=$(pwd)/firebase-hosting-key.json
-          sz deploy web \
+          sz deploy app web \
             --stage stable \
             --message "Workflow $GITHUB_JOB, commit $GITHUB_SHA" \
             --flavor ${{ matrix.environment.flavor }}
@@ -203,7 +203,7 @@ jobs:
           CHANGELOG="${{ github.event.inputs.android-changelog }}"
           CHANGELOG_WITH_NEW_LINES=$(echo -e "$CHANGELOG" | sed 's/\\n/\\n/g')
 
-          sz deploy app:android \
+          sz deploy app android \
             --stage stable \
             --whats-new "$CHANGELOG_WITH_NEW_LINES" \
             --rollout-percentage ${{ github.event.inputs.android-rollout-percentage }}
@@ -254,6 +254,6 @@ jobs:
           CHANGELOG="${{ github.event.inputs.macos-changelog }}"
           CHANGELOG_WITH_NEW_LINES=$(echo -e "$CHANGELOG" | sed 's/\\n/\\n/g')
 
-          sz deploy app:macos \
+          sz deploy app macos \
             --stage stable \
             --whats-new "$CHANGELOG_WITH_NEW_LINES"

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -100,7 +100,7 @@ jobs:
           CHANGELOG="${{ github.event.inputs.ios-changelog }}"
           CHANGELOG_WITH_NEW_LINES=$(echo -e "$CHANGELOG" | sed 's/\\n/\\n/g')
 
-          sz deploy ios \
+          sz deploy app:ios \
             --stage stable \
             --whats-new "$CHANGELOG_WITH_NEW_LINES" \
             --export-options-plist=$HOME/export_options.plist
@@ -203,7 +203,7 @@ jobs:
           CHANGELOG="${{ github.event.inputs.android-changelog }}"
           CHANGELOG_WITH_NEW_LINES=$(echo -e "$CHANGELOG" | sed 's/\\n/\\n/g')
 
-          sz deploy android \
+          sz deploy app:android \
             --stage stable \
             --whats-new "$CHANGELOG_WITH_NEW_LINES" \
             --rollout-percentage ${{ github.event.inputs.android-rollout-percentage }}
@@ -254,6 +254,6 @@ jobs:
           CHANGELOG="${{ github.event.inputs.macos-changelog }}"
           CHANGELOG_WITH_NEW_LINES=$(echo -e "$CHANGELOG" | sed 's/\\n/\\n/g')
 
-          sz deploy macos \
+          sz deploy app:macos \
             --stage stable \
             --whats-new "$CHANGELOG_WITH_NEW_LINES"

--- a/.github/workflows/unsafe_app_ci.yml
+++ b/.github/workflows/unsafe_app_ci.yml
@@ -164,7 +164,7 @@ jobs:
       - name: Build web app
         working-directory: app
         run: |
-          sz build web \
+          sz build app web \
             --flavor dev \
             --stage preview
 

--- a/tools/sz_repo_cli/lib/src/commands/commands.dart
+++ b/tools/sz_repo_cli/lib/src/commands/commands.dart
@@ -8,7 +8,7 @@
 
 export 'src/analyze_command.dart' show AnalyzeCommand;
 export 'src/deploy_command.dart';
-export 'src/deploy_web_app_command.dart';
+export 'src/deploy_app_web_command.dart';
 export 'src/do_stuff_command.dart';
 export 'src/exec_command.dart';
 export 'src/fix_comment_spacing_command.dart' show FixCommentSpacingCommand;

--- a/tools/sz_repo_cli/lib/src/commands/src/build_app_android_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/build_app_android_command.dart
@@ -69,7 +69,7 @@ When none is specified, the value from pubspec.yaml is used.''',
   String get description => 'Build the Sharezone Android app in release mode.';
 
   @override
-  String get name => 'app:android';
+  String get name => 'android';
 
   @override
   Future<void> run() async {

--- a/tools/sz_repo_cli/lib/src/commands/src/build_app_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/build_app_command.dart
@@ -1,0 +1,19 @@
+// Copyright (c) 2022 Sharezone UG (haftungsbeschränkt)
+// Licensed under the EUPL-1.2-or-later.
+//
+// You may obtain a copy of the Licence at:
+// https://joinup.ec.europa.eu/software/page/eupl
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+import 'package:sz_repo_cli/src/common/common.dart';
+
+class BuildAppCommand extends CommandBase {
+  BuildAppCommand(super.context);
+
+  @override
+  String get description => 'Build the Sharezone app in release mode.';
+
+  @override
+  String get name => 'app';
+}

--- a/tools/sz_repo_cli/lib/src/commands/src/build_app_ios_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/build_app_ios_command.dart
@@ -61,7 +61,7 @@ When none is specified, the value from pubspec.yaml is used.''',
   String get description => 'Build the Sharezone iOS app in release mode.';
 
   @override
-  String get name => 'app:ios';
+  String get name => 'ios';
 
   @override
   Future<void> run() async {

--- a/tools/sz_repo_cli/lib/src/commands/src/build_app_macos_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/build_app_macos_command.dart
@@ -21,8 +21,8 @@ final _macOsFlavors = [
   'dev',
 ];
 
-class BuildMacOsCommand extends CommandBase {
-  BuildMacOsCommand(super.context) {
+class BuildAppMacOsCommand extends CommandBase {
+  BuildAppMacOsCommand(super.context) {
     argParser
       ..addOption(
         releaseStageOptionName,
@@ -52,7 +52,7 @@ When none is specified, the value from pubspec.yaml is used.''')
   String get description => 'Build the Sharezone macOS app in release mode.';
 
   @override
-  String get name => 'macos';
+  String get name => 'app:macos';
 
   @override
   Future<void> run() async {

--- a/tools/sz_repo_cli/lib/src/commands/src/build_app_macos_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/build_app_macos_command.dart
@@ -52,7 +52,7 @@ When none is specified, the value from pubspec.yaml is used.''')
   String get description => 'Build the Sharezone macOS app in release mode.';
 
   @override
-  String get name => 'app:macos';
+  String get name => 'macos';
 
   @override
   Future<void> run() async {

--- a/tools/sz_repo_cli/lib/src/commands/src/build_app_web_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/build_app_web_command.dart
@@ -24,8 +24,8 @@ final _webFlavors = [
   'dev',
 ];
 
-class BuildWebCommand extends CommandBase {
-  BuildWebCommand(super.context) {
+class BuildAppWebCommand extends CommandBase {
+  BuildAppWebCommand(super.context) {
     argParser
       ..addOption(
         releaseStageOptionName,
@@ -48,7 +48,7 @@ class BuildWebCommand extends CommandBase {
   String get description => 'Build the Sharezone web app in release mode.';
 
   @override
-  String get name => 'web';
+  String get name => 'app:web';
 
   @override
   Future<void> run() async {

--- a/tools/sz_repo_cli/lib/src/commands/src/build_app_web_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/build_app_web_command.dart
@@ -48,7 +48,7 @@ class BuildAppWebCommand extends CommandBase {
   String get description => 'Build the Sharezone web app in release mode.';
 
   @override
-  String get name => 'app:web';
+  String get name => 'web';
 
   @override
   Future<void> run() async {

--- a/tools/sz_repo_cli/lib/src/commands/src/deploy_app_android_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/deploy_app_android_command.dart
@@ -69,7 +69,7 @@ class DeployAndroidCommand extends CommandBase {
       'Deploys the Sharezone Android app to the Play Store. Automatically bumps the build number and builds the app. Codemagic CLI tools & Fastlane are required.';
 
   @override
-  String get name => 'app:android';
+  String get name => 'android';
 
   @override
   Future<void> run() async {

--- a/tools/sz_repo_cli/lib/src/commands/src/deploy_app_android_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/deploy_app_android_command.dart
@@ -69,7 +69,7 @@ class DeployAndroidCommand extends CommandBase {
       'Deploys the Sharezone Android app to the Play Store. Automatically bumps the build number and builds the app. Codemagic CLI tools & Fastlane are required.';
 
   @override
-  String get name => 'android';
+  String get name => 'app:android';
 
   @override
   Future<void> run() async {

--- a/tools/sz_repo_cli/lib/src/commands/src/deploy_app_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/deploy_app_command.dart
@@ -1,0 +1,19 @@
+// Copyright (c) 2022 Sharezone UG (haftungsbeschränkt)
+// Licensed under the EUPL-1.2-or-later.
+//
+// You may obtain a copy of the Licence at:
+// https://joinup.ec.europa.eu/software/page/eupl
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+import 'package:sz_repo_cli/src/common/common.dart';
+
+class DeployAppCommand extends CommandBase {
+  DeployAppCommand(super.context);
+
+  @override
+  String get description => 'Deploy the Sharezone app.';
+
+  @override
+  String get name => 'app';
+}

--- a/tools/sz_repo_cli/lib/src/commands/src/deploy_app_ios_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/deploy_app_ios_command.dart
@@ -25,7 +25,7 @@ final _iosFlavors = [
   'prod',
 ];
 
-/// [DeployIosCommand] provides functionality for deploying the Sharezone iOS
+/// [DeployAppIosCommand] provides functionality for deploying the Sharezone iOS
 /// app to the App Store or TestFlight.
 ///
 /// This command automatically increments the build number and builds the app.
@@ -49,8 +49,8 @@ final _iosFlavors = [
 /// These options can either be provided via the command line or set as
 /// environment variables (only applies for some of them). If any required
 /// argument is missing, the deployment will fail.
-class DeployIosCommand extends CommandBase {
-  DeployIosCommand(super.context) {
+class DeployAppIosCommand extends CommandBase {
+  DeployAppIosCommand(super.context) {
     argParser
       ..addOption(
         releaseStageOptionName,
@@ -89,7 +89,7 @@ class DeployIosCommand extends CommandBase {
       'Deploys the Sharezone iOS app to the App Store or TestFlight. Automatically bumps the build number and builds the app. Codemagic CLI tools are required.';
 
   @override
-  String get name => 'ios';
+  String get name => 'app:ios';
 
   @override
   Future<void> run() async {

--- a/tools/sz_repo_cli/lib/src/commands/src/deploy_app_ios_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/deploy_app_ios_command.dart
@@ -89,7 +89,7 @@ class DeployAppIosCommand extends CommandBase {
       'Deploys the Sharezone iOS app to the App Store or TestFlight. Automatically bumps the build number and builds the app. Codemagic CLI tools are required.';
 
   @override
-  String get name => 'app:ios';
+  String get name => 'ios';
 
   @override
   Future<void> run() async {

--- a/tools/sz_repo_cli/lib/src/commands/src/deploy_app_macos_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/deploy_app_macos_command.dart
@@ -31,7 +31,7 @@ final _macOsFlavors = [
   'dev',
 ];
 
-/// [DeployMacOsCommand] provides functionality for deploying the Sharezone macOS
+/// [DeployAppMacOsCommand] provides functionality for deploying the Sharezone macOS
 /// app to the App Store or TestFlight.
 ///
 /// This command automatically increments the build number and builds the app.
@@ -53,8 +53,8 @@ final _macOsFlavors = [
 /// These options can either be provided via the command line or set as
 /// environment variables (only applies for some of them). If any required
 /// argument is missing, the deployment will fail.
-class DeployMacOsCommand extends CommandBase {
-  DeployMacOsCommand(super.context) {
+class DeployAppMacOsCommand extends CommandBase {
+  DeployAppMacOsCommand(super.context) {
     argParser.addOption(
       releaseStageOptionName,
       abbr: 's',
@@ -86,7 +86,7 @@ class DeployMacOsCommand extends CommandBase {
       'Deploys the Sharezone macOS app to the App Store or TestFlight. Automatically bumps the build number and builds the app. Codemagic CLI tools are required.';
 
   @override
-  String get name => 'macos';
+  String get name => 'app:macos';
 
   @override
   Future<void> run() async {

--- a/tools/sz_repo_cli/lib/src/commands/src/deploy_app_macos_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/deploy_app_macos_command.dart
@@ -86,7 +86,7 @@ class DeployAppMacOsCommand extends CommandBase {
       'Deploys the Sharezone macOS app to the App Store or TestFlight. Automatically bumps the build number and builds the app. Codemagic CLI tools are required.';
 
   @override
-  String get name => 'app:macos';
+  String get name => 'macos';
 
   @override
   Future<void> run() async {

--- a/tools/sz_repo_cli/lib/src/commands/src/deploy_app_web_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/deploy_app_web_command.dart
@@ -38,8 +38,8 @@ final _webFlavors = [
 ///
 /// The command will automatically use the right firebase config as configured
 /// inside [_stageToTarget].
-class DeployWebAppCommand extends CommandBase {
-  DeployWebAppCommand(super.context) {
+class DeployAppWebCommand extends CommandBase {
+  DeployAppWebCommand(super.context) {
     argParser
       ..addOption(
         releaseStageOptionName,
@@ -70,7 +70,7 @@ class DeployWebAppCommand extends CommandBase {
       'Deploy the Sharezone web app in the given environment';
 
   @override
-  String get name => 'web';
+  String get name => 'app:web';
 
   @override
   Future<void> run() async {

--- a/tools/sz_repo_cli/lib/src/commands/src/deploy_app_web_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/deploy_app_web_command.dart
@@ -70,7 +70,7 @@ class DeployAppWebCommand extends CommandBase {
       'Deploy the Sharezone web app in the given environment';
 
   @override
-  String get name => 'app:web';
+  String get name => 'web';
 
   @override
   Future<void> run() async {

--- a/tools/sz_repo_cli/lib/src/main.dart
+++ b/tools/sz_repo_cli/lib/src/main.dart
@@ -14,6 +14,7 @@ import 'package:file/local.dart';
 import 'package:process_runner/process_runner.dart';
 import 'package:sz_repo_cli/src/commands/src/add_license_headers_command.dart';
 import 'package:sz_repo_cli/src/commands/src/build_app_android_command.dart';
+import 'package:sz_repo_cli/src/commands/src/build_app_command.dart';
 import 'package:sz_repo_cli/src/commands/src/build_command.dart';
 import 'package:sz_repo_cli/src/commands/src/build_app_ios_command.dart';
 import 'package:sz_repo_cli/src/commands/src/build_app_macos_command.dart';
@@ -23,6 +24,7 @@ import 'package:sz_repo_cli/src/commands/src/build_app_web_command.dart';
 import 'package:sz_repo_cli/src/commands/src/build_website_command.dart';
 import 'package:sz_repo_cli/src/commands/src/check_license_headers_command.dart';
 import 'package:sz_repo_cli/src/commands/src/deploy_app_android_command.dart';
+import 'package:sz_repo_cli/src/commands/src/deploy_app_command.dart';
 import 'package:sz_repo_cli/src/commands/src/deploy_app_ios_command.dart';
 import 'package:sz_repo_cli/src/commands/src/deploy_app_macos_command.dart';
 import 'package:sz_repo_cli/src/commands/src/deploy_website_command.dart';
@@ -65,16 +67,18 @@ Future<void> main(List<String> args) async {
           ..addSubcommand(CheckLicenseHeadersCommand(context))
           ..addSubcommand(AddLicenseHeadersCommand(context)))
         ..addCommand(DeployCommand()
-          ..addSubcommand(DeployAppWebCommand(context))
-          ..addSubcommand(DeployAppIosCommand(context))
-          ..addSubcommand(DeployAppMacOsCommand(context))
-          ..addSubcommand(DeployAndroidCommand(context))
+          ..addSubcommand(DeployAppCommand(context)
+            ..addSubcommand(DeployAppWebCommand(context))
+            ..addSubcommand(DeployAppIosCommand(context))
+            ..addSubcommand(DeployAppMacOsCommand(context))
+            ..addSubcommand(DeployAndroidCommand(context)))
           ..addSubcommand(DeployWebsiteCommand(context)))
         ..addCommand(BuildCommand()
-          ..addSubcommand(BuildAppAndroidCommand(context))
-          ..addSubcommand(BuildAppMacOsCommand(context))
-          ..addSubcommand(BuildAppWebCommand(context))
-          ..addSubcommand(BuildAppIosCommand(context))
+          ..addSubcommand(BuildAppCommand(context)
+            ..addSubcommand(BuildAppAndroidCommand(context))
+            ..addSubcommand(BuildAppMacOsCommand(context))
+            ..addSubcommand(BuildAppWebCommand(context))
+            ..addSubcommand(BuildAppIosCommand(context)))
           ..addSubcommand(BuildWebsiteCommand(context)))
         ..addCommand(
             BuildRunnerCommand()..addSubcommand(BuildRunnerBuild(context)));

--- a/tools/sz_repo_cli/lib/src/main.dart
+++ b/tools/sz_repo_cli/lib/src/main.dart
@@ -13,18 +13,18 @@ import 'package:args/command_runner.dart';
 import 'package:file/local.dart';
 import 'package:process_runner/process_runner.dart';
 import 'package:sz_repo_cli/src/commands/src/add_license_headers_command.dart';
-import 'package:sz_repo_cli/src/commands/src/build_android_command.dart';
+import 'package:sz_repo_cli/src/commands/src/build_app_android_command.dart';
 import 'package:sz_repo_cli/src/commands/src/build_command.dart';
-import 'package:sz_repo_cli/src/commands/src/build_ios_command.dart';
-import 'package:sz_repo_cli/src/commands/src/build_macos_command.dart';
+import 'package:sz_repo_cli/src/commands/src/build_app_ios_command.dart';
+import 'package:sz_repo_cli/src/commands/src/build_app_macos_command.dart';
 import 'package:sz_repo_cli/src/commands/src/build_runner_build_command.dart';
 import 'package:sz_repo_cli/src/commands/src/build_runner_command.dart';
-import 'package:sz_repo_cli/src/commands/src/build_web_command.dart';
+import 'package:sz_repo_cli/src/commands/src/build_app_web_command.dart';
 import 'package:sz_repo_cli/src/commands/src/build_website_command.dart';
 import 'package:sz_repo_cli/src/commands/src/check_license_headers_command.dart';
-import 'package:sz_repo_cli/src/commands/src/deploy_android_command.dart';
-import 'package:sz_repo_cli/src/commands/src/deploy_ios_command.dart';
-import 'package:sz_repo_cli/src/commands/src/deploy_macos_command.dart';
+import 'package:sz_repo_cli/src/commands/src/deploy_app_android_command.dart';
+import 'package:sz_repo_cli/src/commands/src/deploy_app_ios_command.dart';
+import 'package:sz_repo_cli/src/commands/src/deploy_app_macos_command.dart';
 import 'package:sz_repo_cli/src/commands/src/deploy_website_command.dart';
 import 'package:sz_repo_cli/src/commands/src/format_command.dart';
 import 'package:sz_repo_cli/src/commands/src/license_headers_command.dart';
@@ -65,16 +65,16 @@ Future<void> main(List<String> args) async {
           ..addSubcommand(CheckLicenseHeadersCommand(context))
           ..addSubcommand(AddLicenseHeadersCommand(context)))
         ..addCommand(DeployCommand()
-          ..addSubcommand(DeployWebAppCommand(context))
-          ..addSubcommand(DeployIosCommand(context))
-          ..addSubcommand(DeployMacOsCommand(context))
+          ..addSubcommand(DeployAppWebCommand(context))
+          ..addSubcommand(DeployAppIosCommand(context))
+          ..addSubcommand(DeployAppMacOsCommand(context))
           ..addSubcommand(DeployAndroidCommand(context))
           ..addSubcommand(DeployWebsiteCommand(context)))
         ..addCommand(BuildCommand()
-          ..addSubcommand(BuildAndroidCommand(context))
-          ..addSubcommand(BuildMacOsCommand(context))
-          ..addSubcommand(BuildWebCommand(context))
-          ..addSubcommand(BuildIosCommand(context))
+          ..addSubcommand(BuildAppAndroidCommand(context))
+          ..addSubcommand(BuildAppMacOsCommand(context))
+          ..addSubcommand(BuildAppWebCommand(context))
+          ..addSubcommand(BuildAppIosCommand(context))
           ..addSubcommand(BuildWebsiteCommand(context)))
         ..addCommand(
             BuildRunnerCommand()..addSubcommand(BuildRunnerBuild(context)));

--- a/website/web/robots_dev.txt
+++ b/website/web/robots_dev.txt
@@ -1,4 +1,4 @@
-# File will be renamed to robots.txt when deploying with "sz deploy web"
+# File will be renamed to robots.txt when deploying with "sz deploy website"
 User-agent: *
 # Disallow all because the dev website should not be indexed by search engines
 Disallow: /

--- a/website/web/robots_prod.txt
+++ b/website/web/robots_prod.txt
@@ -1,4 +1,4 @@
-# File will be renamed to robots.txt when deploying with "sz deploy web"
+# File will be renamed to robots.txt when deploying with "sz deploy website"
 User-agent: *
 Allow: /
 


### PR DESCRIPTION
Since we are adding more and more different `build` and `deploy` commands (like `sz deploy website`), I added a `app` prefix for the app commands:

From `sz deploy ios` to `sz deploy app ios` (same applies for `macos`, `android` and `web`).