### PR TITLE
Add `sz.bat` and `sharezone.bat` to `/bin`.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ _tl;dr: We recommend macOS._
 
 You can use the operating system you like. But we recommend to use macOS because you might have some issues with other operating systems.
 
-#### Known issues:
+#### Known issues
 
 - Golden tests are only passing with macOS
 - The Sharezone CLI (used for development) only officially supports macOS and Windows (should also work with other operating systems, but might cause problems in some cases)
@@ -63,15 +63,15 @@ You should now be able to run `sz` or `sharezone` in your terminal.
 
 #### Windows
 
-At the moment, there is no Windows support for a command alias like `sz` or `sharezone`. Instead you need to run `dart run tools/sz_repo_cli/bin/sz_repo_cli.dart`, like `dart run tools/sz_repo_cli/bin/sz_repo_cli.dart pub get`. Please keep this in mind when reading commands like `sz pub get`.
-
 Execute the following steps to install the Sharezone CLI:
 
 1. [Clone this repository](#clone-this-repository)
 2. Navigate to the repository (`cd sharezone-app`)
 3. Run `dart pub get -C tools/sz_repo_cli`
+4. Add the `./bin` to your PATH environment variables ([tutorial](https://www.architectryan.com/2018/03/17/add-to-the-path-on-windows-10/))
+5. Restart your terminal / code editor
 
-You should now be able to run `dart run tools/sz_repo_cli/bin/sz_repo_cli.dart`.
+You should now be able to run `sz` or `sharezone` in your terminal.
 
 ### Clone this repository
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ _tl;dr: We recommend macOS._
 
 You can use the operating system you like. But we recommend to use macOS because you might have some issues with other operating systems.
 
-#### Known issues
+#### Known issues:
 
 - Golden tests are only passing with macOS
 - The Sharezone CLI (used for development) only officially supports macOS and Windows (should also work with other operating systems, but might cause problems in some cases)

--- a/bin/sharezone.bat
+++ b/bin/sharezone.bat
@@ -1,0 +1,7 @@
+@echo off
+
+:: From: https://stackoverflow.com/a/3827582
+SET directory_of_this_script=%~dp0
+SET directory_of_this_script=%directory_of_this_script:~0,-1%
+
+fvm dart run %directory_of_this_script%\..\tools\sz_repo_cli\bin\sz_repo_cli.dart %*

--- a/bin/sz.bat
+++ b/bin/sz.bat
@@ -1,0 +1,2 @@
+@echo off
+sharezone %*


### PR DESCRIPTION
Adds bat files so that developers on Windows can add the `/bin` folder of this repo to their path and then just type `sz` or `sharezone` instead of `fvm dart run ./tools/sz_repo_cli/bin/sz_repo_cli.dart`.