### PR TITLE
Upgrade dev packages and `analyzer`

### DIFF
--- a/app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -29,6 +29,7 @@ import purchases_flutter
 import shared_preferences_foundation
 import sqflite
 import url_launcher_macos
+import video_player_avfoundation
 import wakelock_plus
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
@@ -56,5 +57,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
+  FVPVideoPlayerPlugin.register(with: registry.registrar(forPlugin: "FVPVideoPlayerPlugin"))
   WakelockPlusMacosPlugin.register(with: registry.registrar(forPlugin: "WakelockPlusMacosPlugin"))
 }

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -13,18 +13,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: ae92f5d747aee634b87f89d9946000c2de774be1d6ac3e58268224348cd0101a
+      sha256: "0b2f2bd91ba804e53a61d757b986f89f1f9eaed5b11e4b2f5a2468d86d6c9fc7"
       url: "https://pub.dev"
     source: hosted
-    version: "61.0.0"
+    version: "67.0.0"
   _flutterfire_internals:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: "737321f9be522620ed3794937298fb0027a48a402624fa2500f7532f94aea810"
+      sha256: fe4c077084ddda88f327dc1c96d16631cd68d4948644593fcbcd911c2c89e2fa
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.22"
+    version: "1.3.23"
   abgabe_client_lib:
     dependency: "direct main"
     description:
@@ -58,10 +58,10 @@ packages:
     dependency: transitive
     description:
       name: analyzer
-      sha256: ea3d8652bda62982addfd92fdc2d0214e5f82e43325104990d4f4c4a2a313562
+      sha256: "37577842a27e4338429a1cbc32679d508836510b056f1eedf0c8d20e39c1383d"
       url: "https://pub.dev"
     source: hosted
-    version: "5.13.0"
+    version: "6.4.1"
   animated_stream_list_nullsafety:
     dependency: "direct main"
     description:
@@ -74,10 +74,10 @@ packages:
     dependency: "direct main"
     description:
       name: animations
-      sha256: ef57563eed3620bd5d75ad96189846aca1e033c0c45fc9a7d26e80ab02b88a70
+      sha256: d3d6dcfb218225bbe68e87ccf6378bbb2e32a94900722c5f81611dad089911cb
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.8"
+    version: "2.0.11"
   animator:
     dependency: "direct main"
     description:
@@ -114,10 +114,10 @@ packages:
     dependency: transitive
     description:
       name: asn1lib
-      sha256: "21afe4333076c02877d14f4a89df111e658a6d466cbfc802eb705eb91bd5adfd"
+      sha256: c9c85fedbe2188b95133cbe960e16f5f448860f7133330e272edbbca5893ddc6
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "1.5.2"
   async:
     dependency: "direct dev"
     description:
@@ -152,10 +152,10 @@ packages:
     dependency: "direct main"
     description:
       name: bloc
-      sha256: "3820f15f502372d979121de1f6b97bfcf1630ebff8fe1d52fb2b0bfa49be5b49"
+      sha256: f53a110e3b48dcd78136c10daa5d51512443cea5e1348c9d80a320095fa2db9e
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.2"
+    version: "8.1.3"
   bloc_base:
     dependency: "direct main"
     description:
@@ -175,10 +175,10 @@ packages:
     dependency: "direct dev"
     description:
       name: bloc_presentation_test
-      sha256: "460881b916b68d696b2a60a04260ccb0b549f42b22a96c84e5b1cf93b667e6f4"
+      sha256: ecf4b9bfc620630a468bf6c33aefc629a9aeb262879ccf8c36dc4ea4a0ee9e3e
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   bloc_provider:
     dependency: "direct main"
     description:
@@ -190,10 +190,10 @@ packages:
     dependency: "direct dev"
     description:
       name: bloc_test
-      sha256: af0de1a1e16a7536e95dcd7491e0a6d6078e11d2d691988e862280b74f5c7968
+      sha256: "55a48f69e0d480717067c5377c8485a3fcd41f1701a820deef72fa0f4ee7215f"
       url: "https://pub.dev"
     source: hosted
-    version: "9.1.4"
+    version: "9.1.6"
   boolean_selector:
     dependency: transitive
     description:
@@ -229,34 +229,34 @@ packages:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: "5f02d73eb2ba16483e693f80bee4f088563a820e47d1027d4cdfe62b5bb43e65"
+      sha256: "0343061a33da9c5810b2d6cee51945127d8f4c060b7fbdd9d54917f0a3feaaa1"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
+    version: "4.0.1"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: a7417cc44d9edb3f2c8760000270c99dba8c72ff66d0146772b8326565780745
+      sha256: "339086358431fa15d7eca8b6a36e5d783728cf025e559b834f4609a1fcfb7b0a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.4.2"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "67d591d602906ef9201caf93452495ad1812bea2074f04e25dbd7c133785821b"
+      sha256: "581bacf68f89ec8792f5e5a0b2c4decd1c948e97ce659dc783688c8a88fbec21"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.7"
+    version: "2.4.8"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: "6d6ee4276b1c5f34f21fdf39425202712d2be82019983d52f351c94aafbc2c41"
+      sha256: "4ae8ffe5ac758da294ecf1802f2aff01558d8b1b00616aa7538ea9a8a5d50799"
       url: "https://pub.dev"
     source: hosted
-    version: "7.2.10"
+    version: "7.3.0"
   built_collection:
     dependency: "direct dev"
     description:
@@ -269,10 +269,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: ff627b645b28fb8bdb69e645f910c2458fd6b65f6585c3a53e0626024897dedf
+      sha256: fedde275e0a6b798c3296963c5cd224e3e1b55d0e478d5b7e65e6b540f363a0e
       url: "https://pub.dev"
     source: hosted
-    version: "8.6.2"
+    version: "8.9.1"
   characters:
     dependency: "direct main"
     description:
@@ -293,10 +293,10 @@ packages:
     dependency: transitive
     description:
       name: chewie
-      sha256: "60701da1f22ed20cd2d40e856fd1f2249dacf5b629d9fa50676443a18a4857b8"
+      sha256: "8bc4ac4cf3f316e50a25958c0f5eb9bb12cf7e8308bb1d74a43b230da2cfc144"
       url: "https://pub.dev"
     source: hosted
-    version: "1.7.0"
+    version: "1.7.5"
   clock:
     dependency: "direct main"
     description:
@@ -309,10 +309,10 @@ packages:
     dependency: "direct main"
     description:
       name: cloud_firestore
-      sha256: e51b896f23f96c541c29171ccfbe771696cc280767d1412df1237db4effea285
+      sha256: "6f6a9e7f1c68f34ffe159c911a290fa7caf1a09b8a88aa1534c65f0246953970"
       url: "https://pub.dev"
     source: hosted
-    version: "4.15.5"
+    version: "4.15.6"
   cloud_firestore_helper:
     dependency: "direct main"
     description:
@@ -324,50 +324,50 @@ packages:
     dependency: transitive
     description:
       name: cloud_firestore_platform_interface
-      sha256: "8c5834277519f7e68d4bdf5ae04046ede3cb98ce7e3cfced3153fb83a16d2508"
+      sha256: "4e92549af19f0d2eec7e379ca44f909caef8eb52295a0cde5467b018cfae0378"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.6"
+    version: "6.1.7"
   cloud_firestore_web:
     dependency: transitive
     description:
       name: cloud_firestore_web
-      sha256: "4f5d9164cf9873d05573eddeec62210be0efa5e4cb047ea81253b6da25ebd9dc"
+      sha256: "2b34cff977da11a4822151d967c5e6ce62640cbcb56d6e52a46382d2316350ac"
       url: "https://pub.dev"
     source: hosted
-    version: "3.10.5"
+    version: "3.10.6"
   cloud_functions:
     dependency: "direct main"
     description:
       name: cloud_functions
-      sha256: "60cf020fd44c7971b196b4c25b26471a0d2114dcbdf5df94d3391d502986c3d8"
+      sha256: "44a88d02b1b1291bb291b8de756ff3f02d3a0c5c68dfc1c42c83c1529ba0416b"
       url: "https://pub.dev"
     source: hosted
-    version: "4.6.5"
+    version: "4.6.6"
   cloud_functions_platform_interface:
     dependency: transitive
     description:
       name: cloud_functions_platform_interface
-      sha256: b57fe3f2ac7fa4e23d314ae599339650ae307552354b2d46670bf9e70eda2478
+      sha256: "9b02f827013f37824de5ec02bd2a1838e47c899edd39df642d1437c68b6f1c3c"
       url: "https://pub.dev"
     source: hosted
-    version: "5.5.16"
+    version: "5.5.17"
   cloud_functions_web:
     dependency: transitive
     description:
       name: cloud_functions_web
-      sha256: a9f5e64a266aaf84ac6230bb7802d82a9243438b287e0ea45c44aa2afd492ad0
+      sha256: "9ccd76057f2f5e20b8c2dc19e785993dd83edef1a9f49472cf0e12268da6781b"
       url: "https://pub.dev"
     source: hosted
-    version: "4.6.16"
+    version: "4.7.0"
   code_builder:
     dependency: transitive
     description:
       name: code_builder
-      sha256: "315a598c7fbe77f22de1c9da7cfd6fd21816312f16ffa124453b4fc679e540f1"
+      sha256: f692079e25e7869c14132d39f223f8eec9830eb76131925143b2129c4bb01b37
       url: "https://pub.dev"
     source: hosted
-    version: "4.6.0"
+    version: "4.10.0"
   collection:
     dependency: "direct main"
     description:
@@ -418,10 +418,10 @@ packages:
     dependency: transitive
     description:
       name: cross_file
-      sha256: fd832b5384d0d6da4f6df60b854d33accaaeb63aa9e10e736a87381f08dee2cb
+      sha256: "55d7b444feb71301ef6b8838dbc1ae02e63dd48c8773f3810ff53bb1e2945b32"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.3+5"
+    version: "0.3.4+1"
   crypto:
     dependency: transitive
     description:
@@ -450,10 +450,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "1efa911ca7086affd35f463ca2fc1799584fb6aa89883cf0af8e3664d6a02d55"
+      sha256: "99e066ce75c89d6b29903d788a7bb9369cf754f7b24bf70bf4b6d6d6b26853b9"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.2"
+    version: "2.3.6"
   date:
     dependency: "direct main"
     description:
@@ -465,10 +465,10 @@ packages:
     dependency: transitive
     description:
       name: dbus
-      sha256: "6f07cba3f7b3448d42d015bfd3d53fe12e5b36da2423f23838efc1d5fb31a263"
+      sha256: "365c771ac3b0e58845f39ec6deebc76e3276aa9922b0cc60840712094d9047ac"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.8"
+    version: "0.7.10"
   design:
     dependency: "direct main"
     description:
@@ -480,10 +480,10 @@ packages:
     dependency: transitive
     description:
       name: device_info_plus
-      sha256: "86add5ef97215562d2e090535b0a16f197902b10c369c558a100e74ea06e8659"
+      sha256: "77f757b789ff68e4eaf9c56d1752309bd9f7ad557cb105b938a7f8eb89e59110"
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.3"
+    version: "9.1.2"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -496,10 +496,10 @@ packages:
     dependency: "direct main"
     description:
       name: diacritic
-      sha256: a84e03ec2779375fb86430dbe9d8fba62c68376f2499097a5f6e75556babe706
+      sha256: "96db5db6149cbe4aa3cfcbfd170aca9b7648639be7e48025f9d458517f807fe4"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.5"
   diff_match_patch:
     dependency: transitive
     description:
@@ -512,10 +512,10 @@ packages:
     dependency: "direct main"
     description:
       name: dio
-      sha256: ce75a1b40947fea0a0e16ce73337122a86762e38b982e1ccb909daa3b9bc4197
+      sha256: "49af28382aefc53562459104f64d16b9dfd1e8ef68c862d5af436cc8356ce5a8"
       url: "https://pub.dev"
     source: hosted
-    version: "5.3.2"
+    version: "5.4.1"
   dynamic_links:
     dependency: "direct main"
     description:
@@ -527,10 +527,10 @@ packages:
     dependency: transitive
     description:
       name: encrypt
-      sha256: "4fd4e4fdc21b9d7d4141823e1e6515cd94e7b8d84749504c232999fba25d9bbb"
+      sha256: "62d9aa4670cc2a8798bab89b39fc71b6dfbacf615de6cf5001fb39f7e4a996a2"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.1"
+    version: "5.0.3"
   equatable:
     dependency: "direct main"
     description:
@@ -559,10 +559,10 @@ packages:
     dependency: "direct main"
     description:
       name: fast_immutable_collections
-      sha256: b4f7d3af6e90a80cf7a3dddd0de3b4a46acb446320795b77b034535c4d267fbe
+      sha256: b910ccdc99bb38a2abbce07c5afb8f81d4e222a892e4d095a548b99814837b0c
       url: "https://pub.dev"
     source: hosted
-    version: "9.1.5"
+    version: "9.2.1"
   fast_rsa:
     dependency: transitive
     description:
@@ -575,10 +575,10 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: "7bf0adc28a23d395f19f3f1eb21dd7cfd1dd9f8e1c50051c069122e6853bc878"
+      sha256: "493f37e7df1804778ff3a53bd691d8692ddf69702cf4c1c1096a2e41b4779e21"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
   file:
     dependency: transitive
     description:
@@ -607,18 +607,18 @@ packages:
     dependency: transitive
     description:
       name: file_selector_macos
-      sha256: "182c3f8350cee659f7b115e956047ee3dc672a96665883a545e81581b9a82c72"
+      sha256: b15c3da8bd4908b9918111fa486903f5808e388b8d1c559949f584725a6594d6
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.3+2"
+    version: "0.9.3+3"
   file_selector_platform_interface:
     dependency: transitive
     description:
       name: file_selector_platform_interface
-      sha256: "0aa47a725c346825a2bd396343ce63ac00bda6eff2fbc43eabe99737dede8262"
+      sha256: a3994c26f10378a039faa11de174d7b78eb8f79e4dd0af2a451410c1a5c3f66b
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.1"
+    version: "2.6.2"
   file_selector_windows:
     dependency: transitive
     description:
@@ -659,58 +659,58 @@ packages:
     dependency: transitive
     description:
       name: firebase_analytics
-      sha256: "54681f6a8c35ec782c86680919953edbae66517a718fe7606a7ba52cfa1b36ca"
+      sha256: c6220b23397f9302a42617227ee8fb1c5d718097a5351fcce53561d73fc10339
       url: "https://pub.dev"
     source: hosted
-    version: "10.8.6"
+    version: "10.8.7"
   firebase_analytics_platform_interface:
     dependency: transitive
     description:
       name: firebase_analytics_platform_interface
-      sha256: cf7378f407c26fd1f1cc808c0d791f2a15dd4f1fe0626bb2ce6a96663c4d8470
+      sha256: "7f1c02cdd93a5e0a561af2f551465ffb6abdd541dbd0c8a9b8628d9ae0a5d024"
       url: "https://pub.dev"
     source: hosted
-    version: "3.9.6"
+    version: "3.9.7"
   firebase_analytics_web:
     dependency: transitive
     description:
       name: firebase_analytics_web
-      sha256: f62c7a2514771f6e122c5b55227c0c7fdaa253cc2fe6efce768897c0fb68a5ab
+      sha256: ebb857c23f35fed52220b6c3271c12eeb6137de3930845223e3d0590b6fd0649
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.5+18"
+    version: "0.5.5+19"
   firebase_auth:
     dependency: "direct main"
     description:
       name: firebase_auth
-      sha256: "06863a0031b5f1b11ecac2c7d93c026df039a1379224a6671c59f528397d19e1"
+      sha256: "6d8b4455524e2a619a135169a0ae817778d4acf56172188acae85f69f5e67185"
       url: "https://pub.dev"
     source: hosted
-    version: "4.17.5"
+    version: "4.17.6"
   firebase_auth_platform_interface:
     dependency: transitive
     description:
       name: firebase_auth_platform_interface
-      sha256: dba259dee045b706112c3d7619b01c2ad338d86cc492df52dd2073584a64de66
+      sha256: "3eed984830f610f43164d539ec6228820cf4936ab6ef491e1afcfaca80143c84"
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.5"
+    version: "7.1.6"
   firebase_auth_web:
     dependency: transitive
     description:
       name: firebase_auth_web
-      sha256: ea47c590d0da836ae7253fadb95546b4595fbc59a5c50583e0fb5a1c5c476aff
+      sha256: fcf4718abc722131218de3b84772d83019be48c9211dbd5998aece716c52ff31
       url: "https://pub.dev"
     source: hosted
-    version: "5.9.5"
+    version: "5.9.6"
   firebase_core:
     dependency: "direct main"
     description:
       name: firebase_core
-      sha256: "7e049e32a9d347616edb39542cf92cd53fdb4a99fb6af0a0bff327c14cd76445"
+      sha256: "797379ea206eaeeb62499775de812761493d0692890fdc7f90b6183a3369176d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.25.4"
+    version: "2.25.5"
   firebase_core_platform_interface:
     dependency: transitive
     description:
@@ -723,42 +723,42 @@ packages:
     dependency: transitive
     description:
       name: firebase_core_web
-      sha256: "57e61d6010e253b36d38191cefd6199d7849152cdcd234b61ca290cdb278a0ba"
+      sha256: c8e1d59385eee98de63c92f961d2a7062c5d9a65e7f45bdc7f1b0b205aab2492
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.4"
+    version: "2.11.5"
   firebase_crashlytics:
     dependency: transitive
     description:
       name: firebase_crashlytics
-      sha256: "4c754db28a7daabe03c4cbf1079dbe81e6f0681284fed6d07e0e640b7f1027c4"
+      sha256: "0126fa101b74fb981796b3e6f47ccf7fc40237ec918327aaec7c0a06fd1bb4c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.15"
+    version: "3.4.16"
   firebase_crashlytics_platform_interface:
     dependency: transitive
     description:
       name: firebase_crashlytics_platform_interface
-      sha256: "08c5d7b5f93dbad7306d26702935abd8b579313ea256eb27006562a1867df249"
+      sha256: cdfa0a20d66e1b32de542883c0ddf651ee9b66b12cebf73067e4d2cdc0865d17
       url: "https://pub.dev"
     source: hosted
-    version: "3.6.22"
+    version: "3.6.23"
   firebase_dynamic_links:
     dependency: transitive
     description:
       name: firebase_dynamic_links
-      sha256: d8a71ffcbc924b493fade9929f746c7e42f071a9be452d9d2caf280c29d7be1a
+      sha256: "52a482aa2cb571bf504d39a5c0c6ec3fdfbb45526f87558d7fda8101b45c31c0"
       url: "https://pub.dev"
     source: hosted
-    version: "5.4.14"
+    version: "5.4.15"
   firebase_dynamic_links_platform_interface:
     dependency: transitive
     description:
       name: firebase_dynamic_links_platform_interface
-      sha256: "39cad519854da0a7d97c78ec0519e9f267cd5a74a713915cbae4d04238a61a22"
+      sha256: "4ae56fe8b1e43e0b8a693f64673da82b180a7c255bcc221d8f31c6f334e5b9b0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.6+22"
+    version: "0.2.6+23"
   firebase_hausaufgabenheft_logik:
     dependency: "direct main"
     description:
@@ -770,98 +770,98 @@ packages:
     dependency: "direct main"
     description:
       name: firebase_messaging
-      sha256: "799922b57d09fe89b5634be2a7fea66a2683eb1a02502c71fe90c212240f89ef"
+      sha256: "1e15c5d90cd1dab98cdd169e258bceece1e98d3855350abe4196146443bbb08a"
       url: "https://pub.dev"
     source: hosted
-    version: "14.7.16"
+    version: "14.7.17"
   firebase_messaging_platform_interface:
     dependency: transitive
     description:
       name: firebase_messaging_platform_interface
-      sha256: "789a3b26097e2bdad15a407dc552d6af74287b477ceb4aa6ec0d8aa967caf9e5"
+      sha256: "5e00f3e5c8b3f24b082dc20edb0c80d653ca87a87757db71218e045070fc7f8e"
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.24"
+    version: "4.5.25"
   firebase_messaging_web:
     dependency: transitive
     description:
       name: firebase_messaging_web
-      sha256: "156a83d281bbcc92b17496f323c747802287520aece51a893a5fdb8078bccbe7"
+      sha256: "59de3f85715416f97a842f307b54c23540cbba4a109a7125e2150082bb041966"
       url: "https://pub.dev"
     source: hosted
-    version: "3.6.5"
+    version: "3.6.6"
   firebase_performance:
     dependency: "direct main"
     description:
       name: firebase_performance
-      sha256: "75afdbc2a3d8d3622c52ce650eee5708c097ff0731a31aec40b2728ec1f69d66"
+      sha256: "49be2ea63c75e151388668582d0fc8924530298914558e4ab35a87c6e735e38d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.3+14"
+    version: "0.9.3+15"
   firebase_performance_platform_interface:
     dependency: transitive
     description:
       name: firebase_performance_platform_interface
-      sha256: "7a8aa16c45fe438fbfb1371b7480dde3313f06284a00b51ae5961ef53c07572d"
+      sha256: "14cc68e339d3f2226d757cff8e97286d6f3bf135613fdcb42590cc175b108383"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.4+22"
+    version: "0.1.4+23"
   firebase_performance_web:
     dependency: transitive
     description:
       name: firebase_performance_web
-      sha256: feb18f29378787208dfbd2b16bf80c7787af50550247250c99881407d7f63431
+      sha256: "1caa3ea74f52ac07717fcd8172695460daedc3422541b08ff68320cf46b13fe5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.4+22"
+    version: "0.1.4+23"
   firebase_remote_config:
     dependency: transitive
     description:
       name: firebase_remote_config
-      sha256: "89a26478b96b831507a8eefbd517755bd5501cd5dd153d1ee70558d7762abbe9"
+      sha256: "912476072613a28606dfd2f3d52aba53e58368086d1fb80db541109936291e80"
       url: "https://pub.dev"
     source: hosted
-    version: "4.3.14"
+    version: "4.3.15"
   firebase_remote_config_platform_interface:
     dependency: transitive
     description:
       name: firebase_remote_config_platform_interface
-      sha256: "9933c7b0ef2e74ff2bb526724bdcfd9c16f7af637a1b8e59d765bf83ee4c1c6f"
+      sha256: "97d51d36a43574eefb7a6d48028f2d844864c523d9a7bbb14f8d932dd8795799"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.22"
+    version: "1.4.23"
   firebase_remote_config_web:
     dependency: transitive
     description:
       name: firebase_remote_config_web
-      sha256: "11ccb8c836dbbabecb3aa126a9b8195def5b228acdd64ed7c5623e9327fe4789"
+      sha256: "58dd265abe7f11761a4a84d2578651022796f8e3e4067c28c8fa2c6d0cb2633d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.22"
+    version: "1.4.23"
   firebase_storage:
     dependency: "direct main"
     description:
       name: firebase_storage
-      sha256: a07433d3ffe948f7a10086e4b0bd3a940be4ed873cffd24746eed1896b568369
+      sha256: "261763ebb2722abb8d3c702f467a9efb1f4ac8978a94c03850b80cfa3009c400"
       url: "https://pub.dev"
     source: hosted
-    version: "11.6.6"
+    version: "11.6.7"
   firebase_storage_platform_interface:
     dependency: transitive
     description:
       name: firebase_storage_platform_interface
-      sha256: af99d9fcf058d6f3a591cea899cad054ded7adb21fb1788dfe65c3e223196b15
+      sha256: "41e5832d930f668a62aa4fd3dc9778af3a301297170f549b882dad4c5b7d3bc7"
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.9"
+    version: "5.1.10"
   firebase_storage_web:
     dependency: transitive
     description:
       name: firebase_storage_web
-      sha256: "06a684016de9609928865798dece0f7d34782a15a76f5ac08bd3a8780035b0b2"
+      sha256: "5eac3e415e01384e8a5fc92510db61fee3001d7008fa0209ff2290bcd051b6c7"
       url: "https://pub.dev"
     source: hosted
-    version: "3.7.0"
+    version: "3.7.1"
   fixnum:
     dependency: transitive
     description:
@@ -895,10 +895,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_bloc
-      sha256: e74efb89ee6945bcbce74a5b3a5a3376b088e5f21f55c263fc38cbdc6237faae
+      sha256: "87325da1ac757fcc4813e6b34ed5dd61169973871fdf181d6c2109dd6935ece1"
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.3"
+    version: "8.1.4"
   flutter_cache_manager:
     dependency: "direct main"
     description:
@@ -978,10 +978,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_plugin_android_lifecycle
-      sha256: f185ac890306b5779ecbd611f52502d8d4d63d27703ef73161ca0407e815f02c
+      sha256: b068ffc46f82a55844acfa4fdbb61fad72fa2aef0905548419d97f0f95c456da
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.16"
+    version: "2.0.17"
   flutter_rating_bar:
     dependency: "direct main"
     description:
@@ -1002,10 +1002,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_slidable
-      sha256: cc4231579e3eae41ae166660df717f4bad1359c87f4a4322ad8ba1befeb3d2be
+      sha256: "19ed4813003a6ff4e9c6bcce37e792a2a358919d7603b2b31ff200229191e44c"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.1"
   flutter_staggered_animations:
     dependency: "direct main"
     description:
@@ -1018,10 +1018,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_svg
-      sha256: "8c5d68a82add3ca76d792f058b186a0599414f279f00ece4830b9b231b570338"
+      sha256: "7b4ca6cf3304575fe9c8ec64813c8d02ee41d2afe60bcfe0678bcb5375d596a2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.7"
+    version: "2.0.10+1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -1044,10 +1044,10 @@ packages:
     dependency: "direct main"
     description:
       name: font_awesome_flutter
-      sha256: "5fb789145cae1f4c3245c58b3f8fb287d055c26323879eab57a7bf0cfd1e45f3"
+      sha256: "275ff26905134bcb59417cf60ad979136f1f8257f2f449914b2c3e05bbb4cd6f"
       url: "https://pub.dev"
     source: hosted
-    version: "10.5.0"
+    version: "10.7.0"
   freezed_annotation:
     dependency: transitive
     description:
@@ -1073,10 +1073,10 @@ packages:
     dependency: transitive
     description:
       name: gcloud
-      sha256: "94cc7901dba3bcc9cd1c0530caf2d87e733392ce8f93734ccb23d82ef9f2a3e2"
+      sha256: e9501083036d5f94027ce5afddd8ddae9b04121cf2fc6036b2cdd5663b52fca7
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.11"
+    version: "0.8.12"
   glob:
     dependency: transitive
     description:
@@ -1097,66 +1097,66 @@ packages:
     dependency: transitive
     description:
       name: google_identity_services_web
-      sha256: "000b7a31e1fa17ee04b6c0553a2b2ea18f9f9352e4dcc0c9fcc785cf10f2484e"
+      sha256: "972ff30eebf6a5eab28be3e1e47a45df087ed64d5aefdac0df47758ecdec5385"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.2"
+    version: "0.3.1"
   google_sign_in:
     dependency: transitive
     description:
       name: google_sign_in
-      sha256: "23982b6a6b9e664bdc540488732d5760bc73e83ec74c2bd87cb690cfd357dd75"
+      sha256: "0b8787cb9c1a68ad398e8010e8c8766bfa33556d2ab97c439fb4137756d7308f"
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.0"
+    version: "6.2.1"
   google_sign_in_android:
     dependency: transitive
     description:
       name: google_sign_in_android
-      sha256: "8d76099cb220d4f10c7e3c24492814c733f48ecb574c45c0ccadf5d5e50b012d"
+      sha256: bfd42c81c30c6faba16e0f62968d5505a87504aaa672b3155ee931461abb0a49
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.19"
+    version: "6.1.21"
   google_sign_in_ios:
     dependency: transitive
     description:
       name: google_sign_in_ios
-      sha256: e050cd907db1ee441b8efc0d8db63f3514f343872fdef6de36940fb09a92b2d7
+      sha256: a7d653803468d30b82ceb47ea00fe86d23c56e63eb2e5c2248bb68e9df203217
       url: "https://pub.dev"
     source: hosted
-    version: "5.7.0"
+    version: "5.7.4"
   google_sign_in_platform_interface:
     dependency: transitive
     description:
       name: google_sign_in_platform_interface
-      sha256: e10eaaa30a0cb03af12dd324fb2e630ac7e9d854d0530f7a87a4d825031f9a4a
+      sha256: "1f6e5787d7a120cc0359ddf315c92309069171306242e181c09472d1b00a2971"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.3"
+    version: "2.4.5"
   google_sign_in_web:
     dependency: transitive
     description:
       name: google_sign_in_web
-      sha256: "794f5494a945d6dd2654c52f979594ecd2558e5c82ce8272295ba371c93015e6"
+      sha256: fc0f14ed45ea616a6cfb4d1c7534c2221b7092cc4f29a709f0c3053cc3e821bd
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.2+1"
+    version: "0.12.4"
   googleapis:
     dependency: transitive
     description:
       name: googleapis
-      sha256: c2f311bcd1b3e4052234162edc6b626a9013a7e1385d6aad37e9e6a6c5f89908
+      sha256: "8a8c311723162af077ca73f94b823b97ff68770d966e29614d20baca9fdb490a"
       url: "https://pub.dev"
     source: hosted
-    version: "11.4.0"
+    version: "12.0.0"
   googleapis_auth:
     dependency: transitive
     description:
       name: googleapis_auth
-      sha256: af7c3a3edf9d0de2e1e0a77e994fae0a581c525fa7012af4fa0d4a52ed9484da
+      sha256: cafc46446574fd42826aa4cd4d623c94482598fda0a5a5649bf2781bcbc09258
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.5.0"
   graphs:
     dependency: transitive
     description:
@@ -1244,10 +1244,10 @@ packages:
     dependency: transitive
     description:
       name: image_picker_android
-      sha256: d32a997bcc4ee135aebca8e272b7c517927aa65a74b9c60a81a2764ef1a0462d
+      sha256: "39f2bfe497e495450c81abcd44b62f56c2a36a37a175da7d137b4454977b51b1"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.7+5"
+    version: "0.8.9+3"
   image_picker_for_web:
     dependency: transitive
     description:
@@ -1260,10 +1260,10 @@ packages:
     dependency: transitive
     description:
       name: image_picker_ios
-      sha256: c5538cacefacac733c724be7484377923b476216ad1ead35a0d2eadcdc0fc497
+      sha256: fadafce49e8569257a0cad56d24438a6fa1f0cbd7ee0af9b631f7492818a4ca3
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.8+2"
+    version: "0.8.9+1"
   image_picker_linux:
     dependency: transitive
     description:
@@ -1284,10 +1284,10 @@ packages:
     dependency: transitive
     description:
       name: image_picker_platform_interface
-      sha256: ed9b00e63977c93b0d2d2b343685bed9c324534ba5abafbb3dfbd6a780b1b514
+      sha256: "3d2c323daea9d60608f1caf30be32a938916f4975434b8352e6f73dae496da38"
       url: "https://pub.dev"
     source: hosted
-    version: "2.9.1"
+    version: "2.9.4"
   image_picker_windows:
     dependency: transitive
     description:
@@ -1407,10 +1407,10 @@ packages:
     dependency: "direct main"
     description:
       name: markdown
-      sha256: acf35edccc0463a9d7384e437c015a3535772e09714cf60e07eeef3a15870dcd
+      sha256: "1b134d9f8ff2da15cb298efe6cd8b7d2a78958c1b00384ebcbdf13fe340a6c90"
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.1"
+    version: "7.2.1"
   matcher:
     dependency: transitive
     description:
@@ -1439,18 +1439,18 @@ packages:
     dependency: transitive
     description:
       name: mime
-      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
+      sha256: "2e123074287cc9fd6c09de8336dae606d1ddb88d9ac47358826db698c176a1f2"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   mobile_scanner:
     dependency: transitive
     description:
       name: mobile_scanner
-      sha256: "2fbc3914fe625e196c64ea8ffc4084cd36781d2be276d4d5923b11af3b5d44ff"
+      sha256: "1b60b8f9d4ce0cb0e7d7bc223c955d083a0737bee66fa1fcfe5de48225e0d5b3"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.1"
+    version: "3.5.7"
   mockito:
     dependency: "direct dev"
     description:
@@ -1463,10 +1463,10 @@ packages:
     dependency: transitive
     description:
       name: mocktail
-      sha256: bac151b31e4ed78bd59ab89aa4c0928f297b1180186d5daf03734519e5f596c1
+      sha256: c4b5007d91ca4f67256e720cb1b6d704e79a510183a12fa551021f652577dce6
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.3"
   navigation_builder:
     dependency: transitive
     description:
@@ -1567,26 +1567,26 @@ packages:
     dependency: transitive
     description:
       name: path_provider
-      sha256: a1aa8aaa2542a6bc57e381f132af822420216c80d4781f7aa085ca3229208aaa
+      sha256: b27217933eeeba8ff24845c34003b003b2b22151de3c908d0e679e8fe1aa078b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   path_provider_android:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: "6b8b19bd80da4f11ce91b2d1fb931f3006911477cec227cce23d3253d80df3f1"
+      sha256: "477184d672607c0a3bf68fbbf601805f92ef79c82b64b4d6eb318cbca4c48668"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.2.2"
   path_provider_foundation:
     dependency: transitive
     description:
       name: path_provider_foundation
-      sha256: "19314d595120f82aca0ba62787d58dde2cc6b5df7d2f0daf72489e38d1b57f2d"
+      sha256: "5a7999be66e000916500be4f15a3633ebceb8302719b47b9cc49ce924125350f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.3.2"
   path_provider_linux:
     dependency: transitive
     description:
@@ -1599,10 +1599,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_platform_interface
-      sha256: "94b1e0dd80970c1ce43d5d4e050a9918fce4f4a775e6142424c30a29a363265c"
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   path_provider_windows:
     dependency: transitive
     description:
@@ -1615,18 +1615,18 @@ packages:
     dependency: "direct dev"
     description:
       name: patrol
-      sha256: "415db7827456cf7133c2fec31a6aba54ba7fcef9b9c35043f850e2636efbcc69"
+      sha256: a3934bc7bfef4bbe46ebcc24ed755f9ff1414dfb25cd91b419dfa8e1db6bde81
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.0"
+    version: "3.5.2"
   patrol_finders:
     dependency: transitive
     description:
       name: patrol_finders
-      sha256: "909a5c28ba1730e5e1e06e06ec78f4ccc49f7e211f3a0919adac552841df19ee"
+      sha256: ac33527cc1b63e3aa131dbd7107cfda8ee2df0fb4a4a423c067174a2e60db77b
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1+1"
+    version: "2.0.2"
   pdfx:
     dependency: transitive
     description:
@@ -1639,58 +1639,58 @@ packages:
     dependency: "direct main"
     description:
       name: permission_handler
-      sha256: "860c6b871c94c78e202dc69546d4d8fd84bd59faeb36f8fb9888668a53ff4f78"
+      sha256: "74e962b7fad7ff75959161bb2c0ad8fe7f2568ee82621c9c2660b751146bfe44"
       url: "https://pub.dev"
     source: hosted
-    version: "11.1.0"
+    version: "11.3.0"
   permission_handler_android:
     dependency: transitive
     description:
       name: permission_handler_android
-      sha256: "2f1bec180ee2f5665c22faada971a8f024761f632e93ddc23310487df52dcfa6"
+      sha256: "1acac6bae58144b442f11e66621c062aead9c99841093c38f5bcdcc24c1c3474"
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.1"
+    version: "12.0.5"
   permission_handler_apple:
     dependency: transitive
     description:
       name: permission_handler_apple
-      sha256: "1a816084338ada8d574b1cb48390e6e8b19305d5120fe3a37c98825bacc78306"
+      sha256: bdafc6db74253abb63907f4e357302e6bb786ab41465e8635f362ee71fd8707b
       url: "https://pub.dev"
     source: hosted
-    version: "9.2.0"
+    version: "9.4.0"
   permission_handler_html:
     dependency: transitive
     description:
       name: permission_handler_html
-      sha256: "11b762a8c123dced6461933a88ea1edbbe036078c3f9f41b08886e678e7864df"
+      sha256: "54bf176b90f6eddd4ece307e2c06cf977fb3973719c35a93b85cc7093eb6070d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.0+2"
+    version: "0.1.1"
   permission_handler_platform_interface:
     dependency: transitive
     description:
       name: permission_handler_platform_interface
-      sha256: d87349312f7eaf6ce0adaf668daf700ac5b06af84338bd8b8574dfbd93ffe1a1
+      sha256: "23dfba8447c076ab5be3dee9ceb66aad345c4a648f0cac292c77b1eb0e800b78"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "4.2.0"
   permission_handler_windows:
     dependency: transitive
     description:
       name: permission_handler_windows
-      sha256: "1e8640c1e39121128da6b816d236e714d2cf17fac5a105dd6acdd3403a628004"
+      sha256: "1a790728016f79a41216d88672dbc5df30e686e811ad4e698bfc51f76ad91f1e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.2.1"
   petitparser:
     dependency: transitive
     description:
       name: petitparser
-      sha256: cb3798bef7fc021ac45b308f4b51208a152792445cce0448c9a4ba5879dd8750
+      sha256: c15605cd28af66339f8eb6fbe0e541bfe2d1b72d5825efc6598f3e0a31b9ad27
       url: "https://pub.dev"
     source: hosted
-    version: "5.4.0"
+    version: "6.0.2"
   photo_view:
     dependency: "direct main"
     description:
@@ -1699,14 +1699,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.14.0"
-  pigeon:
-    dependency: transitive
-    description:
-      name: pigeon
-      sha256: "5a79fd0b10423f6b5705525e32015597f861c31220b522a67d1e6b580da96719"
-      url: "https://pub.dev"
-    source: hosted
-    version: "11.0.1"
   platform:
     dependency: transitive
     description:
@@ -1726,18 +1718,18 @@ packages:
     dependency: transitive
     description:
       name: plugin_platform_interface
-      sha256: da3fdfeccc4d4ff2da8f8c556704c08f912542c5fb3cf2233ed75372384a034d
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.6"
+    version: "2.1.8"
   pointycastle:
     dependency: transitive
     description:
       name: pointycastle
-      sha256: "7c1e5f0d23c9016c5bbd8b1473d0d3fb3fc851b876046039509e18e0c7485f2c"
+      sha256: "43ac87de6e10afabc85c445745a7b799e04de84cebaa4fd7bf55a5e1e9604d29"
       url: "https://pub.dev"
     source: hosted
-    version: "3.7.3"
+    version: "3.7.4"
   pool:
     dependency: transitive
     description:
@@ -1758,10 +1750,10 @@ packages:
     dependency: "direct main"
     description:
       name: provider
-      sha256: cdbe7530b12ecd9eb455bdaa2fcb8d4dad22e80b8afb4798b41479d5ce26847f
+      sha256: c8a055ee5ce3fd98d6fc872478b03823ffdb448699c6ebdbbc71d59b596fd48c
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.5"
+    version: "6.1.2"
   pub_semver:
     dependency: transitive
     description:
@@ -1782,10 +1774,10 @@ packages:
     dependency: "direct main"
     description:
       name: purchases_flutter
-      sha256: "0e87add3989b08dc80dbd42c9c4b053a6842a844dfad890224d24ebdf9a9335d"
+      sha256: "83d1c0e752d3b351e993037892eb8008a2a40e3ff090acc1b1e3732ce463a834"
       url: "https://pub.dev"
     source: hosted
-    version: "6.6.0"
+    version: "6.22.0"
   qr:
     dependency: transitive
     description:
@@ -1844,10 +1836,10 @@ packages:
     dependency: transitive
     description:
       name: rsa_pkcs
-      sha256: "17a52b0c010319f0d4c7bcc635eb89e2efeaec44975b3fb45f850b350a2b0513"
+      sha256: "6e1e03563d2cbd9758d8a562f738b759763d464fd65d32da132153230a0c0395"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.1.0"
   rxdart:
     dependency: "direct main"
     description:
@@ -1892,10 +1884,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_foundation
-      sha256: "7bf53a9f2d007329ee6f3df7268fd498f8373602f943c975598bbb34649b62a7"
+      sha256: "7708d83064f38060c7b39db12aefe449cb8cdc031d6062280087bc4cdb988f5c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.4"
+    version: "2.3.5"
   shared_preferences_linux:
     dependency: transitive
     description:
@@ -1908,18 +1900,18 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_platform_interface
-      sha256: d4ec5fc9ebb2f2e056c617112aa75dcf92fc2e4faaf2ae999caa297473f75d8a
+      sha256: "22e2ecac9419b4246d7c22bfbbda589e3acf5c0351137d87dd2939d984d37c3b"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.3.2"
   shared_preferences_web:
     dependency: transitive
     description:
       name: shared_preferences_web
-      sha256: d762709c2bbe80626ecc819143013cc820fa49ca5e363620ee20a8b15a3e3daf
+      sha256: "9aee1089b36bd2aafe06582b7d7817fd317ef05fc30e6ba14bff247d0933042a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.1"
+    version: "2.3.0"
   shared_preferences_windows:
     dependency: transitive
     description:
@@ -2029,10 +2021,10 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: fc0da689e5302edb6177fdd964efcb7f58912f43c28c2047a808f5bfff643d16
+      sha256: "14658ba5f669685cd3d63701d01b31ea748310f7ab854e471962670abcf57832"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -2069,18 +2061,18 @@ packages:
     dependency: transitive
     description:
       name: sqflite
-      sha256: "591f1602816e9c31377d5f008c2d9ef7b8aca8941c3f89cc5fd9d84da0c38a9a"
+      sha256: a9016f495c927cb90557c909ff26a6d92d9bd54fc42ba92e19d4e79d61e798c6
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "2.3.2"
   sqflite_common:
     dependency: transitive
     description:
       name: sqflite_common
-      sha256: "1b92f368f44b0dee2425bb861cfa17b6f6cf3961f762ff6f941d20b33355660a"
+      sha256: "28d8c66baee4968519fb8bd6cdbedad982d6e53359091f0b74544a9f32ec72d5"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.0"
+    version: "2.5.3"
   stack_trace:
     dependency: transitive
     description:
@@ -2156,10 +2148,10 @@ packages:
     dependency: transitive
     description:
       name: synchronized
-      sha256: "5fcbd27688af6082f5abd611af56ee575342c30e87541d0245f7ff99faa02c60"
+      sha256: "539ef412b170d65ecdafd780f924e5be3f60032a1128df156adad6c5b373d558"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.0+1"
   term_glyph:
     dependency: transitive
     description:
@@ -2203,10 +2195,10 @@ packages:
     dependency: "direct main"
     description:
       name: timeago
-      sha256: "4addcda362e51f23cf7ae2357fccd053f29d59b4ddd17fb07fc3e7febb47a456"
+      sha256: d3204eb4c788214883380253da7f23485320a58c11d145babc82ad16bf4e7764
       url: "https://pub.dev"
     source: hosted
-    version: "3.5.0"
+    version: "3.6.1"
   timing:
     dependency: transitive
     description:
@@ -2243,10 +2235,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "31222ffb0063171b526d3e569079cf1f8b294075ba323443fdc690842bfd4def"
+      sha256: d4ed0711849dd8e33eb2dd69c25db0d0d3fdc37e0a62e629fe32f57a22db2745
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.0"
+    version: "6.3.0"
   url_launcher_extended:
     dependency: "direct main"
     description:
@@ -2258,10 +2250,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_ios
-      sha256: bba3373219b7abb6b5e0d071b0fe66dfbe005d07517a68e38d4fc3638f35c6d3
+      sha256: "9149d493b075ed740901f3ee844a38a00b33116c7c5c10d7fb27df8987fb51d5"
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.1"
+    version: "6.2.5"
   url_launcher_linux:
     dependency: transitive
     description:
@@ -2282,10 +2274,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_platform_interface
-      sha256: "980e8d9af422f477be6948bdfb68df8433be71f5743a188968b0c1b887807e50"
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.2"
   url_launcher_web:
     dependency: transitive
     description:
@@ -2320,34 +2312,34 @@ packages:
     dependency: transitive
     description:
       name: uuid
-      sha256: df5a4d8f22ee4ccd77f8839ac7cb274ebc11ef9adcce8b92be14b797fe889921
+      sha256: cd210a09f7c18cbe5a02511718e0334de6559871052c90a90c0cca46a4aa81c8
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.1"
+    version: "4.3.3"
   vector_graphics:
     dependency: transitive
     description:
       name: vector_graphics
-      sha256: "670f6e07aca990b4a2bcdc08a784193c4ccdd1932620244c3a86bb72a0eac67f"
+      sha256: "32c3c684e02f9bc0afb0ae0aa653337a2fe022e8ab064bcd7ffda27a74e288e3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.7"
+    version: "1.1.11+1"
   vector_graphics_codec:
     dependency: transitive
     description:
       name: vector_graphics_codec
-      sha256: "7451721781d967db9933b63f5733b1c4533022c0ba373a01bdd79d1a5457f69f"
+      sha256: c86987475f162fadff579e7320c7ddda04cd2fdeffbe1129227a85d9ac9e03da
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.7"
+    version: "1.1.11+1"
   vector_graphics_compiler:
     dependency: transitive
     description:
       name: vector_graphics_compiler
-      sha256: "80a13c613c8bde758b1464a1755a7b3a8f2b6cec61fbf0f5a53c94c30f03ba2e"
+      sha256: "12faff3f73b1741a36ca7e31b292ddeb629af819ca9efe9953b70bd63fc8cd81"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.7"
+    version: "1.1.11+1"
   vector_math:
     dependency: transitive
     description:
@@ -2360,42 +2352,42 @@ packages:
     dependency: "direct main"
     description:
       name: video_player
-      sha256: d3910a8cefc0de8a432a4411dcf85030e885d8fef3ddea291f162253a05dbf01
+      sha256: fbf28ce8bcfe709ad91b5789166c832cb7a684d14f571a81891858fefb5bb1c2
       url: "https://pub.dev"
     source: hosted
-    version: "2.7.1"
+    version: "2.8.2"
   video_player_android:
     dependency: transitive
     description:
       name: video_player_android
-      sha256: "3fe89ab07fdbce786e7eb25b58532d6eaf189ceddc091cb66cba712f8d9e8e55"
+      sha256: "4dd9b8b86d70d65eecf3dcabfcdfbb9c9115d244d022654aba49a00336d540c2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.10"
+    version: "2.4.12"
   video_player_avfoundation:
     dependency: transitive
     description:
       name: video_player_avfoundation
-      sha256: c3b123a5a56c9812b9029f840c65b92fd65083eb08d69be016b01e8aa018f77d
+      sha256: "309e3962795e761be010869bae65c0b0e45b5230c5cee1bec72197ca7db040ed"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.10"
+    version: "2.5.6"
   video_player_platform_interface:
     dependency: transitive
     description:
       name: video_player_platform_interface
-      sha256: be72301bf2c0150ab35a8c34d66e5a99de525f6de1e8d27c0672b836fe48f73a
+      sha256: "236454725fafcacf98f0f39af0d7c7ab2ce84762e3b63f2cbb3ef9a7e0550bc6"
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.1"
+    version: "6.2.2"
   video_player_web:
     dependency: transitive
     description:
       name: video_player_web
-      sha256: "68bdd115389d68aea99466259b079a5ef3fa9ca7600ef12b616d8551fa1541a9"
+      sha256: "8e9cb7fe94e49490e67bbc15149691792b58a0ade31b32e3f3688d104a0e057b"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.18"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
@@ -2441,10 +2433,10 @@ packages:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: d88238e5eac9a42bb43ca4e721edba3c08c6354d4a53063afaa568516217621b
+      sha256: "1d8e795e2a8b3730c41b8a98a2dff2e0fb57ae6f0764a1c46ec5915387d257b2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.4"
   webdriver:
     dependency: transitive
     description:
@@ -2465,34 +2457,34 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: "9e82a402b7f3d518fb9c02d0e9ae45952df31b9bf34d77baf19da2de03fc2aaa"
+      sha256: "464f5674532865248444b4c3daca12bd9bf2d7c47f759ce2617986e7229494a8"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.7"
+    version: "5.2.0"
   win32_registry:
     dependency: transitive
     description:
       name: win32_registry
-      sha256: e4506d60b7244251bc59df15656a3093501c37fb5af02105a944d73eb95be4c9
+      sha256: "41fd8a189940d8696b1b810efb9abcf60827b6cbfab90b0c43e8439e3a39d85a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   xdg_directories:
     dependency: transitive
     description:
       name: xdg_directories
-      sha256: "589ada45ba9e39405c198fe34eb0f607cddb2108527e658136120892beac46d2"
+      sha256: faea9dee56b520b55a566385b84f2e8de55e7496104adada9962e0bd11bcff1d
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   xml:
     dependency: transitive
     description:
       name: xml
-      sha256: "5bc72e1e45e941d825fd7468b9b4cc3b9327942649aeb6fc5cdbf135f0a86e84"
+      sha256: b015a8ad1c488f66851d762d3090a21c600e479dc75e68328c52774040cf9226
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.0"
+    version: "6.5.0"
   yaml:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -207,8 +207,8 @@ dependency_overrides:
 
 dev_dependencies:
   async: ^2.4.1
-  built_collection: ^5.1.0
-  build_runner: ^2.4.7
+  built_collection: ^5.1.1
+  build_runner: ^2.4.8
   flutter_test:
     sdk: flutter
   golden_toolkit: ^0.15.0

--- a/app/test/course/course_create_bloc_test.mocks.dart
+++ b/app/test/course/course_create_bloc_test.mocks.dart
@@ -98,6 +98,7 @@ class MockCourseCreateGateway extends _i1.Mock
           Invocation.getter(#courseGateway),
         ),
       ) as _i2.CourseGateway);
+
   @override
   _i3.SchoolClassGateway get schoolClassGateway => (super.noSuchMethod(
         Invocation.getter(#schoolClassGateway),
@@ -110,6 +111,7 @@ class MockCourseCreateGateway extends _i1.Mock
           Invocation.getter(#schoolClassGateway),
         ),
       ) as _i3.SchoolClassGateway);
+
   @override
   _i4.UserGateway get userGateway => (super.noSuchMethod(
         Invocation.getter(#userGateway),
@@ -122,12 +124,14 @@ class MockCourseCreateGateway extends _i1.Mock
           Invocation.getter(#userGateway),
         ),
       ) as _i4.UserGateway);
+
   @override
   List<_i5.Course> get currentCourses => (super.noSuchMethod(
         Invocation.getter(#currentCourses),
         returnValue: <_i5.Course>[],
         returnValueForMissingStub: <_i5.Course>[],
       ) as List<_i5.Course>);
+
   @override
   _i5.Course createCourse(_i8.UserInput? userInput) => (super.noSuchMethod(
         Invocation.method(
@@ -149,6 +153,7 @@ class MockCourseCreateGateway extends _i1.Mock
           ),
         ),
       ) as _i5.Course);
+
   @override
   _i9.Future<_i6.AppFunctionsResult<bool>> createSchoolClassCourse(
     _i8.UserInput? userInput,

--- a/app/test/dashboard/update_reminder_test.mocks.dart
+++ b/app/test/dashboard/update_reminder_test.mocks.dart
@@ -139,6 +139,7 @@ class MockUpdateReminderBloc extends _i1.Mock
           Invocation.getter(#getLatestRelease),
         )),
       ) as _i9.Future<_i2.Release> Function());
+
   @override
   _i9.Future<_i3.Version> Function() get getCurrentVersion =>
       (super.noSuchMethod(
@@ -153,6 +154,7 @@ class MockUpdateReminderBloc extends _i1.Mock
           Invocation.getter(#getCurrentVersion),
         )),
       ) as _i9.Future<_i3.Version> Function());
+
   @override
   Duration get updateGracePeriod => (super.noSuchMethod(
         Invocation.getter(#updateGracePeriod),
@@ -165,6 +167,7 @@ class MockUpdateReminderBloc extends _i1.Mock
           Invocation.getter(#updateGracePeriod),
         ),
       ) as Duration);
+
   @override
   DateTime Function() get getCurrentDateTime => (super.noSuchMethod(
         Invocation.getter(#getCurrentDateTime),
@@ -177,6 +180,7 @@ class MockUpdateReminderBloc extends _i1.Mock
           Invocation.getter(#getCurrentDateTime),
         ),
       ) as DateTime Function());
+
   @override
   _i9.Future<bool> shouldRemindToUpdate() => (super.noSuchMethod(
         Invocation.method(
@@ -186,6 +190,7 @@ class MockUpdateReminderBloc extends _i1.Mock
         returnValue: _i9.Future<bool>.value(false),
         returnValueForMissingStub: _i9.Future<bool>.value(false),
       ) as _i9.Future<bool>);
+
   @override
   void dispose() => super.noSuchMethod(
         Invocation.method(
@@ -212,6 +217,7 @@ class MockHolidayBloc extends _i1.Mock implements _i5.HolidayBloc {
           Invocation.getter(#holidayManager),
         ),
       ) as _i4.HolidayService);
+
   @override
   set getCurrentTime(DateTime Function()? _getCurrentTime) =>
       super.noSuchMethod(
@@ -221,6 +227,7 @@ class MockHolidayBloc extends _i1.Mock implements _i5.HolidayBloc {
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   _i5.HolidayStateGateway get stateGateway => (super.noSuchMethod(
         Invocation.getter(#stateGateway),
@@ -233,24 +240,28 @@ class MockHolidayBloc extends _i1.Mock implements _i5.HolidayBloc {
           Invocation.getter(#stateGateway),
         ),
       ) as _i5.HolidayStateGateway);
+
   @override
   _i9.Stream<List<_i4.Holiday?>> get holidays => (super.noSuchMethod(
         Invocation.getter(#holidays),
         returnValue: _i9.Stream<List<_i4.Holiday?>>.empty(),
         returnValueForMissingStub: _i9.Stream<List<_i4.Holiday?>>.empty(),
       ) as _i9.Stream<List<_i4.Holiday?>>);
+
   @override
   _i9.Stream<_i10.StateEnum?> get userState => (super.noSuchMethod(
         Invocation.getter(#userState),
         returnValue: _i9.Stream<_i10.StateEnum?>.empty(),
         returnValueForMissingStub: _i9.Stream<_i10.StateEnum?>.empty(),
       ) as _i9.Stream<_i10.StateEnum?>);
+
   @override
   _i9.Stream<bool> get hasStateSelected => (super.noSuchMethod(
         Invocation.getter(#hasStateSelected),
         returnValue: _i9.Stream<bool>.empty(),
         returnValueForMissingStub: _i9.Stream<bool>.empty(),
       ) as _i9.Stream<bool>);
+
   @override
   _i9.Future<void> Function(_i10.StateEnum?) get changeState =>
       (super.noSuchMethod(
@@ -259,6 +270,7 @@ class MockHolidayBloc extends _i1.Mock implements _i5.HolidayBloc {
         returnValueForMissingStub: (_i10.StateEnum? state) =>
             _i9.Future<void>.value(),
       ) as _i9.Future<void> Function(_i10.StateEnum?));
+
   @override
   void dispose() => super.noSuchMethod(
         Invocation.method(
@@ -286,6 +298,7 @@ class MockDashboardTipSystem extends _i1.Mock
           Invocation.getter(#cache),
         ),
       ) as _i6.DashboardTipCache);
+
   @override
   _i7.NavigationBloc get navigationBloc => (super.noSuchMethod(
         Invocation.getter(#navigationBloc),
@@ -298,12 +311,14 @@ class MockDashboardTipSystem extends _i1.Mock
           Invocation.getter(#navigationBloc),
         ),
       ) as _i7.NavigationBloc);
+
   @override
   _i9.Stream<_i12.DashboardTip?> get dashboardTip => (super.noSuchMethod(
         Invocation.getter(#dashboardTip),
         returnValue: _i9.Stream<_i12.DashboardTip?>.empty(),
         returnValueForMissingStub: _i9.Stream<_i12.DashboardTip?>.empty(),
       ) as _i9.Stream<_i12.DashboardTip?>);
+
   @override
   void dispose() => super.noSuchMethod(
         Invocation.method(
@@ -330,6 +345,7 @@ class MockDashboardBloc extends _i1.Mock implements _i13.DashboardBloc {
           Invocation.getter(#todayDateTimeWithoutTime),
         ),
       ) as DateTime);
+
   @override
   _i9.Stream<List<_i14.HomeworkView>> get urgentHomeworks =>
       (super.noSuchMethod(
@@ -337,6 +353,7 @@ class MockDashboardBloc extends _i1.Mock implements _i13.DashboardBloc {
         returnValue: _i9.Stream<List<_i14.HomeworkView>>.empty(),
         returnValueForMissingStub: _i9.Stream<List<_i14.HomeworkView>>.empty(),
       ) as _i9.Stream<List<_i14.HomeworkView>>);
+
   @override
   _i9.Stream<List<_i15.BlackboardView>> get unreadBlackboardViews =>
       (super.noSuchMethod(
@@ -345,48 +362,56 @@ class MockDashboardBloc extends _i1.Mock implements _i13.DashboardBloc {
         returnValueForMissingStub:
             _i9.Stream<List<_i15.BlackboardView>>.empty(),
       ) as _i9.Stream<List<_i15.BlackboardView>>);
+
   @override
   _i9.Stream<bool> get urgentHomeworksEmpty => (super.noSuchMethod(
         Invocation.getter(#urgentHomeworksEmpty),
         returnValue: _i9.Stream<bool>.empty(),
         returnValueForMissingStub: _i9.Stream<bool>.empty(),
       ) as _i9.Stream<bool>);
+
   @override
   _i9.Stream<List<_i16.EventView>> get upcomingEvents => (super.noSuchMethod(
         Invocation.getter(#upcomingEvents),
         returnValue: _i9.Stream<List<_i16.EventView>>.empty(),
         returnValueForMissingStub: _i9.Stream<List<_i16.EventView>>.empty(),
       ) as _i9.Stream<List<_i16.EventView>>);
+
   @override
   _i9.Stream<int> get numberOfUrgentHomeworks => (super.noSuchMethod(
         Invocation.getter(#numberOfUrgentHomeworks),
         returnValue: _i9.Stream<int>.empty(),
         returnValueForMissingStub: _i9.Stream<int>.empty(),
       ) as _i9.Stream<int>);
+
   @override
   _i9.Stream<List<_i17.LessonView>> get lessonViews => (super.noSuchMethod(
         Invocation.getter(#lessonViews),
         returnValue: _i9.Stream<List<_i17.LessonView>>.empty(),
         returnValueForMissingStub: _i9.Stream<List<_i17.LessonView>>.empty(),
       ) as _i9.Stream<List<_i17.LessonView>>);
+
   @override
   _i9.Stream<int> get numberOfUnreadBlackboardViews => (super.noSuchMethod(
         Invocation.getter(#numberOfUnreadBlackboardViews),
         returnValue: _i9.Stream<int>.empty(),
         returnValueForMissingStub: _i9.Stream<int>.empty(),
       ) as _i9.Stream<int>);
+
   @override
   _i9.Stream<bool> get unreadBlackboardViewsEmpty => (super.noSuchMethod(
         Invocation.getter(#unreadBlackboardViewsEmpty),
         returnValue: _i9.Stream<bool>.empty(),
         returnValueForMissingStub: _i9.Stream<bool>.empty(),
       ) as _i9.Stream<bool>);
+
   @override
   _i9.Stream<int> get numberOfUpcomingEvents => (super.noSuchMethod(
         Invocation.getter(#numberOfUpcomingEvents),
         returnValue: _i9.Stream<int>.empty(),
         returnValueForMissingStub: _i9.Stream<int>.empty(),
       ) as _i9.Stream<int>);
+
   @override
   void dispose() => super.noSuchMethod(
         Invocation.method(

--- a/app/test/groups/group_join_select_courses_bloc_test.mocks.dart
+++ b/app/test/groups/group_join_select_courses_bloc_test.mocks.dart
@@ -91,6 +91,7 @@ class MockConnectionsGateway extends _i1.Mock
           Invocation.getter(#joinedCoursesPackage),
         ),
       ) as _i2.DataCollectionPackage<_i4.Course>);
+
   @override
   set joinedCoursesPackage(
           _i2.DataCollectionPackage<_i4.Course>? _joinedCoursesPackage) =>
@@ -101,12 +102,14 @@ class MockConnectionsGateway extends _i1.Mock
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   List<_i4.Course> get newJoinedCourses => (super.noSuchMethod(
         Invocation.getter(#newJoinedCourses),
         returnValue: <_i4.Course>[],
         returnValueForMissingStub: <_i4.Course>[],
       ) as List<_i4.Course>);
+
   @override
   set newJoinedCourses(List<_i4.Course>? _newJoinedCourses) =>
       super.noSuchMethod(
@@ -116,6 +119,7 @@ class MockConnectionsGateway extends _i1.Mock
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   _i3.References get references => (super.noSuchMethod(
         Invocation.getter(#references),
@@ -128,6 +132,7 @@ class MockConnectionsGateway extends _i1.Mock
           Invocation.getter(#references),
         ),
       ) as _i3.References);
+
   @override
   String get memberID => (super.noSuchMethod(
         Invocation.getter(#memberID),
@@ -140,6 +145,7 @@ class MockConnectionsGateway extends _i1.Mock
           Invocation.getter(#memberID),
         ),
       ) as String);
+
   @override
   _i8.Stream<_i4.ConnectionsData?> streamConnectionsData() =>
       (super.noSuchMethod(
@@ -150,6 +156,7 @@ class MockConnectionsGateway extends _i1.Mock
         returnValue: _i8.Stream<_i4.ConnectionsData?>.empty(),
         returnValueForMissingStub: _i8.Stream<_i4.ConnectionsData?>.empty(),
       ) as _i8.Stream<_i4.ConnectionsData?>);
+
   @override
   _i8.Future<_i4.ConnectionsData> get() => (super.noSuchMethod(
         Invocation.method(
@@ -173,6 +180,7 @@ class MockConnectionsGateway extends _i1.Mock
           ),
         )),
       ) as _i8.Future<_i4.ConnectionsData>);
+
   @override
   _i8.Future<_i5.AppFunctionsResult<dynamic>> joinByKey({
     required String? publicKey,
@@ -217,6 +225,7 @@ class MockConnectionsGateway extends _i1.Mock
           ),
         )),
       ) as _i8.Future<_i5.AppFunctionsResult<dynamic>>);
+
   @override
   _i8.Future<_i5.AppFunctionsResult<dynamic>> joinByJoinLink(
           {required String? joinLink}) =>
@@ -246,6 +255,7 @@ class MockConnectionsGateway extends _i1.Mock
           ),
         )),
       ) as _i8.Future<_i5.AppFunctionsResult<dynamic>>);
+
   @override
   _i8.Future<void> addConnectionCreate({
     required String? id,
@@ -265,6 +275,7 @@ class MockConnectionsGateway extends _i1.Mock
         returnValue: _i8.Future<void>.value(),
         returnValueForMissingStub: _i8.Future<void>.value(),
       ) as _i8.Future<void>);
+
   @override
   _i8.Future<void> addCoursePersonalDesign({
     required String? id,
@@ -284,6 +295,7 @@ class MockConnectionsGateway extends _i1.Mock
         returnValue: _i8.Future<void>.value(),
         returnValueForMissingStub: _i8.Future<void>.value(),
       ) as _i8.Future<void>);
+
   @override
   _i8.Future<void> removeCoursePersonalDesign({
     required String? courseID,
@@ -301,6 +313,7 @@ class MockConnectionsGateway extends _i1.Mock
         returnValue: _i8.Future<void>.value(),
         returnValueForMissingStub: _i8.Future<void>.value(),
       ) as _i8.Future<void>);
+
   @override
   _i8.Future<_i5.AppFunctionsResult<bool>> joinWithId({
     required String? id,
@@ -341,6 +354,7 @@ class MockConnectionsGateway extends _i1.Mock
           ),
         )),
       ) as _i8.Future<_i5.AppFunctionsResult<bool>>);
+
   @override
   _i8.Future<_i5.AppFunctionsResult<bool>> leave({
     required String? id,
@@ -381,6 +395,7 @@ class MockConnectionsGateway extends _i1.Mock
           ),
         )),
       ) as _i8.Future<_i5.AppFunctionsResult<bool>>);
+
   @override
   _i8.Future<_i5.AppFunctionsResult<bool>> delete({
     required String? id,
@@ -425,6 +440,7 @@ class MockConnectionsGateway extends _i1.Mock
           ),
         )),
       ) as _i8.Future<_i5.AppFunctionsResult<bool>>);
+
   @override
   _i8.Future<void> dispose() => (super.noSuchMethod(
         Invocation.method(
@@ -448,6 +464,7 @@ class MockCrashAnalytics extends _i1.Mock implements _i10.CrashAnalytics {
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   void crash() => super.noSuchMethod(
         Invocation.method(
@@ -456,6 +473,7 @@ class MockCrashAnalytics extends _i1.Mock implements _i10.CrashAnalytics {
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   _i8.Future<void> recordFlutterError(_i11.FlutterErrorDetails? details) =>
       (super.noSuchMethod(
@@ -466,6 +484,7 @@ class MockCrashAnalytics extends _i1.Mock implements _i10.CrashAnalytics {
         returnValue: _i8.Future<void>.value(),
         returnValueForMissingStub: _i8.Future<void>.value(),
       ) as _i8.Future<void>);
+
   @override
   _i8.Future<void> recordError(
     dynamic exception,
@@ -484,6 +503,7 @@ class MockCrashAnalytics extends _i1.Mock implements _i10.CrashAnalytics {
         returnValue: _i8.Future<void>.value(),
         returnValueForMissingStub: _i8.Future<void>.value(),
       ) as _i8.Future<void>);
+
   @override
   void log(String? msg) => super.noSuchMethod(
         Invocation.method(
@@ -492,6 +512,7 @@ class MockCrashAnalytics extends _i1.Mock implements _i10.CrashAnalytics {
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   _i8.Future<void> setCustomKey(
     String? key,
@@ -508,6 +529,7 @@ class MockCrashAnalytics extends _i1.Mock implements _i10.CrashAnalytics {
         returnValue: _i8.Future<void>.value(),
         returnValueForMissingStub: _i8.Future<void>.value(),
       ) as _i8.Future<void>);
+
   @override
   _i8.Future<void> setUserIdentifier(String? identifier) => (super.noSuchMethod(
         Invocation.method(
@@ -517,6 +539,7 @@ class MockCrashAnalytics extends _i1.Mock implements _i10.CrashAnalytics {
         returnValue: _i8.Future<void>.value(),
         returnValueForMissingStub: _i8.Future<void>.value(),
       ) as _i8.Future<void>);
+
   @override
   _i8.Future<void> setCrashAnalyticsEnabled(bool? enabled) =>
       (super.noSuchMethod(

--- a/app/test/holidays/holiday_bloc_unit_test.mocks.dart
+++ b/app/test/holidays/holiday_bloc_unit_test.mocks.dart
@@ -82,12 +82,14 @@ class MockHolidayApi extends _i1.Mock implements _i2.HolidayApi {
           Invocation.getter(#apiClient),
         ),
       ) as _i2.HolidayApiClient);
+
   @override
   bool get returnPassedHolidays => (super.noSuchMethod(
         Invocation.getter(#returnPassedHolidays),
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
+
   @override
   DateTime Function() get getCurrentTime => (super.noSuchMethod(
         Invocation.getter(#getCurrentTime),
@@ -100,6 +102,7 @@ class MockHolidayApi extends _i1.Mock implements _i2.HolidayApi {
           Invocation.getter(#getCurrentTime),
         ),
       ) as DateTime Function());
+
   @override
   set getCurrentTime(DateTime Function()? _getCurrentTime) =>
       super.noSuchMethod(
@@ -109,6 +112,7 @@ class MockHolidayApi extends _i1.Mock implements _i2.HolidayApi {
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   _i4.Future<List<_i5.Holiday>> load(
     int? yearsInAdvance,
@@ -128,6 +132,7 @@ class MockHolidayApi extends _i1.Mock implements _i2.HolidayApi {
         returnValueForMissingStub:
             _i4.Future<List<_i5.Holiday>>.value(<_i5.Holiday>[]),
       ) as _i4.Future<List<_i5.Holiday>>);
+
   @override
   void removePassedHolidays(List<_i5.Holiday>? holidayList) =>
       super.noSuchMethod(
@@ -155,6 +160,7 @@ class MockHolidayCache extends _i1.Mock implements _i7.HolidayCache {
           Invocation.getter(#cache),
         ),
       ) as _i3.KeyValueStore);
+
   @override
   Duration get maxValidDurationTillLastSaved => (super.noSuchMethod(
         Invocation.getter(#maxValidDurationTillLastSaved),
@@ -167,6 +173,7 @@ class MockHolidayCache extends _i1.Mock implements _i7.HolidayCache {
           Invocation.getter(#maxValidDurationTillLastSaved),
         ),
       ) as Duration);
+
   @override
   set getCurrentTime(_i7.SavingDateTimeFunction? _getCurrentTime) =>
       super.noSuchMethod(
@@ -176,6 +183,7 @@ class MockHolidayCache extends _i1.Mock implements _i7.HolidayCache {
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   _i7.CacheResponse? load(_i6.State? state) => (super.noSuchMethod(
         Invocation.method(
@@ -184,6 +192,7 @@ class MockHolidayCache extends _i1.Mock implements _i7.HolidayCache {
         ),
         returnValueForMissingStub: null,
       ) as _i7.CacheResponse?);
+
   @override
   List<_i5.Holiday> removePassedHolidays(List<_i5.Holiday>? holidays) =>
       (super.noSuchMethod(
@@ -194,6 +203,7 @@ class MockHolidayCache extends _i1.Mock implements _i7.HolidayCache {
         returnValue: <_i5.Holiday>[],
         returnValueForMissingStub: <_i5.Holiday>[],
       ) as List<_i5.Holiday>);
+
   @override
   _i4.Future<void> save(
     List<_i5.Holiday?>? holidays,
@@ -210,6 +220,7 @@ class MockHolidayCache extends _i1.Mock implements _i7.HolidayCache {
         returnValue: _i4.Future<void>.value(),
         returnValueForMissingStub: _i4.Future<void>.value(),
       ) as _i4.Future<void>);
+
   @override
   bool isCacheDataValid(
     _i5.HolidayCacheData? cacheData,

--- a/app/test/holidays/integration_test.mocks.dart
+++ b/app/test/holidays/integration_test.mocks.dart
@@ -86,6 +86,7 @@ class MockSharezoneAppFunctions extends _i1.Mock
           ),
         )),
       ) as _i4.Future<_i2.AppFunctionsResult<dynamic>>);
+
   @override
   _i4.Future<_i2.AppFunctionsResult<dynamic>> enterActivationCode(
           {required String? enteredActivationCode}) =>
@@ -115,6 +116,7 @@ class MockSharezoneAppFunctions extends _i1.Mock
           ),
         )),
       ) as _i4.Future<_i2.AppFunctionsResult<dynamic>>);
+
   @override
   _i4.Future<_i2.AppFunctionsResult<bool>> joinWithGroupId({
     required String? id,
@@ -159,6 +161,7 @@ class MockSharezoneAppFunctions extends _i1.Mock
           ),
         )),
       ) as _i4.Future<_i2.AppFunctionsResult<bool>>);
+
   @override
   _i4.Future<_i2.AppFunctionsResult<bool>> leave({
     required String? id,
@@ -203,6 +206,7 @@ class MockSharezoneAppFunctions extends _i1.Mock
           ),
         )),
       ) as _i4.Future<_i2.AppFunctionsResult<bool>>);
+
   @override
   _i4.Future<_i2.AppFunctionsResult<bool>> groupEdit({
     required String? id,
@@ -247,6 +251,7 @@ class MockSharezoneAppFunctions extends _i1.Mock
           ),
         )),
       ) as _i4.Future<_i2.AppFunctionsResult<bool>>);
+
   @override
   _i4.Future<_i2.AppFunctionsResult<bool>> groupEditSettings({
     required String? id,
@@ -291,6 +296,7 @@ class MockSharezoneAppFunctions extends _i1.Mock
           ),
         )),
       ) as _i4.Future<_i2.AppFunctionsResult<bool>>);
+
   @override
   _i4.Future<_i2.AppFunctionsResult<bool>> groupDelete({
     required String? groupID,
@@ -335,6 +341,7 @@ class MockSharezoneAppFunctions extends _i1.Mock
           ),
         )),
       ) as _i4.Future<_i2.AppFunctionsResult<bool>>);
+
   @override
   _i4.Future<_i2.AppFunctionsResult<bool>> groupCreate({
     required String? id,
@@ -383,6 +390,7 @@ class MockSharezoneAppFunctions extends _i1.Mock
           ),
         )),
       ) as _i4.Future<_i2.AppFunctionsResult<bool>>);
+
   @override
   _i4.Future<_i2.AppFunctionsResult<bool>> userUpdate({
     required String? userID,
@@ -423,6 +431,7 @@ class MockSharezoneAppFunctions extends _i1.Mock
           ),
         )),
       ) as _i4.Future<_i2.AppFunctionsResult<bool>>);
+
   @override
   _i4.Future<_i2.AppFunctionsResult<bool>> memberUpdateRole({
     required String? memberID,
@@ -471,6 +480,7 @@ class MockSharezoneAppFunctions extends _i1.Mock
           ),
         )),
       ) as _i4.Future<_i2.AppFunctionsResult<bool>>);
+
   @override
   _i4.Future<_i2.AppFunctionsResult<bool>> userDelete(
           {required String? userID}) =>
@@ -500,6 +510,7 @@ class MockSharezoneAppFunctions extends _i1.Mock
           ),
         )),
       ) as _i4.Future<_i2.AppFunctionsResult<bool>>);
+
   @override
   _i4.Future<_i2.AppFunctionsResult<bool>> schoolClassAddCourse({
     required String? schoolClassID,
@@ -540,6 +551,7 @@ class MockSharezoneAppFunctions extends _i1.Mock
           ),
         )),
       ) as _i4.Future<_i2.AppFunctionsResult<bool>>);
+
   @override
   _i4.Future<_i2.AppFunctionsResult<bool>> schoolClassRemoveCourse({
     required String? schoolClassID,
@@ -580,6 +592,7 @@ class MockSharezoneAppFunctions extends _i1.Mock
           ),
         )),
       ) as _i4.Future<_i2.AppFunctionsResult<bool>>);
+
   @override
   _i4.Future<_i2.AppFunctionsResult<bool>> authenticateUserViaQrCodeId({
     required String? uid,
@@ -620,6 +633,7 @@ class MockSharezoneAppFunctions extends _i1.Mock
           ),
         )),
       ) as _i4.Future<_i2.AppFunctionsResult<bool>>);
+
   @override
   _i4.Future<_i2.AppFunctionsResult<Map<String, dynamic>>> loadHolidays({
     required String? stateCode,

--- a/app/test/homework/homework_dialog_test.mocks.dart
+++ b/app/test/homework/homework_dialog_test.mocks.dart
@@ -326,6 +326,7 @@ class MockDocumentReference<T extends Object?> extends _i1.Mock
           Invocation.getter(#firestore),
         ),
       ) as _i2.FirebaseFirestore);
+
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
@@ -338,6 +339,7 @@ class MockDocumentReference<T extends Object?> extends _i1.Mock
           Invocation.getter(#id),
         ),
       ) as String);
+
   @override
   _i2.CollectionReference<T> get parent => (super.noSuchMethod(
         Invocation.getter(#parent),
@@ -350,6 +352,7 @@ class MockDocumentReference<T extends Object?> extends _i1.Mock
           Invocation.getter(#parent),
         ),
       ) as _i2.CollectionReference<T>);
+
   @override
   String get path => (super.noSuchMethod(
         Invocation.getter(#path),
@@ -362,6 +365,7 @@ class MockDocumentReference<T extends Object?> extends _i1.Mock
           Invocation.getter(#path),
         ),
       ) as String);
+
   @override
   _i2.CollectionReference<Map<String, dynamic>> collection(
           String? collectionPath) =>
@@ -386,6 +390,7 @@ class MockDocumentReference<T extends Object?> extends _i1.Mock
           ),
         ),
       ) as _i2.CollectionReference<Map<String, dynamic>>);
+
   @override
   _i24.Future<void> delete() => (super.noSuchMethod(
         Invocation.method(
@@ -395,6 +400,7 @@ class MockDocumentReference<T extends Object?> extends _i1.Mock
         returnValue: _i24.Future<void>.value(),
         returnValueForMissingStub: _i24.Future<void>.value(),
       ) as _i24.Future<void>);
+
   @override
   _i24.Future<void> update(Map<Object, Object?>? data) => (super.noSuchMethod(
         Invocation.method(
@@ -404,6 +410,7 @@ class MockDocumentReference<T extends Object?> extends _i1.Mock
         returnValue: _i24.Future<void>.value(),
         returnValueForMissingStub: _i24.Future<void>.value(),
       ) as _i24.Future<void>);
+
   @override
   _i24.Future<_i2.DocumentSnapshot<T>> get([_i25.GetOptions? options]) =>
       (super.noSuchMethod(
@@ -428,6 +435,7 @@ class MockDocumentReference<T extends Object?> extends _i1.Mock
           ),
         )),
       ) as _i24.Future<_i2.DocumentSnapshot<T>>);
+
   @override
   _i24.Stream<_i2.DocumentSnapshot<T>> snapshots(
           {bool? includeMetadataChanges = false}) =>
@@ -440,6 +448,7 @@ class MockDocumentReference<T extends Object?> extends _i1.Mock
         returnValue: _i24.Stream<_i2.DocumentSnapshot<T>>.empty(),
         returnValueForMissingStub: _i24.Stream<_i2.DocumentSnapshot<T>>.empty(),
       ) as _i24.Stream<_i2.DocumentSnapshot<T>>);
+
   @override
   _i24.Future<void> set(
     T? data, [
@@ -456,6 +465,7 @@ class MockDocumentReference<T extends Object?> extends _i1.Mock
         returnValue: _i24.Future<void>.value(),
         returnValueForMissingStub: _i24.Future<void>.value(),
       ) as _i24.Future<void>);
+
   @override
   _i2.DocumentReference<R> withConverter<R>({
     required _i2.FromFirestore<R>? fromFirestore,
@@ -511,6 +521,7 @@ class MockSharezoneContext extends _i1.Mock implements _i26.SharezoneContext {
           Invocation.getter(#api),
         ),
       ) as _i3.SharezoneGateway);
+
   @override
   _i4.Analytics get analytics => (super.noSuchMethod(
         Invocation.getter(#analytics),
@@ -523,6 +534,7 @@ class MockSharezoneContext extends _i1.Mock implements _i26.SharezoneContext {
           Invocation.getter(#analytics),
         ),
       ) as _i4.Analytics);
+
   @override
   _i5.StreamingSharedPreferences get streamingSharedPreferences =>
       (super.noSuchMethod(
@@ -536,6 +548,7 @@ class MockSharezoneContext extends _i1.Mock implements _i26.SharezoneContext {
           Invocation.getter(#streamingSharedPreferences),
         ),
       ) as _i5.StreamingSharedPreferences);
+
   @override
   _i6.SharedPreferences get sharedPreferences => (super.noSuchMethod(
         Invocation.getter(#sharedPreferences),
@@ -548,6 +561,7 @@ class MockSharezoneContext extends _i1.Mock implements _i26.SharezoneContext {
           Invocation.getter(#sharedPreferences),
         ),
       ) as _i6.SharedPreferences);
+
   @override
   _i7.NavigationService get navigationService => (super.noSuchMethod(
         Invocation.getter(#navigationService),
@@ -560,6 +574,7 @@ class MockSharezoneContext extends _i1.Mock implements _i26.SharezoneContext {
           Invocation.getter(#navigationService),
         ),
       ) as _i7.NavigationService);
+
   @override
   void dispose() => super.noSuchMethod(
         Invocation.method(
@@ -586,6 +601,7 @@ class MockSharezoneGateway extends _i1.Mock implements _i3.SharezoneGateway {
           Invocation.getter(#uID),
         ),
       ) as String);
+
   @override
   _i8.UserId get userId => (super.noSuchMethod(
         Invocation.getter(#userId),
@@ -598,6 +614,7 @@ class MockSharezoneGateway extends _i1.Mock implements _i3.SharezoneGateway {
           Invocation.getter(#userId),
         ),
       ) as _i8.UserId);
+
   @override
   _i9.HomeworkGateway get homework => (super.noSuchMethod(
         Invocation.getter(#homework),
@@ -610,6 +627,7 @@ class MockSharezoneGateway extends _i1.Mock implements _i3.SharezoneGateway {
           Invocation.getter(#homework),
         ),
       ) as _i9.HomeworkGateway);
+
   @override
   _i10.BlackboardGateway get blackboard => (super.noSuchMethod(
         Invocation.getter(#blackboard),
@@ -622,6 +640,7 @@ class MockSharezoneGateway extends _i1.Mock implements _i3.SharezoneGateway {
           Invocation.getter(#blackboard),
         ),
       ) as _i10.BlackboardGateway);
+
   @override
   _i11.FileSharingGateway get fileSharing => (super.noSuchMethod(
         Invocation.getter(#fileSharing),
@@ -634,6 +653,7 @@ class MockSharezoneGateway extends _i1.Mock implements _i3.SharezoneGateway {
           Invocation.getter(#fileSharing),
         ),
       ) as _i11.FileSharingGateway);
+
   @override
   _i12.UserGateway get user => (super.noSuchMethod(
         Invocation.getter(#user),
@@ -646,6 +666,7 @@ class MockSharezoneGateway extends _i1.Mock implements _i3.SharezoneGateway {
           Invocation.getter(#user),
         ),
       ) as _i12.UserGateway);
+
   @override
   _i13.References get references => (super.noSuchMethod(
         Invocation.getter(#references),
@@ -658,6 +679,7 @@ class MockSharezoneGateway extends _i1.Mock implements _i3.SharezoneGateway {
           Invocation.getter(#references),
         ),
       ) as _i13.References);
+
   @override
   String get memberID => (super.noSuchMethod(
         Invocation.getter(#memberID),
@@ -670,6 +692,7 @@ class MockSharezoneGateway extends _i1.Mock implements _i3.SharezoneGateway {
           Invocation.getter(#memberID),
         ),
       ) as String);
+
   @override
   _i14.ConnectionsGateway get connectionsGateway => (super.noSuchMethod(
         Invocation.getter(#connectionsGateway),
@@ -682,6 +705,7 @@ class MockSharezoneGateway extends _i1.Mock implements _i3.SharezoneGateway {
           Invocation.getter(#connectionsGateway),
         ),
       ) as _i14.ConnectionsGateway);
+
   @override
   _i15.CourseGateway get course => (super.noSuchMethod(
         Invocation.getter(#course),
@@ -694,6 +718,7 @@ class MockSharezoneGateway extends _i1.Mock implements _i3.SharezoneGateway {
           Invocation.getter(#course),
         ),
       ) as _i15.CourseGateway);
+
   @override
   _i16.SchoolClassGateway get schoolClassGateway => (super.noSuchMethod(
         Invocation.getter(#schoolClassGateway),
@@ -706,6 +731,7 @@ class MockSharezoneGateway extends _i1.Mock implements _i3.SharezoneGateway {
           Invocation.getter(#schoolClassGateway),
         ),
       ) as _i16.SchoolClassGateway);
+
   @override
   _i17.TimetableGateway get timetable => (super.noSuchMethod(
         Invocation.getter(#timetable),
@@ -718,6 +744,7 @@ class MockSharezoneGateway extends _i1.Mock implements _i3.SharezoneGateway {
           Invocation.getter(#timetable),
         ),
       ) as _i17.TimetableGateway);
+
   @override
   _i24.Future<void> dispose() => (super.noSuchMethod(
         Invocation.method(
@@ -745,6 +772,7 @@ class MockUserGateway extends _i1.Mock implements _i12.UserGateway {
           Invocation.getter(#references),
         ),
       ) as _i13.References);
+
   @override
   String get uID => (super.noSuchMethod(
         Invocation.getter(#uID),
@@ -757,24 +785,28 @@ class MockUserGateway extends _i1.Mock implements _i12.UserGateway {
           Invocation.getter(#uID),
         ),
       ) as String);
+
   @override
   _i24.Stream<_i18.AppUser?> get userStream => (super.noSuchMethod(
         Invocation.getter(#userStream),
         returnValue: _i24.Stream<_i18.AppUser?>.empty(),
         returnValueForMissingStub: _i24.Stream<_i18.AppUser?>.empty(),
       ) as _i24.Stream<_i18.AppUser?>);
+
   @override
   _i24.Stream<_i27.AuthUser?> get authUserStream => (super.noSuchMethod(
         Invocation.getter(#authUserStream),
         returnValue: _i24.Stream<_i27.AuthUser?>.empty(),
         returnValueForMissingStub: _i24.Stream<_i27.AuthUser?>.empty(),
       ) as _i24.Stream<_i27.AuthUser?>);
+
   @override
   _i24.Stream<bool> get isSignedInStream => (super.noSuchMethod(
         Invocation.getter(#isSignedInStream),
         returnValue: _i24.Stream<bool>.empty(),
         returnValueForMissingStub: _i24.Stream<bool>.empty(),
       ) as _i24.Stream<bool>);
+
   @override
   _i24.Stream<_i2.DocumentSnapshot<Object?>> get userDocument =>
       (super.noSuchMethod(
@@ -783,12 +815,14 @@ class MockUserGateway extends _i1.Mock implements _i12.UserGateway {
         returnValueForMissingStub:
             _i24.Stream<_i2.DocumentSnapshot<Object?>>.empty(),
       ) as _i24.Stream<_i2.DocumentSnapshot<Object?>>);
+
   @override
   _i24.Stream<_i27.Provider?> get providerStream => (super.noSuchMethod(
         Invocation.getter(#providerStream),
         returnValue: _i24.Stream<_i27.Provider?>.empty(),
         returnValueForMissingStub: _i24.Stream<_i27.Provider?>.empty(),
       ) as _i24.Stream<_i27.Provider?>);
+
   @override
   _i24.Future<_i18.AppUser> get() => (super.noSuchMethod(
         Invocation.method(
@@ -811,6 +845,7 @@ class MockUserGateway extends _i1.Mock implements _i12.UserGateway {
           ),
         )),
       ) as _i24.Future<_i18.AppUser>);
+
   @override
   _i24.Future<void> logOut() => (super.noSuchMethod(
         Invocation.method(
@@ -820,6 +855,7 @@ class MockUserGateway extends _i1.Mock implements _i12.UserGateway {
         returnValue: _i24.Future<void>.value(),
         returnValueForMissingStub: _i24.Future<void>.value(),
       ) as _i24.Future<void>);
+
   @override
   bool isAnonymous() => (super.noSuchMethod(
         Invocation.method(
@@ -829,6 +865,7 @@ class MockUserGateway extends _i1.Mock implements _i12.UserGateway {
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
+
   @override
   _i24.Stream<bool?> isAnonymousStream() => (super.noSuchMethod(
         Invocation.method(
@@ -838,6 +875,7 @@ class MockUserGateway extends _i1.Mock implements _i12.UserGateway {
         returnValue: _i24.Stream<bool?>.empty(),
         returnValueForMissingStub: _i24.Stream<bool?>.empty(),
       ) as _i24.Stream<bool?>);
+
   @override
   _i24.Future<void> linkWithCredential(_i28.AuthCredential? credential) =>
       (super.noSuchMethod(
@@ -848,6 +886,7 @@ class MockUserGateway extends _i1.Mock implements _i12.UserGateway {
         returnValue: _i24.Future<void>.value(),
         returnValueForMissingStub: _i24.Future<void>.value(),
       ) as _i24.Future<void>);
+
   @override
   _i24.Future<void> changeState(_i18.StateEnum? state) => (super.noSuchMethod(
         Invocation.method(
@@ -857,6 +896,7 @@ class MockUserGateway extends _i1.Mock implements _i12.UserGateway {
         returnValue: _i24.Future<void>.value(),
         returnValueForMissingStub: _i24.Future<void>.value(),
       ) as _i24.Future<void>);
+
   @override
   _i24.Future<void> addNotificationToken(String? token) => (super.noSuchMethod(
         Invocation.method(
@@ -866,6 +906,7 @@ class MockUserGateway extends _i1.Mock implements _i12.UserGateway {
         returnValue: _i24.Future<void>.value(),
         returnValueForMissingStub: _i24.Future<void>.value(),
       ) as _i24.Future<void>);
+
   @override
   void removeNotificationToken(String? token) => super.noSuchMethod(
         Invocation.method(
@@ -874,6 +915,7 @@ class MockUserGateway extends _i1.Mock implements _i12.UserGateway {
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   _i24.Future<void> setHomeworkReminderTime(_i29.TimeOfDay? timeOfDay) =>
       (super.noSuchMethod(
@@ -884,6 +926,7 @@ class MockUserGateway extends _i1.Mock implements _i12.UserGateway {
         returnValue: _i24.Future<void>.value(),
         returnValueForMissingStub: _i24.Future<void>.value(),
       ) as _i24.Future<void>);
+
   @override
   _i24.Future<void> updateSettings(_i18.UserSettings? userSettings) =>
       (super.noSuchMethod(
@@ -894,6 +937,7 @@ class MockUserGateway extends _i1.Mock implements _i12.UserGateway {
         returnValue: _i24.Future<void>.value(),
         returnValueForMissingStub: _i24.Future<void>.value(),
       ) as _i24.Future<void>);
+
   @override
   _i24.Future<void> updateSettingsSingleFiled(
     String? fieldName,
@@ -910,6 +954,7 @@ class MockUserGateway extends _i1.Mock implements _i12.UserGateway {
         returnValue: _i24.Future<void>.value(),
         returnValueForMissingStub: _i24.Future<void>.value(),
       ) as _i24.Future<void>);
+
   @override
   _i24.Future<void> updateUserTip(
     _i18.UserTipKey? userTipKey,
@@ -926,6 +971,7 @@ class MockUserGateway extends _i1.Mock implements _i12.UserGateway {
         returnValue: _i24.Future<void>.value(),
         returnValueForMissingStub: _i24.Future<void>.value(),
       ) as _i24.Future<void>);
+
   @override
   void setBlackboardNotifications(bool? enabled) => super.noSuchMethod(
         Invocation.method(
@@ -934,6 +980,7 @@ class MockUserGateway extends _i1.Mock implements _i12.UserGateway {
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   void setCommentsNotifications(bool? enabled) => super.noSuchMethod(
         Invocation.method(
@@ -942,6 +989,7 @@ class MockUserGateway extends _i1.Mock implements _i12.UserGateway {
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   _i24.Future<void> changeEmail(String? email) => (super.noSuchMethod(
         Invocation.method(
@@ -951,6 +999,7 @@ class MockUserGateway extends _i1.Mock implements _i12.UserGateway {
         returnValue: _i24.Future<void>.value(),
         returnValueForMissingStub: _i24.Future<void>.value(),
       ) as _i24.Future<void>);
+
   @override
   _i24.Future<void> addUser({
     required _i18.AppUser? user,
@@ -968,6 +1017,7 @@ class MockUserGateway extends _i1.Mock implements _i12.UserGateway {
         returnValue: _i24.Future<void>.value(),
         returnValueForMissingStub: _i24.Future<void>.value(),
       ) as _i24.Future<void>);
+
   @override
   _i24.Future<bool> deleteUser(_i3.SharezoneGateway? gateway) =>
       (super.noSuchMethod(
@@ -978,6 +1028,7 @@ class MockUserGateway extends _i1.Mock implements _i12.UserGateway {
         returnValue: _i24.Future<bool>.value(false),
         returnValueForMissingStub: _i24.Future<bool>.value(false),
       ) as _i24.Future<bool>);
+
   @override
   _i24.Future<_i19.AppFunctionsResult<bool>> updateUser(
           _i18.AppUser? userData) =>
@@ -1004,6 +1055,7 @@ class MockUserGateway extends _i1.Mock implements _i12.UserGateway {
           ),
         )),
       ) as _i24.Future<_i19.AppFunctionsResult<bool>>);
+
   @override
   _i24.Future<void> dispose() => (super.noSuchMethod(
         Invocation.method(
@@ -1031,6 +1083,7 @@ class MockHomeworkGateway extends _i1.Mock implements _i9.HomeworkGateway {
           Invocation.getter(#userId),
         ),
       ) as String);
+
   @override
   _i2.CollectionReference<Map<String, dynamic>> get homeworkCollection =>
       (super.noSuchMethod(
@@ -1045,12 +1098,14 @@ class MockHomeworkGateway extends _i1.Mock implements _i9.HomeworkGateway {
           Invocation.getter(#homeworkCollection),
         ),
       ) as _i2.CollectionReference<Map<String, dynamic>>);
+
   @override
   _i24.Stream<_i18.TypeOfUser?> get typeOfUserStream => (super.noSuchMethod(
         Invocation.getter(#typeOfUserStream),
         returnValue: _i24.Stream<_i18.TypeOfUser?>.empty(),
         returnValueForMissingStub: _i24.Stream<_i18.TypeOfUser?>.empty(),
       ) as _i24.Stream<_i18.TypeOfUser?>);
+
   @override
   _i24.Stream<List<_i20.HomeworkDto>> get homeworkForNowAndInFutureStream =>
       (super.noSuchMethod(
@@ -1058,12 +1113,14 @@ class MockHomeworkGateway extends _i1.Mock implements _i9.HomeworkGateway {
         returnValue: _i24.Stream<List<_i20.HomeworkDto>>.empty(),
         returnValueForMissingStub: _i24.Stream<List<_i20.HomeworkDto>>.empty(),
       ) as _i24.Stream<List<_i20.HomeworkDto>>);
+
   @override
   _i24.Stream<List<_i20.HomeworkDto>> get homeworkStream => (super.noSuchMethod(
         Invocation.getter(#homeworkStream),
         returnValue: _i24.Stream<List<_i20.HomeworkDto>>.empty(),
         returnValueForMissingStub: _i24.Stream<List<_i20.HomeworkDto>>.empty(),
       ) as _i24.Stream<List<_i20.HomeworkDto>>);
+
   @override
   _i24.Stream<_i20.HomeworkDto> singleHomeworkStream(String? homeworkId) =>
       (super.noSuchMethod(
@@ -1074,6 +1131,7 @@ class MockHomeworkGateway extends _i1.Mock implements _i9.HomeworkGateway {
         returnValue: _i24.Stream<_i20.HomeworkDto>.empty(),
         returnValueForMissingStub: _i24.Stream<_i20.HomeworkDto>.empty(),
       ) as _i24.Stream<_i20.HomeworkDto>);
+
   @override
   _i24.Future<_i20.HomeworkDto> singleHomework(
     String? homeworkId, {
@@ -1103,6 +1161,7 @@ class MockHomeworkGateway extends _i1.Mock implements _i9.HomeworkGateway {
           ),
         )),
       ) as _i24.Future<_i20.HomeworkDto>);
+
   @override
   _i24.Future<void> deleteHomework(
     _i20.HomeworkDto? homework, {
@@ -1117,6 +1176,7 @@ class MockHomeworkGateway extends _i1.Mock implements _i9.HomeworkGateway {
         returnValue: _i24.Future<void>.value(),
         returnValueForMissingStub: _i24.Future<void>.value(),
       ) as _i24.Future<void>);
+
   @override
   void deleteHomeworkOnlyForCurrentUser(_i20.HomeworkDto? homework) =>
       super.noSuchMethod(
@@ -1126,6 +1186,7 @@ class MockHomeworkGateway extends _i1.Mock implements _i9.HomeworkGateway {
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   _i24.Future<_i2.DocumentReference<Object?>> addHomeworkToCourse(
     _i20.HomeworkDto? homework, {
@@ -1167,6 +1228,7 @@ class MockHomeworkGateway extends _i1.Mock implements _i9.HomeworkGateway {
           ),
         )),
       ) as _i24.Future<_i2.DocumentReference<Object?>>);
+
   @override
   _i24.Future<void> addPrivateHomework(
     _i20.HomeworkDto? homework,
@@ -1189,6 +1251,7 @@ class MockHomeworkGateway extends _i1.Mock implements _i9.HomeworkGateway {
         returnValue: _i24.Future<void>.value(),
         returnValueForMissingStub: _i24.Future<void>.value(),
       ) as _i24.Future<void>);
+
   @override
   void changeIsHomeworkDoneTo(
     String? homeworkDocumentID,
@@ -1204,6 +1267,7 @@ class MockHomeworkGateway extends _i1.Mock implements _i9.HomeworkGateway {
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   void dispose() => super.noSuchMethod(
         Invocation.method(
@@ -1230,6 +1294,7 @@ class MockCourseGateway extends _i1.Mock implements _i15.CourseGateway {
           Invocation.getter(#references),
         ),
       ) as _i13.References);
+
   @override
   String get memberID => (super.noSuchMethod(
         Invocation.getter(#memberID),
@@ -1242,6 +1307,7 @@ class MockCourseGateway extends _i1.Mock implements _i15.CourseGateway {
           Invocation.getter(#memberID),
         ),
       ) as String);
+
   @override
   _i21.CourseMemberAccessor get memberAccessor => (super.noSuchMethod(
         Invocation.getter(#memberAccessor),
@@ -1254,6 +1320,7 @@ class MockCourseGateway extends _i1.Mock implements _i15.CourseGateway {
           Invocation.getter(#memberAccessor),
         ),
       ) as _i21.CourseMemberAccessor);
+
   @override
   _i22.Course createCourse(
     _i22.CourseData? courseData,
@@ -1288,6 +1355,7 @@ class MockCourseGateway extends _i1.Mock implements _i15.CourseGateway {
           ),
         ),
       ) as _i22.Course);
+
   @override
   _i24.Future<_i19.AppFunctionsResult<bool>> joinCourse(String? courseID) =>
       (super.noSuchMethod(
@@ -1313,6 +1381,7 @@ class MockCourseGateway extends _i1.Mock implements _i15.CourseGateway {
           ),
         )),
       ) as _i24.Future<_i19.AppFunctionsResult<bool>>);
+
   @override
   _i24.Future<_i19.AppFunctionsResult<bool>> leaveCourse(String? courseID) =>
       (super.noSuchMethod(
@@ -1338,6 +1407,7 @@ class MockCourseGateway extends _i1.Mock implements _i15.CourseGateway {
           ),
         )),
       ) as _i24.Future<_i19.AppFunctionsResult<bool>>);
+
   @override
   _i24.Future<_i19.AppFunctionsResult<bool>> kickMember(
     String? courseID,
@@ -1375,6 +1445,7 @@ class MockCourseGateway extends _i1.Mock implements _i15.CourseGateway {
           ),
         )),
       ) as _i24.Future<_i19.AppFunctionsResult<bool>>);
+
   @override
   _i24.Future<_i19.AppFunctionsResult<bool>> editCourse(_i22.Course? course) =>
       (super.noSuchMethod(
@@ -1400,6 +1471,7 @@ class MockCourseGateway extends _i1.Mock implements _i15.CourseGateway {
           ),
         )),
       ) as _i24.Future<_i19.AppFunctionsResult<bool>>);
+
   @override
   _i22.Course? getCourse(String? id) => (super.noSuchMethod(
         Invocation.method(
@@ -1408,6 +1480,7 @@ class MockCourseGateway extends _i1.Mock implements _i15.CourseGateway {
         ),
         returnValueForMissingStub: null,
       ) as _i22.Course?);
+
   @override
   _i24.Future<_i19.AppFunctionsResult<bool>> editCourseSettings(
     String? courseID,
@@ -1445,6 +1518,7 @@ class MockCourseGateway extends _i1.Mock implements _i15.CourseGateway {
           ),
         )),
       ) as _i24.Future<_i19.AppFunctionsResult<bool>>);
+
   @override
   _i24.Future<_i19.AppFunctionsResult<bool>> deleteCourse(String? courseID) =>
       (super.noSuchMethod(
@@ -1470,6 +1544,7 @@ class MockCourseGateway extends _i1.Mock implements _i15.CourseGateway {
           ),
         )),
       ) as _i24.Future<_i19.AppFunctionsResult<bool>>);
+
   @override
   _i24.Future<bool> editCourseGeneralDesign({
     required String? courseID,
@@ -1487,6 +1562,7 @@ class MockCourseGateway extends _i1.Mock implements _i15.CourseGateway {
         returnValue: _i24.Future<bool>.value(false),
         returnValueForMissingStub: _i24.Future<bool>.value(false),
       ) as _i24.Future<bool>);
+
   @override
   _i24.Future<bool> editCoursePersonalDesign({
     required String? courseID,
@@ -1504,6 +1580,7 @@ class MockCourseGateway extends _i1.Mock implements _i15.CourseGateway {
         returnValue: _i24.Future<bool>.value(false),
         returnValueForMissingStub: _i24.Future<bool>.value(false),
       ) as _i24.Future<bool>);
+
   @override
   _i24.Future<bool> removeCoursePersonalDesign(String? courseID) =>
       (super.noSuchMethod(
@@ -1514,6 +1591,7 @@ class MockCourseGateway extends _i1.Mock implements _i15.CourseGateway {
         returnValue: _i24.Future<bool>.value(false),
         returnValueForMissingStub: _i24.Future<bool>.value(false),
       ) as _i24.Future<bool>);
+
   @override
   _i24.Future<_i19.AppFunctionsResult<bool>> memberUpdateRole({
     required String? courseID,
@@ -1558,6 +1636,7 @@ class MockCourseGateway extends _i1.Mock implements _i15.CourseGateway {
           ),
         )),
       ) as _i24.Future<_i19.AppFunctionsResult<bool>>);
+
   @override
   _i22.MemberRole? getRoleFromCourseNoSync(String? courseID) =>
       (super.noSuchMethod(
@@ -1567,6 +1646,7 @@ class MockCourseGateway extends _i1.Mock implements _i15.CourseGateway {
         ),
         returnValueForMissingStub: null,
       ) as _i22.MemberRole?);
+
   @override
   _i24.Stream<_i22.Course?> streamCourse(String? courseID) =>
       (super.noSuchMethod(
@@ -1577,6 +1657,7 @@ class MockCourseGateway extends _i1.Mock implements _i15.CourseGateway {
         returnValue: _i24.Stream<_i22.Course?>.empty(),
         returnValueForMissingStub: _i24.Stream<_i22.Course?>.empty(),
       ) as _i24.Stream<_i22.Course?>);
+
   @override
   _i24.Stream<List<_i22.Course>> streamCourses() => (super.noSuchMethod(
         Invocation.method(
@@ -1586,6 +1667,7 @@ class MockCourseGateway extends _i1.Mock implements _i15.CourseGateway {
         returnValue: _i24.Stream<List<_i22.Course>>.empty(),
         returnValueForMissingStub: _i24.Stream<List<_i22.Course>>.empty(),
       ) as _i24.Stream<List<_i22.Course>>);
+
   @override
   _i24.Stream<Map<String, _i22.GroupInfo>> getGroupInfoStream(
           _i16.SchoolClassGateway? schoolClassGateway) =>
@@ -1598,6 +1680,7 @@ class MockCourseGateway extends _i1.Mock implements _i15.CourseGateway {
         returnValueForMissingStub:
             _i24.Stream<Map<String, _i22.GroupInfo>>.empty(),
       ) as _i24.Stream<Map<String, _i22.GroupInfo>>);
+
   @override
   _i24.Future<List<_i22.Course>> getCourses() => (super.noSuchMethod(
         Invocation.method(
@@ -1608,6 +1691,7 @@ class MockCourseGateway extends _i1.Mock implements _i15.CourseGateway {
         returnValueForMissingStub:
             _i24.Future<List<_i22.Course>>.value(<_i22.Course>[]),
       ) as _i24.Future<List<_i22.Course>>);
+
   @override
   List<_i22.Course> getCurrentCourses() => (super.noSuchMethod(
         Invocation.method(
@@ -1617,6 +1701,7 @@ class MockCourseGateway extends _i1.Mock implements _i15.CourseGateway {
         returnValue: <_i22.Course>[],
         returnValueForMissingStub: <_i22.Course>[],
       ) as List<_i22.Course>);
+
   @override
   bool canEditCourse(_i22.Course? course) => (super.noSuchMethod(
         Invocation.method(

--- a/app/test/notifications/fcm_notification_test.mocks.dart
+++ b/app/test/notifications/fcm_notification_test.mocks.dart
@@ -39,6 +39,7 @@ class MockNotificationTokenAdderApi extends _i1.Mock
           Invocation.getter(#vapidKey),
         ),
       ) as String);
+
   @override
   _i4.Future<String?> getFCMToken() => (super.noSuchMethod(
         Invocation.method(
@@ -48,6 +49,7 @@ class MockNotificationTokenAdderApi extends _i1.Mock
         returnValue: _i4.Future<String?>.value(),
         returnValueForMissingStub: _i4.Future<String?>.value(),
       ) as _i4.Future<String?>);
+
   @override
   _i4.Future<void> tryAddTokenToDatabase(String? token) => (super.noSuchMethod(
         Invocation.method(
@@ -57,6 +59,7 @@ class MockNotificationTokenAdderApi extends _i1.Mock
         returnValue: _i4.Future<void>.value(),
         returnValueForMissingStub: _i4.Future<void>.value(),
       ) as _i4.Future<void>);
+
   @override
   _i4.Future<List<String>> getUserTokensFromDatabase() => (super.noSuchMethod(
         Invocation.method(

--- a/app/test/notifications/notification_permission_test.mocks.dart
+++ b/app/test/notifications/notification_permission_test.mocks.dart
@@ -61,6 +61,7 @@ class MockFirebaseMessaging extends _i1.Mock implements _i4.FirebaseMessaging {
           Invocation.getter(#app),
         ),
       ) as _i2.FirebaseApp);
+
   @override
   set app(_i2.FirebaseApp? _app) => super.noSuchMethod(
         Invocation.setter(
@@ -69,24 +70,28 @@ class MockFirebaseMessaging extends _i1.Mock implements _i4.FirebaseMessaging {
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   bool get isAutoInitEnabled => (super.noSuchMethod(
         Invocation.getter(#isAutoInitEnabled),
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
+
   @override
   _i5.Stream<String> get onTokenRefresh => (super.noSuchMethod(
         Invocation.getter(#onTokenRefresh),
         returnValue: _i5.Stream<String>.empty(),
         returnValueForMissingStub: _i5.Stream<String>.empty(),
       ) as _i5.Stream<String>);
+
   @override
   Map<dynamic, dynamic> get pluginConstants => (super.noSuchMethod(
         Invocation.getter(#pluginConstants),
         returnValue: <dynamic, dynamic>{},
         returnValueForMissingStub: <dynamic, dynamic>{},
       ) as Map<dynamic, dynamic>);
+
   @override
   _i5.Future<_i3.RemoteMessage?> getInitialMessage() => (super.noSuchMethod(
         Invocation.method(
@@ -96,6 +101,7 @@ class MockFirebaseMessaging extends _i1.Mock implements _i4.FirebaseMessaging {
         returnValue: _i5.Future<_i3.RemoteMessage?>.value(),
         returnValueForMissingStub: _i5.Future<_i3.RemoteMessage?>.value(),
       ) as _i5.Future<_i3.RemoteMessage?>);
+
   @override
   _i5.Future<void> deleteToken() => (super.noSuchMethod(
         Invocation.method(
@@ -105,6 +111,7 @@ class MockFirebaseMessaging extends _i1.Mock implements _i4.FirebaseMessaging {
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),
       ) as _i5.Future<void>);
+
   @override
   _i5.Future<String?> getAPNSToken() => (super.noSuchMethod(
         Invocation.method(
@@ -114,6 +121,7 @@ class MockFirebaseMessaging extends _i1.Mock implements _i4.FirebaseMessaging {
         returnValue: _i5.Future<String?>.value(),
         returnValueForMissingStub: _i5.Future<String?>.value(),
       ) as _i5.Future<String?>);
+
   @override
   _i5.Future<String?> getToken({String? vapidKey}) => (super.noSuchMethod(
         Invocation.method(
@@ -124,6 +132,7 @@ class MockFirebaseMessaging extends _i1.Mock implements _i4.FirebaseMessaging {
         returnValue: _i5.Future<String?>.value(),
         returnValueForMissingStub: _i5.Future<String?>.value(),
       ) as _i5.Future<String?>);
+
   @override
   _i5.Future<bool> isSupported() => (super.noSuchMethod(
         Invocation.method(
@@ -133,6 +142,7 @@ class MockFirebaseMessaging extends _i1.Mock implements _i4.FirebaseMessaging {
         returnValue: _i5.Future<bool>.value(false),
         returnValueForMissingStub: _i5.Future<bool>.value(false),
       ) as _i5.Future<bool>);
+
   @override
   _i5.Future<_i3.NotificationSettings> getNotificationSettings() =>
       (super.noSuchMethod(
@@ -157,6 +167,7 @@ class MockFirebaseMessaging extends _i1.Mock implements _i4.FirebaseMessaging {
           ),
         )),
       ) as _i5.Future<_i3.NotificationSettings>);
+
   @override
   _i5.Future<_i3.NotificationSettings> requestPermission({
     bool? alert = true,
@@ -216,6 +227,7 @@ class MockFirebaseMessaging extends _i1.Mock implements _i4.FirebaseMessaging {
           ),
         )),
       ) as _i5.Future<_i3.NotificationSettings>);
+
   @override
   _i5.Future<void> sendMessage({
     String? to,
@@ -241,6 +253,7 @@ class MockFirebaseMessaging extends _i1.Mock implements _i4.FirebaseMessaging {
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),
       ) as _i5.Future<void>);
+
   @override
   _i5.Future<void> setAutoInitEnabled(bool? enabled) => (super.noSuchMethod(
         Invocation.method(
@@ -250,6 +263,7 @@ class MockFirebaseMessaging extends _i1.Mock implements _i4.FirebaseMessaging {
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),
       ) as _i5.Future<void>);
+
   @override
   _i5.Future<void> setDeliveryMetricsExportToBigQuery(bool? enabled) =>
       (super.noSuchMethod(
@@ -260,6 +274,7 @@ class MockFirebaseMessaging extends _i1.Mock implements _i4.FirebaseMessaging {
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),
       ) as _i5.Future<void>);
+
   @override
   _i5.Future<void> setForegroundNotificationPresentationOptions({
     bool? alert = false,
@@ -279,6 +294,7 @@ class MockFirebaseMessaging extends _i1.Mock implements _i4.FirebaseMessaging {
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),
       ) as _i5.Future<void>);
+
   @override
   _i5.Future<void> subscribeToTopic(String? topic) => (super.noSuchMethod(
         Invocation.method(
@@ -288,6 +304,7 @@ class MockFirebaseMessaging extends _i1.Mock implements _i4.FirebaseMessaging {
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),
       ) as _i5.Future<void>);
+
   @override
   _i5.Future<void> unsubscribeFromTopic(String? topic) => (super.noSuchMethod(
         Invocation.method(

--- a/app/test/pages/settings/notification_page_test.mocks.dart
+++ b/app/test/pages/settings/notification_page_test.mocks.dart
@@ -88,6 +88,7 @@ class MockNotificationsBloc extends _i1.Mock implements _i3.NotificationsBloc {
           Invocation.getter(#subscription),
         ),
       ) as _i2.StreamSubscription<dynamic>);
+
   @override
   set subscription(_i2.StreamSubscription<dynamic>? _subscription) =>
       super.noSuchMethod(
@@ -97,24 +98,28 @@ class MockNotificationsBloc extends _i1.Mock implements _i3.NotificationsBloc {
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   _i2.Stream<bool> get notificationsForHomeworks => (super.noSuchMethod(
         Invocation.getter(#notificationsForHomeworks),
         returnValue: _i2.Stream<bool>.empty(),
         returnValueForMissingStub: _i2.Stream<bool>.empty(),
       ) as _i2.Stream<bool>);
+
   @override
   _i2.Stream<bool> get notificationsForBlackboard => (super.noSuchMethod(
         Invocation.getter(#notificationsForBlackboard),
         returnValue: _i2.Stream<bool>.empty(),
         returnValueForMissingStub: _i2.Stream<bool>.empty(),
       ) as _i2.Stream<bool>);
+
   @override
   _i2.Stream<bool> get notificationsForComments => (super.noSuchMethod(
         Invocation.getter(#notificationsForComments),
         returnValue: _i2.Stream<bool>.empty(),
         returnValueForMissingStub: _i2.Stream<bool>.empty(),
       ) as _i2.Stream<bool>);
+
   @override
   dynamic Function(bool) get changeNotificationsForHomeworks =>
       (super.noSuchMethod(
@@ -122,6 +127,7 @@ class MockNotificationsBloc extends _i1.Mock implements _i3.NotificationsBloc {
         returnValue: (bool __p0) => null,
         returnValueForMissingStub: (bool __p0) => null,
       ) as dynamic Function(bool));
+
   @override
   dynamic Function(bool) get changeNotificationsForBlackboard =>
       (super.noSuchMethod(
@@ -129,6 +135,7 @@ class MockNotificationsBloc extends _i1.Mock implements _i3.NotificationsBloc {
         returnValue: (bool __p0) => null,
         returnValueForMissingStub: (bool __p0) => null,
       ) as dynamic Function(bool));
+
   @override
   dynamic Function(bool) get changeNotificationsForComments =>
       (super.noSuchMethod(
@@ -136,6 +143,7 @@ class MockNotificationsBloc extends _i1.Mock implements _i3.NotificationsBloc {
         returnValue: (bool __p0) => null,
         returnValueForMissingStub: (bool __p0) => null,
       ) as dynamic Function(bool));
+
   @override
   _i2.Stream<_i6.TimeOfDay?> get notificationsTimeForHomeworks =>
       (super.noSuchMethod(
@@ -143,6 +151,7 @@ class MockNotificationsBloc extends _i1.Mock implements _i3.NotificationsBloc {
         returnValue: _i2.Stream<_i6.TimeOfDay?>.empty(),
         returnValueForMissingStub: _i2.Stream<_i6.TimeOfDay?>.empty(),
       ) as _i2.Stream<_i6.TimeOfDay?>);
+
   @override
   dynamic Function(_i6.TimeOfDay) get changeNotificationsTimeForHomeworks =>
       (super.noSuchMethod(
@@ -150,6 +159,7 @@ class MockNotificationsBloc extends _i1.Mock implements _i3.NotificationsBloc {
         returnValue: (_i6.TimeOfDay __p0) => null,
         returnValueForMissingStub: (_i6.TimeOfDay __p0) => null,
       ) as dynamic Function(_i6.TimeOfDay));
+
   @override
   List<_i6.TimeOfDay> getTimeForHomeworkNotifications() => (super.noSuchMethod(
         Invocation.method(
@@ -159,6 +169,7 @@ class MockNotificationsBloc extends _i1.Mock implements _i3.NotificationsBloc {
         returnValue: <_i6.TimeOfDay>[],
         returnValueForMissingStub: <_i6.TimeOfDay>[],
       ) as List<_i6.TimeOfDay>);
+
   @override
   void dispose() => super.noSuchMethod(
         Invocation.method(
@@ -195,6 +206,7 @@ class MockNotificationsBlocFactory extends _i1.Mock
           ),
         ),
       ) as _i3.NotificationsBloc);
+
   @override
   void dispose() => super.noSuchMethod(
         Invocation.method(
@@ -216,6 +228,7 @@ class MockSubscriptionService extends _i1.Mock
         returnValue: _i2.Stream<_i9.AppUser?>.empty(),
         returnValueForMissingStub: _i2.Stream<_i9.AppUser?>.empty(),
       ) as _i2.Stream<_i9.AppUser?>);
+
   @override
   _i4.Clock get clock => (super.noSuchMethod(
         Invocation.getter(#clock),
@@ -228,6 +241,7 @@ class MockSubscriptionService extends _i1.Mock
           Invocation.getter(#clock),
         ),
       ) as _i4.Clock);
+
   @override
   _i5.SubscriptionEnabledFlag get isSubscriptionEnabledFlag =>
       (super.noSuchMethod(
@@ -241,6 +255,7 @@ class MockSubscriptionService extends _i1.Mock
           Invocation.getter(#isSubscriptionEnabledFlag),
         ),
       ) as _i5.SubscriptionEnabledFlag);
+
   @override
   bool isSubscriptionActive([_i9.AppUser? appUser]) => (super.noSuchMethod(
         Invocation.method(
@@ -250,6 +265,7 @@ class MockSubscriptionService extends _i1.Mock
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
+
   @override
   _i2.Stream<bool> isSubscriptionActiveStream() => (super.noSuchMethod(
         Invocation.method(
@@ -259,6 +275,7 @@ class MockSubscriptionService extends _i1.Mock
         returnValue: _i2.Stream<bool>.empty(),
         returnValueForMissingStub: _i2.Stream<bool>.empty(),
       ) as _i2.Stream<bool>);
+
   @override
   bool hasFeatureUnlocked(_i8.SharezonePlusFeature? feature) =>
       (super.noSuchMethod(
@@ -269,6 +286,7 @@ class MockSubscriptionService extends _i1.Mock
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
+
   @override
   _i2.Stream<bool> hasFeatureUnlockedStream(
           _i8.SharezonePlusFeature? feature) =>

--- a/app/test/privacy_policy/table_of_contents/toc_currently_reading_test.mocks.dart
+++ b/app/test/privacy_policy/table_of_contents/toc_currently_reading_test.mocks.dart
@@ -75,6 +75,7 @@ class MockDocumentController extends _i1.Mock
           Invocation.getter(#anchorController),
         ),
       ) as _i2.AnchorController);
+
   @override
   _i3.CurrentlyReadThreshold get threshold => (super.noSuchMethod(
         Invocation.getter(#threshold),
@@ -87,6 +88,7 @@ class MockDocumentController extends _i1.Mock
           Invocation.getter(#threshold),
         ),
       ) as _i3.CurrentlyReadThreshold);
+
   @override
   _i4.ValueListenable<_i5.IList<_i3.DocumentSectionHeadingPosition>>
       get sortedSectionHeadings => (super.noSuchMethod(
@@ -103,6 +105,7 @@ class MockDocumentController extends _i1.Mock
             ),
           ) as _i4
               .ValueListenable<_i5.IList<_i3.DocumentSectionHeadingPosition>>);
+
   @override
   _i6.Future<void> scrollToDocumentSection(
           _i3.DocumentSectionId? documentSectionId) =>

--- a/app/test/settings/notifications/notification_test.mocks.dart
+++ b/app/test/settings/notifications/notification_test.mocks.dart
@@ -97,6 +97,7 @@ class MockUserGateway extends _i1.Mock implements _i5.UserGateway {
           Invocation.getter(#references),
         ),
       ) as _i2.References);
+
   @override
   String get uID => (super.noSuchMethod(
         Invocation.getter(#uID),
@@ -109,24 +110,28 @@ class MockUserGateway extends _i1.Mock implements _i5.UserGateway {
           Invocation.getter(#uID),
         ),
       ) as String);
+
   @override
   _i7.Stream<_i3.AppUser?> get userStream => (super.noSuchMethod(
         Invocation.getter(#userStream),
         returnValue: _i7.Stream<_i3.AppUser?>.empty(),
         returnValueForMissingStub: _i7.Stream<_i3.AppUser?>.empty(),
       ) as _i7.Stream<_i3.AppUser?>);
+
   @override
   _i7.Stream<_i8.AuthUser?> get authUserStream => (super.noSuchMethod(
         Invocation.getter(#authUserStream),
         returnValue: _i7.Stream<_i8.AuthUser?>.empty(),
         returnValueForMissingStub: _i7.Stream<_i8.AuthUser?>.empty(),
       ) as _i7.Stream<_i8.AuthUser?>);
+
   @override
   _i7.Stream<bool> get isSignedInStream => (super.noSuchMethod(
         Invocation.getter(#isSignedInStream),
         returnValue: _i7.Stream<bool>.empty(),
         returnValueForMissingStub: _i7.Stream<bool>.empty(),
       ) as _i7.Stream<bool>);
+
   @override
   _i7.Stream<_i9.DocumentSnapshot<Object?>> get userDocument =>
       (super.noSuchMethod(
@@ -135,12 +140,14 @@ class MockUserGateway extends _i1.Mock implements _i5.UserGateway {
         returnValueForMissingStub:
             _i7.Stream<_i9.DocumentSnapshot<Object?>>.empty(),
       ) as _i7.Stream<_i9.DocumentSnapshot<Object?>>);
+
   @override
   _i7.Stream<_i8.Provider?> get providerStream => (super.noSuchMethod(
         Invocation.getter(#providerStream),
         returnValue: _i7.Stream<_i8.Provider?>.empty(),
         returnValueForMissingStub: _i7.Stream<_i8.Provider?>.empty(),
       ) as _i7.Stream<_i8.Provider?>);
+
   @override
   _i7.Future<_i3.AppUser> get() => (super.noSuchMethod(
         Invocation.method(
@@ -162,6 +169,7 @@ class MockUserGateway extends _i1.Mock implements _i5.UserGateway {
           ),
         )),
       ) as _i7.Future<_i3.AppUser>);
+
   @override
   _i7.Future<void> logOut() => (super.noSuchMethod(
         Invocation.method(
@@ -171,6 +179,7 @@ class MockUserGateway extends _i1.Mock implements _i5.UserGateway {
         returnValue: _i7.Future<void>.value(),
         returnValueForMissingStub: _i7.Future<void>.value(),
       ) as _i7.Future<void>);
+
   @override
   bool isAnonymous() => (super.noSuchMethod(
         Invocation.method(
@@ -180,6 +189,7 @@ class MockUserGateway extends _i1.Mock implements _i5.UserGateway {
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
+
   @override
   _i7.Stream<bool?> isAnonymousStream() => (super.noSuchMethod(
         Invocation.method(
@@ -189,6 +199,7 @@ class MockUserGateway extends _i1.Mock implements _i5.UserGateway {
         returnValue: _i7.Stream<bool?>.empty(),
         returnValueForMissingStub: _i7.Stream<bool?>.empty(),
       ) as _i7.Stream<bool?>);
+
   @override
   _i7.Future<void> linkWithCredential(_i10.AuthCredential? credential) =>
       (super.noSuchMethod(
@@ -199,6 +210,7 @@ class MockUserGateway extends _i1.Mock implements _i5.UserGateway {
         returnValue: _i7.Future<void>.value(),
         returnValueForMissingStub: _i7.Future<void>.value(),
       ) as _i7.Future<void>);
+
   @override
   _i7.Future<void> changeState(_i3.StateEnum? state) => (super.noSuchMethod(
         Invocation.method(
@@ -208,6 +220,7 @@ class MockUserGateway extends _i1.Mock implements _i5.UserGateway {
         returnValue: _i7.Future<void>.value(),
         returnValueForMissingStub: _i7.Future<void>.value(),
       ) as _i7.Future<void>);
+
   @override
   _i7.Future<void> addNotificationToken(String? token) => (super.noSuchMethod(
         Invocation.method(
@@ -217,6 +230,7 @@ class MockUserGateway extends _i1.Mock implements _i5.UserGateway {
         returnValue: _i7.Future<void>.value(),
         returnValueForMissingStub: _i7.Future<void>.value(),
       ) as _i7.Future<void>);
+
   @override
   void removeNotificationToken(String? token) => super.noSuchMethod(
         Invocation.method(
@@ -225,6 +239,7 @@ class MockUserGateway extends _i1.Mock implements _i5.UserGateway {
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   _i7.Future<void> setHomeworkReminderTime(_i11.TimeOfDay? timeOfDay) =>
       (super.noSuchMethod(
@@ -235,6 +250,7 @@ class MockUserGateway extends _i1.Mock implements _i5.UserGateway {
         returnValue: _i7.Future<void>.value(),
         returnValueForMissingStub: _i7.Future<void>.value(),
       ) as _i7.Future<void>);
+
   @override
   _i7.Future<void> updateSettings(_i3.UserSettings? userSettings) =>
       (super.noSuchMethod(
@@ -245,6 +261,7 @@ class MockUserGateway extends _i1.Mock implements _i5.UserGateway {
         returnValue: _i7.Future<void>.value(),
         returnValueForMissingStub: _i7.Future<void>.value(),
       ) as _i7.Future<void>);
+
   @override
   _i7.Future<void> updateSettingsSingleFiled(
     String? fieldName,
@@ -261,6 +278,7 @@ class MockUserGateway extends _i1.Mock implements _i5.UserGateway {
         returnValue: _i7.Future<void>.value(),
         returnValueForMissingStub: _i7.Future<void>.value(),
       ) as _i7.Future<void>);
+
   @override
   _i7.Future<void> updateUserTip(
     _i3.UserTipKey? userTipKey,
@@ -277,6 +295,7 @@ class MockUserGateway extends _i1.Mock implements _i5.UserGateway {
         returnValue: _i7.Future<void>.value(),
         returnValueForMissingStub: _i7.Future<void>.value(),
       ) as _i7.Future<void>);
+
   @override
   void setBlackboardNotifications(bool? enabled) => super.noSuchMethod(
         Invocation.method(
@@ -285,6 +304,7 @@ class MockUserGateway extends _i1.Mock implements _i5.UserGateway {
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   void setCommentsNotifications(bool? enabled) => super.noSuchMethod(
         Invocation.method(
@@ -293,6 +313,7 @@ class MockUserGateway extends _i1.Mock implements _i5.UserGateway {
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   _i7.Future<void> changeEmail(String? email) => (super.noSuchMethod(
         Invocation.method(
@@ -302,6 +323,7 @@ class MockUserGateway extends _i1.Mock implements _i5.UserGateway {
         returnValue: _i7.Future<void>.value(),
         returnValueForMissingStub: _i7.Future<void>.value(),
       ) as _i7.Future<void>);
+
   @override
   _i7.Future<void> addUser({
     required _i3.AppUser? user,
@@ -319,6 +341,7 @@ class MockUserGateway extends _i1.Mock implements _i5.UserGateway {
         returnValue: _i7.Future<void>.value(),
         returnValueForMissingStub: _i7.Future<void>.value(),
       ) as _i7.Future<void>);
+
   @override
   _i7.Future<bool> deleteUser(_i12.SharezoneGateway? gateway) =>
       (super.noSuchMethod(
@@ -329,6 +352,7 @@ class MockUserGateway extends _i1.Mock implements _i5.UserGateway {
         returnValue: _i7.Future<bool>.value(false),
         returnValueForMissingStub: _i7.Future<bool>.value(false),
       ) as _i7.Future<bool>);
+
   @override
   _i7.Future<_i4.AppFunctionsResult<bool>> updateUser(_i3.AppUser? userData) =>
       (super.noSuchMethod(
@@ -354,6 +378,7 @@ class MockUserGateway extends _i1.Mock implements _i5.UserGateway {
           ),
         )),
       ) as _i7.Future<_i4.AppFunctionsResult<bool>>);
+
   @override
   _i7.Future<void> dispose() => (super.noSuchMethod(
         Invocation.method(
@@ -381,6 +406,7 @@ class MockAppUser extends _i1.Mock implements _i3.AppUser {
           Invocation.getter(#id),
         ),
       ) as String);
+
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
@@ -393,6 +419,7 @@ class MockAppUser extends _i1.Mock implements _i3.AppUser {
           Invocation.getter(#name),
         ),
       ) as String);
+
   @override
   String get abbreviation => (super.noSuchMethod(
         Invocation.getter(#abbreviation),
@@ -405,30 +432,35 @@ class MockAppUser extends _i1.Mock implements _i3.AppUser {
           Invocation.getter(#abbreviation),
         ),
       ) as String);
+
   @override
   _i3.TypeOfUser get typeOfUser => (super.noSuchMethod(
         Invocation.getter(#typeOfUser),
         returnValue: _i3.TypeOfUser.student,
         returnValueForMissingStub: _i3.TypeOfUser.student,
       ) as _i3.TypeOfUser);
+
   @override
   int get referralScore => (super.noSuchMethod(
         Invocation.getter(#referralScore),
         returnValue: 0,
         returnValueForMissingStub: 0,
       ) as int);
+
   @override
   _i3.StateEnum get state => (super.noSuchMethod(
         Invocation.getter(#state),
         returnValue: _i3.StateEnum.badenWuerttemberg,
         returnValueForMissingStub: _i3.StateEnum.badenWuerttemberg,
       ) as _i3.StateEnum);
+
   @override
   List<String?> get notificationTokens => (super.noSuchMethod(
         Invocation.getter(#notificationTokens),
         returnValue: <String?>[],
         returnValueForMissingStub: <String?>[],
       ) as List<String?>);
+
   @override
   _i3.UserSettings get userSettings => (super.noSuchMethod(
         Invocation.getter(#userSettings),
@@ -441,6 +473,7 @@ class MockAppUser extends _i1.Mock implements _i3.AppUser {
           Invocation.getter(#userSettings),
         ),
       ) as _i3.UserSettings);
+
   @override
   _i3.UserTipData get userTipData => (super.noSuchMethod(
         Invocation.getter(#userTipData),
@@ -453,6 +486,7 @@ class MockAppUser extends _i1.Mock implements _i3.AppUser {
           Invocation.getter(#userTipData),
         ),
       ) as _i3.UserTipData);
+
   @override
   Map<String, dynamic> toCreateJson() => (super.noSuchMethod(
         Invocation.method(
@@ -462,6 +496,7 @@ class MockAppUser extends _i1.Mock implements _i3.AppUser {
         returnValue: <String, dynamic>{},
         returnValueForMissingStub: <String, dynamic>{},
       ) as Map<String, dynamic>);
+
   @override
   Map<String, dynamic> toEditJson() => (super.noSuchMethod(
         Invocation.method(
@@ -471,6 +506,7 @@ class MockAppUser extends _i1.Mock implements _i3.AppUser {
         returnValue: <String, dynamic>{},
         returnValueForMissingStub: <String, dynamic>{},
       ) as Map<String, dynamic>);
+
   @override
   _i3.AppUser copyWith({
     String? id,

--- a/app/test/settings/support/support_page_test.mocks.dart
+++ b/app/test/settings/support/support_page_test.mocks.dart
@@ -47,6 +47,7 @@ class MockSupportPageController extends _i1.Mock
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
+
   @override
   set hasPlusSupportUnlocked(bool? _hasPlusSupportUnlocked) =>
       super.noSuchMethod(
@@ -56,12 +57,14 @@ class MockSupportPageController extends _i1.Mock
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   bool get isUserInGroupOnboarding => (super.noSuchMethod(
         Invocation.getter(#isUserInGroupOnboarding),
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
+
   @override
   set isUserInGroupOnboarding(bool? _isUserInGroupOnboarding) =>
       super.noSuchMethod(
@@ -71,6 +74,7 @@ class MockSupportPageController extends _i1.Mock
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   set userId(_i4.UserId? _userId) => super.noSuchMethod(
         Invocation.setter(
@@ -79,6 +83,7 @@ class MockSupportPageController extends _i1.Mock
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   set userEmail(String? _userEmail) => super.noSuchMethod(
         Invocation.setter(
@@ -87,6 +92,7 @@ class MockSupportPageController extends _i1.Mock
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   set userName(String? _userName) => super.noSuchMethod(
         Invocation.setter(
@@ -95,18 +101,21 @@ class MockSupportPageController extends _i1.Mock
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   bool get isUserSignedIn => (super.noSuchMethod(
         Invocation.getter(#isUserSignedIn),
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
+
   @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
+
   @override
   String getVideoCallAppointmentsUnencodedUrlWithPrefills() =>
       (super.noSuchMethod(
@@ -129,6 +138,7 @@ class MockSupportPageController extends _i1.Mock
           ),
         ),
       ) as String);
+
   @override
   void dispose() => super.noSuchMethod(
         Invocation.method(
@@ -137,6 +147,7 @@ class MockSupportPageController extends _i1.Mock
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   void addListener(_i6.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
@@ -145,6 +156,7 @@ class MockSupportPageController extends _i1.Mock
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   void removeListener(_i6.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
@@ -153,6 +165,7 @@ class MockSupportPageController extends _i1.Mock
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   void notifyListeners() => super.noSuchMethod(
         Invocation.method(
@@ -180,18 +193,21 @@ class MockSubscriptionEnabledFlag extends _i1.Mock
           Invocation.getter(#keyValueStore),
         ),
       ) as _i2.KeyValueStore);
+
   @override
   bool get isEnabled => (super.noSuchMethod(
         Invocation.getter(#isEnabled),
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
+
   @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
+
   @override
   void toggle() => super.noSuchMethod(
         Invocation.method(
@@ -200,6 +216,7 @@ class MockSubscriptionEnabledFlag extends _i1.Mock
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   void addListener(_i6.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
@@ -208,6 +225,7 @@ class MockSubscriptionEnabledFlag extends _i1.Mock
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   void removeListener(_i6.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
@@ -216,6 +234,7 @@ class MockSubscriptionEnabledFlag extends _i1.Mock
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   void dispose() => super.noSuchMethod(
         Invocation.method(
@@ -224,6 +243,7 @@ class MockSubscriptionEnabledFlag extends _i1.Mock
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   void notifyListeners() => super.noSuchMethod(
         Invocation.method(

--- a/app/test/timetable/timetable_dialog_test.mocks.dart
+++ b/app/test/timetable/timetable_dialog_test.mocks.dart
@@ -60,6 +60,7 @@ class MockEventDialogApi extends _i1.Mock implements _i3.EventDialogApi {
           ),
         )),
       ) as _i4.Future<_i2.Course>);
+
   @override
   _i4.Future<void> createEvent(_i3.CreateEventCommand? command) =>
       (super.noSuchMethod(

--- a/app/test/timetable/timetable_page_test.mocks.dart
+++ b/app/test/timetable/timetable_page_test.mocks.dart
@@ -58,6 +58,7 @@ class MockSubscriptionService extends _i1.Mock
         returnValue: _i5.Stream<_i6.AppUser?>.empty(),
         returnValueForMissingStub: _i5.Stream<_i6.AppUser?>.empty(),
       ) as _i5.Stream<_i6.AppUser?>);
+
   @override
   _i2.Clock get clock => (super.noSuchMethod(
         Invocation.getter(#clock),
@@ -70,6 +71,7 @@ class MockSubscriptionService extends _i1.Mock
           Invocation.getter(#clock),
         ),
       ) as _i2.Clock);
+
   @override
   _i3.SubscriptionEnabledFlag get isSubscriptionEnabledFlag =>
       (super.noSuchMethod(
@@ -83,6 +85,7 @@ class MockSubscriptionService extends _i1.Mock
           Invocation.getter(#isSubscriptionEnabledFlag),
         ),
       ) as _i3.SubscriptionEnabledFlag);
+
   @override
   bool isSubscriptionActive([_i6.AppUser? appUser]) => (super.noSuchMethod(
         Invocation.method(
@@ -92,6 +95,7 @@ class MockSubscriptionService extends _i1.Mock
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
+
   @override
   _i5.Stream<bool> isSubscriptionActiveStream() => (super.noSuchMethod(
         Invocation.method(
@@ -101,6 +105,7 @@ class MockSubscriptionService extends _i1.Mock
         returnValue: _i5.Stream<bool>.empty(),
         returnValueForMissingStub: _i5.Stream<bool>.empty(),
       ) as _i5.Stream<bool>);
+
   @override
   bool hasFeatureUnlocked(_i4.SharezonePlusFeature? feature) =>
       (super.noSuchMethod(
@@ -111,6 +116,7 @@ class MockSubscriptionService extends _i1.Mock
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
+
   @override
   _i5.Stream<bool> hasFeatureUnlockedStream(
           _i4.SharezonePlusFeature? feature) =>

--- a/app/test_goldens/blackboard/details/blackboard_item_read_by_users_list_page_test.mocks.dart
+++ b/app/test_goldens/blackboard/details/blackboard_item_read_by_users_list_page_test.mocks.dart
@@ -62,6 +62,7 @@ class MockBlackboardItemReadByUsersListBloc extends _i1.Mock
         returnValue: _i5.Stream<List<_i6.UserView>>.empty(),
         returnValueForMissingStub: _i5.Stream<List<_i6.UserView>>.empty(),
       ) as _i5.Stream<List<_i6.UserView>>);
+
   @override
   void dispose() => super.noSuchMethod(
         Invocation.method(
@@ -83,6 +84,7 @@ class MockSubscriptionService extends _i1.Mock
         returnValue: _i5.Stream<_i8.AppUser?>.empty(),
         returnValueForMissingStub: _i5.Stream<_i8.AppUser?>.empty(),
       ) as _i5.Stream<_i8.AppUser?>);
+
   @override
   _i2.Clock get clock => (super.noSuchMethod(
         Invocation.getter(#clock),
@@ -95,6 +97,7 @@ class MockSubscriptionService extends _i1.Mock
           Invocation.getter(#clock),
         ),
       ) as _i2.Clock);
+
   @override
   _i3.SubscriptionEnabledFlag get isSubscriptionEnabledFlag =>
       (super.noSuchMethod(
@@ -108,6 +111,7 @@ class MockSubscriptionService extends _i1.Mock
           Invocation.getter(#isSubscriptionEnabledFlag),
         ),
       ) as _i3.SubscriptionEnabledFlag);
+
   @override
   bool isSubscriptionActive([_i8.AppUser? appUser]) => (super.noSuchMethod(
         Invocation.method(
@@ -117,6 +121,7 @@ class MockSubscriptionService extends _i1.Mock
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
+
   @override
   _i5.Stream<bool> isSubscriptionActiveStream() => (super.noSuchMethod(
         Invocation.method(
@@ -126,6 +131,7 @@ class MockSubscriptionService extends _i1.Mock
         returnValue: _i5.Stream<bool>.empty(),
         returnValueForMissingStub: _i5.Stream<bool>.empty(),
       ) as _i5.Stream<bool>);
+
   @override
   bool hasFeatureUnlocked(_i7.SharezonePlusFeature? feature) =>
       (super.noSuchMethod(
@@ -136,6 +142,7 @@ class MockSubscriptionService extends _i1.Mock
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
+
   @override
   _i5.Stream<bool> hasFeatureUnlockedStream(
           _i7.SharezonePlusFeature? feature) =>

--- a/app/test_goldens/calendrical_events/page/past_calendrical_events_page_test.mocks.dart
+++ b/app/test_goldens/calendrical_events/page/past_calendrical_events_page_test.mocks.dart
@@ -183,6 +183,7 @@ class MockPastCalendricalEventsPageControllerFactory extends _i1.Mock
           Invocation.getter(#subscriptionService),
         ),
       ) as _i2.SubscriptionService);
+
   @override
   _i3.TimetableGateway get timetableGateway => (super.noSuchMethod(
         Invocation.getter(#timetableGateway),
@@ -195,6 +196,7 @@ class MockPastCalendricalEventsPageControllerFactory extends _i1.Mock
           Invocation.getter(#timetableGateway),
         ),
       ) as _i3.TimetableGateway);
+
   @override
   _i4.CourseGateway get courseGateway => (super.noSuchMethod(
         Invocation.getter(#courseGateway),
@@ -207,6 +209,7 @@ class MockPastCalendricalEventsPageControllerFactory extends _i1.Mock
           Invocation.getter(#courseGateway),
         ),
       ) as _i4.CourseGateway);
+
   @override
   _i5.SchoolClassGateway get schoolClassGateway => (super.noSuchMethod(
         Invocation.getter(#schoolClassGateway),
@@ -219,6 +222,7 @@ class MockPastCalendricalEventsPageControllerFactory extends _i1.Mock
           Invocation.getter(#schoolClassGateway),
         ),
       ) as _i5.SchoolClassGateway);
+
   @override
   _i6.Clock get clock => (super.noSuchMethod(
         Invocation.getter(#clock),
@@ -231,6 +235,7 @@ class MockPastCalendricalEventsPageControllerFactory extends _i1.Mock
           Invocation.getter(#clock),
         ),
       ) as _i6.Clock);
+
   @override
   _i7.PastCalendricalEventsPageAnalytics get analytics => (super.noSuchMethod(
         Invocation.getter(#analytics),
@@ -243,6 +248,7 @@ class MockPastCalendricalEventsPageControllerFactory extends _i1.Mock
           Invocation.getter(#analytics),
         ),
       ) as _i7.PastCalendricalEventsPageAnalytics);
+
   @override
   _i8.PastCalendricalEventsPageController create() => (super.noSuchMethod(
         Invocation.method(
@@ -284,6 +290,7 @@ class MockPastCalendricalEventsPageController extends _i1.Mock
           Invocation.getter(#state),
         ),
       ) as _i8.PastCalendricalEventsPageState);
+
   @override
   set state(_i8.PastCalendricalEventsPageState? _state) => super.noSuchMethod(
         Invocation.setter(
@@ -292,6 +299,7 @@ class MockPastCalendricalEventsPageController extends _i1.Mock
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   _i3.TimetableGateway get timetableGateway => (super.noSuchMethod(
         Invocation.getter(#timetableGateway),
@@ -304,6 +312,7 @@ class MockPastCalendricalEventsPageController extends _i1.Mock
           Invocation.getter(#timetableGateway),
         ),
       ) as _i3.TimetableGateway);
+
   @override
   _i4.CourseGateway get courseGateway => (super.noSuchMethod(
         Invocation.getter(#courseGateway),
@@ -316,6 +325,7 @@ class MockPastCalendricalEventsPageController extends _i1.Mock
           Invocation.getter(#courseGateway),
         ),
       ) as _i4.CourseGateway);
+
   @override
   _i5.SchoolClassGateway get schoolClassGateway => (super.noSuchMethod(
         Invocation.getter(#schoolClassGateway),
@@ -328,6 +338,7 @@ class MockPastCalendricalEventsPageController extends _i1.Mock
           Invocation.getter(#schoolClassGateway),
         ),
       ) as _i5.SchoolClassGateway);
+
   @override
   _i7.PastCalendricalEventsPageAnalytics get analytics => (super.noSuchMethod(
         Invocation.getter(#analytics),
@@ -340,12 +351,14 @@ class MockPastCalendricalEventsPageController extends _i1.Mock
           Invocation.getter(#analytics),
         ),
       ) as _i7.PastCalendricalEventsPageAnalytics);
+
   @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
+
   @override
   void setSortOrder(_i8.EventsSortingOrder? order) => super.noSuchMethod(
         Invocation.method(
@@ -354,6 +367,7 @@ class MockPastCalendricalEventsPageController extends _i1.Mock
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   void dispose() => super.noSuchMethod(
         Invocation.method(
@@ -362,6 +376,7 @@ class MockPastCalendricalEventsPageController extends _i1.Mock
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   void addListener(_i15.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
@@ -370,6 +385,7 @@ class MockPastCalendricalEventsPageController extends _i1.Mock
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   void removeListener(_i15.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
@@ -378,6 +394,7 @@ class MockPastCalendricalEventsPageController extends _i1.Mock
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   void notifyListeners() => super.noSuchMethod(
         Invocation.method(
@@ -404,6 +421,7 @@ class MockCalendricalEvent extends _i1.Mock implements _i12.CalendricalEvent {
           Invocation.getter(#eventID),
         ),
       ) as String);
+
   @override
   String get groupID => (super.noSuchMethod(
         Invocation.getter(#groupID),
@@ -416,6 +434,7 @@ class MockCalendricalEvent extends _i1.Mock implements _i12.CalendricalEvent {
           Invocation.getter(#groupID),
         ),
       ) as String);
+
   @override
   String get authorID => (super.noSuchMethod(
         Invocation.getter(#authorID),
@@ -428,18 +447,21 @@ class MockCalendricalEvent extends _i1.Mock implements _i12.CalendricalEvent {
           Invocation.getter(#authorID),
         ),
       ) as String);
+
   @override
   _i16.GroupType get groupType => (super.noSuchMethod(
         Invocation.getter(#groupType),
         returnValue: _i16.GroupType.course,
         returnValueForMissingStub: _i16.GroupType.course,
       ) as _i16.GroupType);
+
   @override
   _i12.EventType get eventType => (super.noSuchMethod(
         Invocation.getter(#eventType),
         returnValue: _i12.EventType.event,
         returnValueForMissingStub: _i12.EventType.event,
       ) as _i12.EventType);
+
   @override
   _i9.Date get date => (super.noSuchMethod(
         Invocation.getter(#date),
@@ -452,6 +474,7 @@ class MockCalendricalEvent extends _i1.Mock implements _i12.CalendricalEvent {
           Invocation.getter(#date),
         ),
       ) as _i9.Date);
+
   @override
   _i10.Time get startTime => (super.noSuchMethod(
         Invocation.getter(#startTime),
@@ -464,6 +487,7 @@ class MockCalendricalEvent extends _i1.Mock implements _i12.CalendricalEvent {
           Invocation.getter(#startTime),
         ),
       ) as _i10.Time);
+
   @override
   _i10.Time get endTime => (super.noSuchMethod(
         Invocation.getter(#endTime),
@@ -476,6 +500,7 @@ class MockCalendricalEvent extends _i1.Mock implements _i12.CalendricalEvent {
           Invocation.getter(#endTime),
         ),
       ) as _i10.Time);
+
   @override
   String get title => (super.noSuchMethod(
         Invocation.getter(#title),
@@ -488,12 +513,14 @@ class MockCalendricalEvent extends _i1.Mock implements _i12.CalendricalEvent {
           Invocation.getter(#title),
         ),
       ) as String);
+
   @override
   bool get sendNotification => (super.noSuchMethod(
         Invocation.getter(#sendNotification),
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
+
   @override
   _i11.LessonLength get length => (super.noSuchMethod(
         Invocation.getter(#length),
@@ -506,6 +533,7 @@ class MockCalendricalEvent extends _i1.Mock implements _i12.CalendricalEvent {
           Invocation.getter(#length),
         ),
       ) as _i11.LessonLength);
+
   @override
   DateTime get startDateTime => (super.noSuchMethod(
         Invocation.getter(#startDateTime),
@@ -518,6 +546,7 @@ class MockCalendricalEvent extends _i1.Mock implements _i12.CalendricalEvent {
           Invocation.getter(#startDateTime),
         ),
       ) as DateTime);
+
   @override
   DateTime get endDateTime => (super.noSuchMethod(
         Invocation.getter(#endDateTime),
@@ -530,6 +559,7 @@ class MockCalendricalEvent extends _i1.Mock implements _i12.CalendricalEvent {
           Invocation.getter(#endDateTime),
         ),
       ) as DateTime);
+
   @override
   Map<String, dynamic> toJson() => (super.noSuchMethod(
         Invocation.method(
@@ -539,6 +569,7 @@ class MockCalendricalEvent extends _i1.Mock implements _i12.CalendricalEvent {
         returnValue: <String, dynamic>{},
         returnValueForMissingStub: <String, dynamic>{},
       ) as Map<String, dynamic>);
+
   @override
   _i12.CalendricalEvent copyWith({
     String? eventID,

--- a/app/test_goldens/groups/src/pages/course/course_edit/design/src/dialog/select_design_dialog_test.mocks.dart
+++ b/app/test_goldens/groups/src/pages/course/course_edit/design/src/dialog/select_design_dialog_test.mocks.dart
@@ -58,6 +58,7 @@ class MockSubscriptionService extends _i1.Mock
         returnValue: _i5.Stream<_i6.AppUser?>.empty(),
         returnValueForMissingStub: _i5.Stream<_i6.AppUser?>.empty(),
       ) as _i5.Stream<_i6.AppUser?>);
+
   @override
   _i2.Clock get clock => (super.noSuchMethod(
         Invocation.getter(#clock),
@@ -70,6 +71,7 @@ class MockSubscriptionService extends _i1.Mock
           Invocation.getter(#clock),
         ),
       ) as _i2.Clock);
+
   @override
   _i3.SubscriptionEnabledFlag get isSubscriptionEnabledFlag =>
       (super.noSuchMethod(
@@ -83,6 +85,7 @@ class MockSubscriptionService extends _i1.Mock
           Invocation.getter(#isSubscriptionEnabledFlag),
         ),
       ) as _i3.SubscriptionEnabledFlag);
+
   @override
   bool isSubscriptionActive([_i6.AppUser? appUser]) => (super.noSuchMethod(
         Invocation.method(
@@ -92,6 +95,7 @@ class MockSubscriptionService extends _i1.Mock
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
+
   @override
   _i5.Stream<bool> isSubscriptionActiveStream() => (super.noSuchMethod(
         Invocation.method(
@@ -101,6 +105,7 @@ class MockSubscriptionService extends _i1.Mock
         returnValue: _i5.Stream<bool>.empty(),
         returnValueForMissingStub: _i5.Stream<bool>.empty(),
       ) as _i5.Stream<bool>);
+
   @override
   bool hasFeatureUnlocked(_i4.SharezonePlusFeature? feature) =>
       (super.noSuchMethod(
@@ -111,6 +116,7 @@ class MockSubscriptionService extends _i1.Mock
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
+
   @override
   _i5.Stream<bool> hasFeatureUnlockedStream(
           _i4.SharezonePlusFeature? feature) =>

--- a/app/test_goldens/homework/teacher/homework_done_by_users_list/homework_completion_user_list_page_test.mocks.dart
+++ b/app/test_goldens/homework/teacher/homework_done_by_users_list/homework_completion_user_list_page_test.mocks.dart
@@ -92,6 +92,7 @@ class MockHomeworkCompletionUserListBlocFactory extends _i1.Mock
           ),
         ),
       ) as _i2.HomeworkCompletionUserListBloc);
+
   @override
   void dispose() => super.noSuchMethod(
         Invocation.method(
@@ -115,6 +116,7 @@ class MockHomeworkCompletionUserListBloc extends _i1.Mock
         returnValueForMissingStub:
             _i7.Stream<List<_i8.UserHasCompletedHomeworkView>>.empty(),
       ) as _i7.Stream<List<_i8.UserHasCompletedHomeworkView>>);
+
   @override
   void logOpenHomeworkDoneByUsersList() => super.noSuchMethod(
         Invocation.method(
@@ -123,6 +125,7 @@ class MockHomeworkCompletionUserListBloc extends _i1.Mock
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   void dispose() => super.noSuchMethod(
         Invocation.method(
@@ -144,6 +147,7 @@ class MockSubscriptionService extends _i1.Mock
         returnValue: _i7.Stream<_i10.AppUser?>.empty(),
         returnValueForMissingStub: _i7.Stream<_i10.AppUser?>.empty(),
       ) as _i7.Stream<_i10.AppUser?>);
+
   @override
   _i3.Clock get clock => (super.noSuchMethod(
         Invocation.getter(#clock),
@@ -156,6 +160,7 @@ class MockSubscriptionService extends _i1.Mock
           Invocation.getter(#clock),
         ),
       ) as _i3.Clock);
+
   @override
   _i4.SubscriptionEnabledFlag get isSubscriptionEnabledFlag =>
       (super.noSuchMethod(
@@ -169,6 +174,7 @@ class MockSubscriptionService extends _i1.Mock
           Invocation.getter(#isSubscriptionEnabledFlag),
         ),
       ) as _i4.SubscriptionEnabledFlag);
+
   @override
   bool isSubscriptionActive([_i10.AppUser? appUser]) => (super.noSuchMethod(
         Invocation.method(
@@ -178,6 +184,7 @@ class MockSubscriptionService extends _i1.Mock
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
+
   @override
   _i7.Stream<bool> isSubscriptionActiveStream() => (super.noSuchMethod(
         Invocation.method(
@@ -187,6 +194,7 @@ class MockSubscriptionService extends _i1.Mock
         returnValue: _i7.Stream<bool>.empty(),
         returnValueForMissingStub: _i7.Stream<bool>.empty(),
       ) as _i7.Stream<bool>);
+
   @override
   bool hasFeatureUnlocked(_i9.SharezonePlusFeature? feature) =>
       (super.noSuchMethod(
@@ -197,6 +205,7 @@ class MockSubscriptionService extends _i1.Mock
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
+
   @override
   _i7.Stream<bool> hasFeatureUnlockedStream(
           _i9.SharezonePlusFeature? feature) =>

--- a/app/test_goldens/settings/notification_page_test.mocks.dart
+++ b/app/test_goldens/settings/notification_page_test.mocks.dart
@@ -88,6 +88,7 @@ class MockNotificationsBloc extends _i1.Mock implements _i3.NotificationsBloc {
           Invocation.getter(#subscription),
         ),
       ) as _i2.StreamSubscription<dynamic>);
+
   @override
   set subscription(_i2.StreamSubscription<dynamic>? _subscription) =>
       super.noSuchMethod(
@@ -97,24 +98,28 @@ class MockNotificationsBloc extends _i1.Mock implements _i3.NotificationsBloc {
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   _i2.Stream<bool> get notificationsForHomeworks => (super.noSuchMethod(
         Invocation.getter(#notificationsForHomeworks),
         returnValue: _i2.Stream<bool>.empty(),
         returnValueForMissingStub: _i2.Stream<bool>.empty(),
       ) as _i2.Stream<bool>);
+
   @override
   _i2.Stream<bool> get notificationsForBlackboard => (super.noSuchMethod(
         Invocation.getter(#notificationsForBlackboard),
         returnValue: _i2.Stream<bool>.empty(),
         returnValueForMissingStub: _i2.Stream<bool>.empty(),
       ) as _i2.Stream<bool>);
+
   @override
   _i2.Stream<bool> get notificationsForComments => (super.noSuchMethod(
         Invocation.getter(#notificationsForComments),
         returnValue: _i2.Stream<bool>.empty(),
         returnValueForMissingStub: _i2.Stream<bool>.empty(),
       ) as _i2.Stream<bool>);
+
   @override
   dynamic Function(bool) get changeNotificationsForHomeworks =>
       (super.noSuchMethod(
@@ -122,6 +127,7 @@ class MockNotificationsBloc extends _i1.Mock implements _i3.NotificationsBloc {
         returnValue: (bool __p0) => null,
         returnValueForMissingStub: (bool __p0) => null,
       ) as dynamic Function(bool));
+
   @override
   dynamic Function(bool) get changeNotificationsForBlackboard =>
       (super.noSuchMethod(
@@ -129,6 +135,7 @@ class MockNotificationsBloc extends _i1.Mock implements _i3.NotificationsBloc {
         returnValue: (bool __p0) => null,
         returnValueForMissingStub: (bool __p0) => null,
       ) as dynamic Function(bool));
+
   @override
   dynamic Function(bool) get changeNotificationsForComments =>
       (super.noSuchMethod(
@@ -136,6 +143,7 @@ class MockNotificationsBloc extends _i1.Mock implements _i3.NotificationsBloc {
         returnValue: (bool __p0) => null,
         returnValueForMissingStub: (bool __p0) => null,
       ) as dynamic Function(bool));
+
   @override
   _i2.Stream<_i6.TimeOfDay?> get notificationsTimeForHomeworks =>
       (super.noSuchMethod(
@@ -143,6 +151,7 @@ class MockNotificationsBloc extends _i1.Mock implements _i3.NotificationsBloc {
         returnValue: _i2.Stream<_i6.TimeOfDay?>.empty(),
         returnValueForMissingStub: _i2.Stream<_i6.TimeOfDay?>.empty(),
       ) as _i2.Stream<_i6.TimeOfDay?>);
+
   @override
   dynamic Function(_i6.TimeOfDay) get changeNotificationsTimeForHomeworks =>
       (super.noSuchMethod(
@@ -150,6 +159,7 @@ class MockNotificationsBloc extends _i1.Mock implements _i3.NotificationsBloc {
         returnValue: (_i6.TimeOfDay __p0) => null,
         returnValueForMissingStub: (_i6.TimeOfDay __p0) => null,
       ) as dynamic Function(_i6.TimeOfDay));
+
   @override
   List<_i6.TimeOfDay> getTimeForHomeworkNotifications() => (super.noSuchMethod(
         Invocation.method(
@@ -159,6 +169,7 @@ class MockNotificationsBloc extends _i1.Mock implements _i3.NotificationsBloc {
         returnValue: <_i6.TimeOfDay>[],
         returnValueForMissingStub: <_i6.TimeOfDay>[],
       ) as List<_i6.TimeOfDay>);
+
   @override
   void dispose() => super.noSuchMethod(
         Invocation.method(
@@ -195,6 +206,7 @@ class MockNotificationsBlocFactory extends _i1.Mock
           ),
         ),
       ) as _i3.NotificationsBloc);
+
   @override
   void dispose() => super.noSuchMethod(
         Invocation.method(
@@ -216,6 +228,7 @@ class MockSubscriptionService extends _i1.Mock
         returnValue: _i2.Stream<_i9.AppUser?>.empty(),
         returnValueForMissingStub: _i2.Stream<_i9.AppUser?>.empty(),
       ) as _i2.Stream<_i9.AppUser?>);
+
   @override
   _i4.Clock get clock => (super.noSuchMethod(
         Invocation.getter(#clock),
@@ -228,6 +241,7 @@ class MockSubscriptionService extends _i1.Mock
           Invocation.getter(#clock),
         ),
       ) as _i4.Clock);
+
   @override
   _i5.SubscriptionEnabledFlag get isSubscriptionEnabledFlag =>
       (super.noSuchMethod(
@@ -241,6 +255,7 @@ class MockSubscriptionService extends _i1.Mock
           Invocation.getter(#isSubscriptionEnabledFlag),
         ),
       ) as _i5.SubscriptionEnabledFlag);
+
   @override
   bool isSubscriptionActive([_i9.AppUser? appUser]) => (super.noSuchMethod(
         Invocation.method(
@@ -250,6 +265,7 @@ class MockSubscriptionService extends _i1.Mock
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
+
   @override
   _i2.Stream<bool> isSubscriptionActiveStream() => (super.noSuchMethod(
         Invocation.method(
@@ -259,6 +275,7 @@ class MockSubscriptionService extends _i1.Mock
         returnValue: _i2.Stream<bool>.empty(),
         returnValueForMissingStub: _i2.Stream<bool>.empty(),
       ) as _i2.Stream<bool>);
+
   @override
   bool hasFeatureUnlocked(_i8.SharezonePlusFeature? feature) =>
       (super.noSuchMethod(
@@ -269,6 +286,7 @@ class MockSubscriptionService extends _i1.Mock
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
+
   @override
   _i2.Stream<bool> hasFeatureUnlockedStream(
           _i8.SharezonePlusFeature? feature) =>

--- a/app/test_goldens/settings/support/support_page_test.mocks.dart
+++ b/app/test_goldens/settings/support/support_page_test.mocks.dart
@@ -47,6 +47,7 @@ class MockSupportPageController extends _i1.Mock
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
+
   @override
   set hasPlusSupportUnlocked(bool? _hasPlusSupportUnlocked) =>
       super.noSuchMethod(
@@ -56,12 +57,14 @@ class MockSupportPageController extends _i1.Mock
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   bool get isUserInGroupOnboarding => (super.noSuchMethod(
         Invocation.getter(#isUserInGroupOnboarding),
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
+
   @override
   set isUserInGroupOnboarding(bool? _isUserInGroupOnboarding) =>
       super.noSuchMethod(
@@ -71,6 +74,7 @@ class MockSupportPageController extends _i1.Mock
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   set userId(_i4.UserId? _userId) => super.noSuchMethod(
         Invocation.setter(
@@ -79,6 +83,7 @@ class MockSupportPageController extends _i1.Mock
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   set userEmail(String? _userEmail) => super.noSuchMethod(
         Invocation.setter(
@@ -87,6 +92,7 @@ class MockSupportPageController extends _i1.Mock
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   set userName(String? _userName) => super.noSuchMethod(
         Invocation.setter(
@@ -95,18 +101,21 @@ class MockSupportPageController extends _i1.Mock
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   bool get isUserSignedIn => (super.noSuchMethod(
         Invocation.getter(#isUserSignedIn),
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
+
   @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
+
   @override
   String getVideoCallAppointmentsUnencodedUrlWithPrefills() =>
       (super.noSuchMethod(
@@ -129,6 +138,7 @@ class MockSupportPageController extends _i1.Mock
           ),
         ),
       ) as String);
+
   @override
   void dispose() => super.noSuchMethod(
         Invocation.method(
@@ -137,6 +147,7 @@ class MockSupportPageController extends _i1.Mock
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   void addListener(_i6.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
@@ -145,6 +156,7 @@ class MockSupportPageController extends _i1.Mock
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   void removeListener(_i6.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
@@ -153,6 +165,7 @@ class MockSupportPageController extends _i1.Mock
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   void notifyListeners() => super.noSuchMethod(
         Invocation.method(
@@ -180,18 +193,21 @@ class MockSubscriptionEnabledFlag extends _i1.Mock
           Invocation.getter(#keyValueStore),
         ),
       ) as _i2.KeyValueStore);
+
   @override
   bool get isEnabled => (super.noSuchMethod(
         Invocation.getter(#isEnabled),
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
+
   @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
+
   @override
   void toggle() => super.noSuchMethod(
         Invocation.method(
@@ -200,6 +216,7 @@ class MockSubscriptionEnabledFlag extends _i1.Mock
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   void addListener(_i6.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
@@ -208,6 +225,7 @@ class MockSubscriptionEnabledFlag extends _i1.Mock
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   void removeListener(_i6.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
@@ -216,6 +234,7 @@ class MockSubscriptionEnabledFlag extends _i1.Mock
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   void dispose() => super.noSuchMethod(
         Invocation.method(
@@ -224,6 +243,7 @@ class MockSubscriptionEnabledFlag extends _i1.Mock
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   void notifyListeners() => super.noSuchMethod(
         Invocation.method(

--- a/app/test_goldens/sharezone_plus/sharezone_plus_page_test.mocks.dart
+++ b/app/test_goldens/sharezone_plus/sharezone_plus_page_test.mocks.dart
@@ -273,6 +273,7 @@ class MockSharezonePlusPageController extends _i2.Mock
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   set price(String? _price) => super.noSuchMethod(
         Invocation.setter(
@@ -281,12 +282,14 @@ class MockSharezonePlusPageController extends _i2.Mock
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
+
   @override
   _i22.Future<void> buySubscription() => (super.noSuchMethod(
         Invocation.method(
@@ -296,6 +299,7 @@ class MockSharezonePlusPageController extends _i2.Mock
         returnValue: _i22.Future<void>.value(),
         returnValueForMissingStub: _i22.Future<void>.value(),
       ) as _i22.Future<void>);
+
   @override
   _i22.Future<void> cancelSubscription() => (super.noSuchMethod(
         Invocation.method(
@@ -305,6 +309,7 @@ class MockSharezonePlusPageController extends _i2.Mock
         returnValue: _i22.Future<void>.value(),
         returnValueForMissingStub: _i22.Future<void>.value(),
       ) as _i22.Future<void>);
+
   @override
   void dispose() => super.noSuchMethod(
         Invocation.method(
@@ -313,6 +318,7 @@ class MockSharezonePlusPageController extends _i2.Mock
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   void addListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
@@ -321,6 +327,7 @@ class MockSharezonePlusPageController extends _i2.Mock
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   void removeListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
@@ -329,6 +336,7 @@ class MockSharezonePlusPageController extends _i2.Mock
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   void notifyListeners() => super.noSuchMethod(
         Invocation.method(
@@ -357,6 +365,7 @@ class MockNavigationBloc extends _i2.Mock implements _i24.NavigationBloc {
           Invocation.getter(#scaffoldKey),
         ),
       ) as _i1.GlobalKey<_i1.State<_i1.StatefulWidget>>);
+
   @override
   _i1.GlobalKey<_i1.State<_i1.StatefulWidget>> get drawerKey =>
       (super.noSuchMethod(
@@ -371,6 +380,7 @@ class MockNavigationBloc extends _i2.Mock implements _i24.NavigationBloc {
           Invocation.getter(#drawerKey),
         ),
       ) as _i1.GlobalKey<_i1.State<_i1.StatefulWidget>>);
+
   @override
   _i1.GlobalKey<_i1.State<_i1.StatefulWidget>> get controllerKey =>
       (super.noSuchMethod(
@@ -385,24 +395,28 @@ class MockNavigationBloc extends _i2.Mock implements _i24.NavigationBloc {
           Invocation.getter(#controllerKey),
         ),
       ) as _i1.GlobalKey<_i1.State<_i1.StatefulWidget>>);
+
   @override
   _i22.Stream<_i25.NavigationItem> get currentItemStream => (super.noSuchMethod(
         Invocation.getter(#currentItemStream),
         returnValue: _i22.Stream<_i25.NavigationItem>.empty(),
         returnValueForMissingStub: _i22.Stream<_i25.NavigationItem>.empty(),
       ) as _i22.Stream<_i25.NavigationItem>);
+
   @override
   _i25.NavigationItem get currentItem => (super.noSuchMethod(
         Invocation.getter(#currentItem),
         returnValue: _i25.NavigationItem.overview,
         returnValueForMissingStub: _i25.NavigationItem.overview,
       ) as _i25.NavigationItem);
+
   @override
   dynamic Function(_i25.NavigationItem) get navigateTo => (super.noSuchMethod(
         Invocation.getter(#navigateTo),
         returnValue: (_i25.NavigationItem __p0) => null,
         returnValueForMissingStub: (_i25.NavigationItem __p0) => null,
       ) as dynamic Function(_i25.NavigationItem));
+
   @override
   void dispose() => super.noSuchMethod(
         Invocation.method(
@@ -432,6 +446,7 @@ class MockNavigationExperimentCache extends _i2.Mock
           Invocation.getter(#currentNavigation),
         ),
       ) as _i3.ValueStream<_i27.NavigationExperimentOption>);
+
   @override
   void setNavigation(_i27.NavigationExperimentOption? option) =>
       super.noSuchMethod(
@@ -441,6 +456,7 @@ class MockNavigationExperimentCache extends _i2.Mock
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   void dispose() => super.noSuchMethod(
         Invocation.method(
@@ -465,6 +481,7 @@ class MockNavigationAnalytics extends _i2.Mock
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   void logDrawerEvent(_i25.NavigationItem? item) => super.noSuchMethod(
         Invocation.method(
@@ -473,6 +490,7 @@ class MockNavigationAnalytics extends _i2.Mock
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   void logUsedSwipeUpLine() => super.noSuchMethod(
         Invocation.method(
@@ -481,6 +499,7 @@ class MockNavigationAnalytics extends _i2.Mock
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   void logDrawerLogoClick() => super.noSuchMethod(
         Invocation.method(
@@ -489,6 +508,7 @@ class MockNavigationAnalytics extends _i2.Mock
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   void logOpenDrawer() => super.noSuchMethod(
         Invocation.method(
@@ -497,6 +517,7 @@ class MockNavigationAnalytics extends _i2.Mock
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   void dispose() => super.noSuchMethod(
         Invocation.method(
@@ -523,6 +544,7 @@ class MockSharezoneContext extends _i2.Mock implements _i29.SharezoneContext {
           Invocation.getter(#api),
         ),
       ) as _i4.SharezoneGateway);
+
   @override
   _i5.Analytics get analytics => (super.noSuchMethod(
         Invocation.getter(#analytics),
@@ -535,6 +557,7 @@ class MockSharezoneContext extends _i2.Mock implements _i29.SharezoneContext {
           Invocation.getter(#analytics),
         ),
       ) as _i5.Analytics);
+
   @override
   _i6.StreamingSharedPreferences get streamingSharedPreferences =>
       (super.noSuchMethod(
@@ -548,6 +571,7 @@ class MockSharezoneContext extends _i2.Mock implements _i29.SharezoneContext {
           Invocation.getter(#streamingSharedPreferences),
         ),
       ) as _i6.StreamingSharedPreferences);
+
   @override
   _i7.SharedPreferences get sharedPreferences => (super.noSuchMethod(
         Invocation.getter(#sharedPreferences),
@@ -560,6 +584,7 @@ class MockSharezoneContext extends _i2.Mock implements _i29.SharezoneContext {
           Invocation.getter(#sharedPreferences),
         ),
       ) as _i7.SharedPreferences);
+
   @override
   _i8.NavigationService get navigationService => (super.noSuchMethod(
         Invocation.getter(#navigationService),
@@ -572,6 +597,7 @@ class MockSharezoneContext extends _i2.Mock implements _i29.SharezoneContext {
           Invocation.getter(#navigationService),
         ),
       ) as _i8.NavigationService);
+
   @override
   void dispose() => super.noSuchMethod(
         Invocation.method(
@@ -598,6 +624,7 @@ class MockSharezoneGateway extends _i2.Mock implements _i4.SharezoneGateway {
           Invocation.getter(#uID),
         ),
       ) as String);
+
   @override
   _i9.UserId get userId => (super.noSuchMethod(
         Invocation.getter(#userId),
@@ -610,6 +637,7 @@ class MockSharezoneGateway extends _i2.Mock implements _i4.SharezoneGateway {
           Invocation.getter(#userId),
         ),
       ) as _i9.UserId);
+
   @override
   _i10.HomeworkGateway get homework => (super.noSuchMethod(
         Invocation.getter(#homework),
@@ -622,6 +650,7 @@ class MockSharezoneGateway extends _i2.Mock implements _i4.SharezoneGateway {
           Invocation.getter(#homework),
         ),
       ) as _i10.HomeworkGateway);
+
   @override
   _i11.BlackboardGateway get blackboard => (super.noSuchMethod(
         Invocation.getter(#blackboard),
@@ -634,6 +663,7 @@ class MockSharezoneGateway extends _i2.Mock implements _i4.SharezoneGateway {
           Invocation.getter(#blackboard),
         ),
       ) as _i11.BlackboardGateway);
+
   @override
   _i12.FileSharingGateway get fileSharing => (super.noSuchMethod(
         Invocation.getter(#fileSharing),
@@ -646,6 +676,7 @@ class MockSharezoneGateway extends _i2.Mock implements _i4.SharezoneGateway {
           Invocation.getter(#fileSharing),
         ),
       ) as _i12.FileSharingGateway);
+
   @override
   _i13.UserGateway get user => (super.noSuchMethod(
         Invocation.getter(#user),
@@ -658,6 +689,7 @@ class MockSharezoneGateway extends _i2.Mock implements _i4.SharezoneGateway {
           Invocation.getter(#user),
         ),
       ) as _i13.UserGateway);
+
   @override
   _i14.References get references => (super.noSuchMethod(
         Invocation.getter(#references),
@@ -670,6 +702,7 @@ class MockSharezoneGateway extends _i2.Mock implements _i4.SharezoneGateway {
           Invocation.getter(#references),
         ),
       ) as _i14.References);
+
   @override
   String get memberID => (super.noSuchMethod(
         Invocation.getter(#memberID),
@@ -682,6 +715,7 @@ class MockSharezoneGateway extends _i2.Mock implements _i4.SharezoneGateway {
           Invocation.getter(#memberID),
         ),
       ) as String);
+
   @override
   _i15.ConnectionsGateway get connectionsGateway => (super.noSuchMethod(
         Invocation.getter(#connectionsGateway),
@@ -694,6 +728,7 @@ class MockSharezoneGateway extends _i2.Mock implements _i4.SharezoneGateway {
           Invocation.getter(#connectionsGateway),
         ),
       ) as _i15.ConnectionsGateway);
+
   @override
   _i16.CourseGateway get course => (super.noSuchMethod(
         Invocation.getter(#course),
@@ -706,6 +741,7 @@ class MockSharezoneGateway extends _i2.Mock implements _i4.SharezoneGateway {
           Invocation.getter(#course),
         ),
       ) as _i16.CourseGateway);
+
   @override
   _i17.SchoolClassGateway get schoolClassGateway => (super.noSuchMethod(
         Invocation.getter(#schoolClassGateway),
@@ -718,6 +754,7 @@ class MockSharezoneGateway extends _i2.Mock implements _i4.SharezoneGateway {
           Invocation.getter(#schoolClassGateway),
         ),
       ) as _i17.SchoolClassGateway);
+
   @override
   _i18.TimetableGateway get timetable => (super.noSuchMethod(
         Invocation.getter(#timetable),
@@ -730,6 +767,7 @@ class MockSharezoneGateway extends _i2.Mock implements _i4.SharezoneGateway {
           Invocation.getter(#timetable),
         ),
       ) as _i18.TimetableGateway);
+
   @override
   _i22.Future<void> dispose() => (super.noSuchMethod(
         Invocation.method(
@@ -757,6 +795,7 @@ class MockUserGateway extends _i2.Mock implements _i13.UserGateway {
           Invocation.getter(#references),
         ),
       ) as _i14.References);
+
   @override
   String get uID => (super.noSuchMethod(
         Invocation.getter(#uID),
@@ -769,24 +808,28 @@ class MockUserGateway extends _i2.Mock implements _i13.UserGateway {
           Invocation.getter(#uID),
         ),
       ) as String);
+
   @override
   _i22.Stream<_i19.AppUser?> get userStream => (super.noSuchMethod(
         Invocation.getter(#userStream),
         returnValue: _i22.Stream<_i19.AppUser?>.empty(),
         returnValueForMissingStub: _i22.Stream<_i19.AppUser?>.empty(),
       ) as _i22.Stream<_i19.AppUser?>);
+
   @override
   _i22.Stream<_i31.AuthUser?> get authUserStream => (super.noSuchMethod(
         Invocation.getter(#authUserStream),
         returnValue: _i22.Stream<_i31.AuthUser?>.empty(),
         returnValueForMissingStub: _i22.Stream<_i31.AuthUser?>.empty(),
       ) as _i22.Stream<_i31.AuthUser?>);
+
   @override
   _i22.Stream<bool> get isSignedInStream => (super.noSuchMethod(
         Invocation.getter(#isSignedInStream),
         returnValue: _i22.Stream<bool>.empty(),
         returnValueForMissingStub: _i22.Stream<bool>.empty(),
       ) as _i22.Stream<bool>);
+
   @override
   _i22.Stream<_i32.DocumentSnapshot<Object?>> get userDocument =>
       (super.noSuchMethod(
@@ -795,12 +838,14 @@ class MockUserGateway extends _i2.Mock implements _i13.UserGateway {
         returnValueForMissingStub:
             _i22.Stream<_i32.DocumentSnapshot<Object?>>.empty(),
       ) as _i22.Stream<_i32.DocumentSnapshot<Object?>>);
+
   @override
   _i22.Stream<_i31.Provider?> get providerStream => (super.noSuchMethod(
         Invocation.getter(#providerStream),
         returnValue: _i22.Stream<_i31.Provider?>.empty(),
         returnValueForMissingStub: _i22.Stream<_i31.Provider?>.empty(),
       ) as _i22.Stream<_i31.Provider?>);
+
   @override
   _i22.Future<_i19.AppUser> get() => (super.noSuchMethod(
         Invocation.method(
@@ -823,6 +868,7 @@ class MockUserGateway extends _i2.Mock implements _i13.UserGateway {
           ),
         )),
       ) as _i22.Future<_i19.AppUser>);
+
   @override
   _i22.Future<void> logOut() => (super.noSuchMethod(
         Invocation.method(
@@ -832,6 +878,7 @@ class MockUserGateway extends _i2.Mock implements _i13.UserGateway {
         returnValue: _i22.Future<void>.value(),
         returnValueForMissingStub: _i22.Future<void>.value(),
       ) as _i22.Future<void>);
+
   @override
   bool isAnonymous() => (super.noSuchMethod(
         Invocation.method(
@@ -841,6 +888,7 @@ class MockUserGateway extends _i2.Mock implements _i13.UserGateway {
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
+
   @override
   _i22.Stream<bool?> isAnonymousStream() => (super.noSuchMethod(
         Invocation.method(
@@ -850,6 +898,7 @@ class MockUserGateway extends _i2.Mock implements _i13.UserGateway {
         returnValue: _i22.Stream<bool?>.empty(),
         returnValueForMissingStub: _i22.Stream<bool?>.empty(),
       ) as _i22.Stream<bool?>);
+
   @override
   _i22.Future<void> linkWithCredential(_i33.AuthCredential? credential) =>
       (super.noSuchMethod(
@@ -860,6 +909,7 @@ class MockUserGateway extends _i2.Mock implements _i13.UserGateway {
         returnValue: _i22.Future<void>.value(),
         returnValueForMissingStub: _i22.Future<void>.value(),
       ) as _i22.Future<void>);
+
   @override
   _i22.Future<void> changeState(_i19.StateEnum? state) => (super.noSuchMethod(
         Invocation.method(
@@ -869,6 +919,7 @@ class MockUserGateway extends _i2.Mock implements _i13.UserGateway {
         returnValue: _i22.Future<void>.value(),
         returnValueForMissingStub: _i22.Future<void>.value(),
       ) as _i22.Future<void>);
+
   @override
   _i22.Future<void> addNotificationToken(String? token) => (super.noSuchMethod(
         Invocation.method(
@@ -878,6 +929,7 @@ class MockUserGateway extends _i2.Mock implements _i13.UserGateway {
         returnValue: _i22.Future<void>.value(),
         returnValueForMissingStub: _i22.Future<void>.value(),
       ) as _i22.Future<void>);
+
   @override
   void removeNotificationToken(String? token) => super.noSuchMethod(
         Invocation.method(
@@ -886,6 +938,7 @@ class MockUserGateway extends _i2.Mock implements _i13.UserGateway {
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   _i22.Future<void> setHomeworkReminderTime(_i1.TimeOfDay? timeOfDay) =>
       (super.noSuchMethod(
@@ -896,6 +949,7 @@ class MockUserGateway extends _i2.Mock implements _i13.UserGateway {
         returnValue: _i22.Future<void>.value(),
         returnValueForMissingStub: _i22.Future<void>.value(),
       ) as _i22.Future<void>);
+
   @override
   _i22.Future<void> updateSettings(_i19.UserSettings? userSettings) =>
       (super.noSuchMethod(
@@ -906,6 +960,7 @@ class MockUserGateway extends _i2.Mock implements _i13.UserGateway {
         returnValue: _i22.Future<void>.value(),
         returnValueForMissingStub: _i22.Future<void>.value(),
       ) as _i22.Future<void>);
+
   @override
   _i22.Future<void> updateSettingsSingleFiled(
     String? fieldName,
@@ -922,6 +977,7 @@ class MockUserGateway extends _i2.Mock implements _i13.UserGateway {
         returnValue: _i22.Future<void>.value(),
         returnValueForMissingStub: _i22.Future<void>.value(),
       ) as _i22.Future<void>);
+
   @override
   _i22.Future<void> updateUserTip(
     _i19.UserTipKey? userTipKey,
@@ -938,6 +994,7 @@ class MockUserGateway extends _i2.Mock implements _i13.UserGateway {
         returnValue: _i22.Future<void>.value(),
         returnValueForMissingStub: _i22.Future<void>.value(),
       ) as _i22.Future<void>);
+
   @override
   void setBlackboardNotifications(bool? enabled) => super.noSuchMethod(
         Invocation.method(
@@ -946,6 +1003,7 @@ class MockUserGateway extends _i2.Mock implements _i13.UserGateway {
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   void setCommentsNotifications(bool? enabled) => super.noSuchMethod(
         Invocation.method(
@@ -954,6 +1012,7 @@ class MockUserGateway extends _i2.Mock implements _i13.UserGateway {
         ),
         returnValueForMissingStub: null,
       );
+
   @override
   _i22.Future<void> changeEmail(String? email) => (super.noSuchMethod(
         Invocation.method(
@@ -963,6 +1022,7 @@ class MockUserGateway extends _i2.Mock implements _i13.UserGateway {
         returnValue: _i22.Future<void>.value(),
         returnValueForMissingStub: _i22.Future<void>.value(),
       ) as _i22.Future<void>);
+
   @override
   _i22.Future<void> addUser({
     required _i19.AppUser? user,
@@ -980,6 +1040,7 @@ class MockUserGateway extends _i2.Mock implements _i13.UserGateway {
         returnValue: _i22.Future<void>.value(),
         returnValueForMissingStub: _i22.Future<void>.value(),
       ) as _i22.Future<void>);
+
   @override
   _i22.Future<bool> deleteUser(_i4.SharezoneGateway? gateway) =>
       (super.noSuchMethod(
@@ -990,6 +1051,7 @@ class MockUserGateway extends _i2.Mock implements _i13.UserGateway {
         returnValue: _i22.Future<bool>.value(false),
         returnValueForMissingStub: _i22.Future<bool>.value(false),
       ) as _i22.Future<bool>);
+
   @override
   _i22.Future<_i20.AppFunctionsResult<bool>> updateUser(
           _i19.AppUser? userData) =>
@@ -1016,6 +1078,7 @@ class MockUserGateway extends _i2.Mock implements _i13.UserGateway {
           ),
         )),
       ) as _i22.Future<_i20.AppFunctionsResult<bool>>);
+
   @override
   _i22.Future<void> dispose() => (super.noSuchMethod(
         Invocation.method(

--- a/app/test_goldens/timetable/timetable_page_test.mocks.dart
+++ b/app/test_goldens/timetable/timetable_page_test.mocks.dart
@@ -58,6 +58,7 @@ class MockSubscriptionService extends _i1.Mock
         returnValue: _i5.Stream<_i6.AppUser?>.empty(),
         returnValueForMissingStub: _i5.Stream<_i6.AppUser?>.empty(),
       ) as _i5.Stream<_i6.AppUser?>);
+
   @override
   _i2.Clock get clock => (super.noSuchMethod(
         Invocation.getter(#clock),
@@ -70,6 +71,7 @@ class MockSubscriptionService extends _i1.Mock
           Invocation.getter(#clock),
         ),
       ) as _i2.Clock);
+
   @override
   _i3.SubscriptionEnabledFlag get isSubscriptionEnabledFlag =>
       (super.noSuchMethod(
@@ -83,6 +85,7 @@ class MockSubscriptionService extends _i1.Mock
           Invocation.getter(#isSubscriptionEnabledFlag),
         ),
       ) as _i3.SubscriptionEnabledFlag);
+
   @override
   bool isSubscriptionActive([_i6.AppUser? appUser]) => (super.noSuchMethod(
         Invocation.method(
@@ -92,6 +95,7 @@ class MockSubscriptionService extends _i1.Mock
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
+
   @override
   _i5.Stream<bool> isSubscriptionActiveStream() => (super.noSuchMethod(
         Invocation.method(
@@ -101,6 +105,7 @@ class MockSubscriptionService extends _i1.Mock
         returnValue: _i5.Stream<bool>.empty(),
         returnValueForMissingStub: _i5.Stream<bool>.empty(),
       ) as _i5.Stream<bool>);
+
   @override
   bool hasFeatureUnlocked(_i4.SharezonePlusFeature? feature) =>
       (super.noSuchMethod(
@@ -111,6 +116,7 @@ class MockSubscriptionService extends _i1.Mock
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
+
   @override
   _i5.Stream<bool> hasFeatureUnlockedStream(
           _i4.SharezonePlusFeature? feature) =>

--- a/lib/abgabe/abgabe_http_api/pubspec.lock
+++ b/lib/abgabe/abgabe_http_api/pubspec.lock
@@ -77,10 +77,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "67d591d602906ef9201caf93452495ad1812bea2074f04e25dbd7c133785821b"
+      sha256: "581bacf68f89ec8792f5e5a0b2c4decd1c948e97ce659dc783688c8a88fbec21"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.7"
+    version: "2.4.8"
   build_runner_core:
     dependency: transitive
     description:

--- a/lib/abgabe/abgabe_http_api/pubspec.yaml
+++ b/lib/abgabe/abgabe_http_api/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   dio: ^5.3.2
 
 dev_dependencies:
-  build_runner: ^2.4.7
+  build_runner: ^2.4.8
   built_value_generator: ^8.4.4
   test: ^1.20.2
   sharezone_lints:

--- a/lib/filesharing/files_usecases/pubspec.lock
+++ b/lib/filesharing/files_usecases/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: "1a5e13736d59235ce0139621b4bbe29bc89839e202409081bc667eb3cd20674c"
+      sha256: fe4c077084ddda88f327dc1c96d16631cd68d4948644593fcbcd911c2c89e2fa
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.5"
+    version: "1.3.23"
   app_functions:
     dependency: transitive
     description:
@@ -75,10 +75,10 @@ packages:
     dependency: transitive
     description:
       name: cloud_firestore
-      sha256: "21cffe06a212015950010ecb9adbf1eb9acaf294f2bd159bde7980aee37c997b"
+      sha256: "6f6a9e7f1c68f34ffe159c911a290fa7caf1a09b8a88aa1534c65f0246953970"
       url: "https://pub.dev"
     source: hosted
-    version: "4.9.0"
+    version: "4.15.6"
   cloud_firestore_helper:
     dependency: transitive
     description:
@@ -90,42 +90,42 @@ packages:
     dependency: transitive
     description:
       name: cloud_firestore_platform_interface
-      sha256: "5749b81aea93afdce220e02d34369162010d210011054ac494b2c38c4e9ebeb7"
+      sha256: "4e92549af19f0d2eec7e379ca44f909caef8eb52295a0cde5467b018cfae0378"
       url: "https://pub.dev"
     source: hosted
-    version: "5.16.0"
+    version: "6.1.7"
   cloud_firestore_web:
     dependency: transitive
     description:
       name: cloud_firestore_web
-      sha256: fef99ad0599e983092adb1bb01f14a596dba601a7a8efaaffd7b2721d64e2c51
+      sha256: "2b34cff977da11a4822151d967c5e6ce62640cbcb56d6e52a46382d2316350ac"
       url: "https://pub.dev"
     source: hosted
-    version: "3.7.0"
+    version: "3.10.6"
   cloud_functions:
     dependency: transitive
     description:
       name: cloud_functions
-      sha256: "6c5ce6c78bcf92b422b58e76dc33cd46b16cf421fc4d439fc77b7d44a74dc80d"
+      sha256: "44a88d02b1b1291bb291b8de756ff3f02d3a0c5c68dfc1c42c83c1529ba0416b"
       url: "https://pub.dev"
     source: hosted
-    version: "4.4.0"
+    version: "4.6.6"
   cloud_functions_platform_interface:
     dependency: transitive
     description:
       name: cloud_functions_platform_interface
-      sha256: "2d6bf40c9b9db65f89e97f0e74833794191df4398f7e92a6b1dd3201ec70cfb7"
+      sha256: "9b02f827013f37824de5ec02bd2a1838e47c899edd39df642d1437c68b6f1c3c"
       url: "https://pub.dev"
     source: hosted
-    version: "5.5.0"
+    version: "5.5.17"
   cloud_functions_web:
     dependency: transitive
     description:
       name: cloud_functions_web
-      sha256: "3937c217f90a51e251c37fc15a4c1be563b50d1f4268284f3ebf83ed70ba1ff8"
+      sha256: "9ccd76057f2f5e20b8c2dc19e785993dd83edef1a9f49472cf0e12268da6781b"
       url: "https://pub.dev"
     source: hosted
-    version: "4.6.0"
+    version: "4.7.0"
   collection:
     dependency: "direct main"
     description:
@@ -294,90 +294,90 @@ packages:
     dependency: transitive
     description:
       name: firebase_auth
-      sha256: "02d9cdf1305f0c22cde492802598a13a1975ec8aa05bf608be799f939352cbe8"
+      sha256: "6d8b4455524e2a619a135169a0ae817778d4acf56172188acae85f69f5e67185"
       url: "https://pub.dev"
     source: hosted
-    version: "4.8.0"
+    version: "4.17.6"
   firebase_auth_platform_interface:
     dependency: transitive
     description:
       name: firebase_auth_platform_interface
-      sha256: "19f8d0762544b72471b85bb56469448c3dc9f98b8b8574f744873ec18e04e18c"
+      sha256: "3eed984830f610f43164d539ec6228820cf4936ab6ef491e1afcfaca80143c84"
       url: "https://pub.dev"
     source: hosted
-    version: "6.17.0"
+    version: "7.1.6"
   firebase_auth_web:
     dependency: transitive
     description:
       name: firebase_auth_web
-      sha256: ae01b306ae03856c1f0682796ea87bacaab72da44e4b728271c806db99620712
+      sha256: fcf4718abc722131218de3b84772d83019be48c9211dbd5998aece716c52ff31
       url: "https://pub.dev"
     source: hosted
-    version: "5.7.0"
+    version: "5.9.6"
   firebase_core:
     dependency: transitive
     description:
       name: firebase_core
-      sha256: c78132175edda4bc532a71e01a32964e4b4fcf53de7853a422d96dac3725f389
+      sha256: "797379ea206eaeeb62499775de812761493d0692890fdc7f90b6183a3369176d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.15.1"
+    version: "2.25.5"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
-      sha256: b63e3be6c96ef5c33bdec1aab23c91eb00696f6452f0519401d640938c94cba2
+      sha256: c437ae5d17e6b5cc7981cf6fd458a5db4d12979905f9aafd1fea930428a9fe63
       url: "https://pub.dev"
     source: hosted
-    version: "4.8.0"
+    version: "5.0.0"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
-      sha256: "4cf4d2161530332ddc3c562f19823fb897ff37a9a774090d28df99f47370e973"
+      sha256: c8e1d59385eee98de63c92f961d2a7062c5d9a65e7f45bdc7f1b0b205aab2492
       url: "https://pub.dev"
     source: hosted
-    version: "2.7.0"
+    version: "2.11.5"
   firebase_crashlytics:
     dependency: transitive
     description:
       name: firebase_crashlytics
-      sha256: fd9e1a1cb7cce3f9dd2358d8363d235f25f056981e23a333db1e57eca693913f
+      sha256: "0126fa101b74fb981796b3e6f47ccf7fc40237ec918327aaec7c0a06fd1bb4c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.5"
+    version: "3.4.16"
   firebase_crashlytics_platform_interface:
     dependency: transitive
     description:
       name: firebase_crashlytics_platform_interface
-      sha256: "0d19ef23cf7a917a357d2eb1807338ec536ec3232e729ebd769f5bb2aba9e085"
+      sha256: cdfa0a20d66e1b32de542883c0ddf651ee9b66b12cebf73067e4d2cdc0865d17
       url: "https://pub.dev"
     source: hosted
-    version: "3.6.5"
+    version: "3.6.23"
   firebase_storage:
     dependency: transitive
     description:
       name: firebase_storage
-      sha256: "11423ac63c1ec566069c80b1d01bc3c9e12a8f106bbc4ba77fa150afb88488a3"
+      sha256: "261763ebb2722abb8d3c702f467a9efb1f4ac8978a94c03850b80cfa3009c400"
       url: "https://pub.dev"
     source: hosted
-    version: "11.2.6"
+    version: "11.6.7"
   firebase_storage_platform_interface:
     dependency: transitive
     description:
       name: firebase_storage_platform_interface
-      sha256: "2a8ee7b8a06ee5201f9a116db6972ba0020e3a314a5065acdcb616f4d6c99771"
+      sha256: "41e5832d930f668a62aa4fd3dc9778af3a301297170f549b882dad4c5b7d3bc7"
       url: "https://pub.dev"
     source: hosted
-    version: "4.4.5"
+    version: "5.1.10"
   firebase_storage_web:
     dependency: transitive
     description:
       name: firebase_storage_web
-      sha256: bd110daa180dc9c89abb490c8a330571e103291b348358d320f5b20a61cd46fc
+      sha256: "5eac3e415e01384e8a5fc92510db61fee3001d7008fa0209ff2290bcd051b6c7"
       url: "https://pub.dev"
     source: hosted
-    version: "3.6.6"
+    version: "3.7.1"
   flare_flutter:
     dependency: transitive
     description:
@@ -1012,66 +1012,66 @@ packages:
     dependency: "direct main"
     description:
       name: url_launcher
-      sha256: "781bd58a1eb16069412365c98597726cd8810ae27435f04b3b4d3a470bacd61e"
+      sha256: "0ecc004c62fd3ed36a2ffcbe0dd9700aee63bd7532d0b642a488b1ec310f492e"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.12"
+    version: "6.2.5"
   url_launcher_android:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "3dd2388cc0c42912eee04434531a26a82512b9cb1827e0214430c9bcbddfe025"
+      sha256: d4ed0711849dd8e33eb2dd69c25db0d0d3fdc37e0a62e629fe32f57a22db2745
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.38"
+    version: "6.3.0"
   url_launcher_ios:
     dependency: transitive
     description:
       name: url_launcher_ios
-      sha256: "9af7ea73259886b92199f9e42c116072f05ff9bea2dcb339ab935dfc957392c2"
+      sha256: "9149d493b075ed740901f3ee844a38a00b33116c7c5c10d7fb27df8987fb51d5"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.4"
+    version: "6.2.5"
   url_launcher_linux:
     dependency: transitive
     description:
       name: url_launcher_linux
-      sha256: "207f4ddda99b95b4d4868320a352d374b0b7e05eefad95a4a26f57da413443f5"
+      sha256: ab360eb661f8879369acac07b6bb3ff09d9471155357da8443fd5d3cf7363811
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.1.1"
   url_launcher_macos:
     dependency: transitive
     description:
       name: url_launcher_macos
-      sha256: "1c4fdc0bfea61a70792ce97157e5cc17260f61abbe4f39354513f39ec6fd73b1"
+      sha256: b7244901ea3cf489c5335bdacda07264a6e960b1c1b1a9f91e4bc371d9e68234
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.6"
+    version: "3.1.0"
   url_launcher_platform_interface:
     dependency: transitive
     description:
       name: url_launcher_platform_interface
-      sha256: bfdfa402f1f3298637d71ca8ecfe840b4696698213d5346e9d12d4ab647ee2ea
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.3.2"
   url_launcher_web:
     dependency: transitive
     description:
       name: url_launcher_web
-      sha256: cc26720eefe98c1b71d85f9dc7ef0cada5132617046369d9dc296b3ecaa5cbb4
+      sha256: fff0932192afeedf63cdd50ecbb1bc825d31aed259f02bb8dba0f3b729a5e88b
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.18"
+    version: "2.2.3"
   url_launcher_windows:
     dependency: transitive
     description:
       name: url_launcher_windows
-      sha256: "7967065dd2b5fccc18c653b97958fdf839c5478c28e767c61ee879f4e7882422"
+      sha256: ecf9725510600aa2bb6d7ddabe16357691b6d2805f66216a97d1b881e21beff7
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.7"
+    version: "3.1.1"
   uuid:
     dependency: transitive
     description:
@@ -1176,6 +1176,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "4188706108906f002b3a293509234588823c8c979dc83304e229ff400c996b05"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.2"
   win32:
     dependency: transitive
     description:
@@ -1210,4 +1218,4 @@ packages:
     version: "6.3.0"
 sdks:
   dart: ">=3.2.3 <4.0.0"
-  flutter: ">=3.16.0"
+  flutter: ">=3.16.6"

--- a/lib/holidays/pubspec.lock
+++ b/lib/holidays/pubspec.lock
@@ -91,10 +91,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "67d591d602906ef9201caf93452495ad1812bea2074f04e25dbd7c133785821b"
+      sha256: "581bacf68f89ec8792f5e5a0b2c4decd1c948e97ce659dc783688c8a88fbec21"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.7"
+    version: "2.4.8"
   build_runner_core:
     dependency: transitive
     description:

--- a/lib/holidays/pubspec.yaml
+++ b/lib/holidays/pubspec.yaml
@@ -36,7 +36,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   mockito: ^5.4.4
-  build_runner: ^2.4.7
+  build_runner: ^2.4.8
   built_value_generator: ^8.1.1
   sharezone_lints:
     path: ../sharezone_lints

--- a/lib/sharezone_plus/stripe_checkout_session/pubspec.lock
+++ b/lib/sharezone_plus/stripe_checkout_session/pubspec.lock
@@ -77,10 +77,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "67d591d602906ef9201caf93452495ad1812bea2074f04e25dbd7c133785821b"
+      sha256: "581bacf68f89ec8792f5e5a0b2c4decd1c948e97ce659dc783688c8a88fbec21"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.7"
+    version: "2.4.8"
   build_runner_core:
     dependency: transitive
     description:

--- a/lib/sharezone_plus/stripe_checkout_session/pubspec.yaml
+++ b/lib/sharezone_plus/stripe_checkout_session/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   retry: ^3.1.2
 
 dev_dependencies:
-  build_runner: ^2.4.7
+  build_runner: ^2.4.8
   mockito: ^5.4.4
   test: ^1.23.1
   sharezone_lints:


### PR DESCRIPTION
Fixes:

> Your current `analyzer` version may not fully support your current SDK version.
>
>Analyzer language version: 3.1.0
SDK language version: 3.3.0
>
>Please update to the latest `analyzer` version (6.4.1) by running
`flutter packages upgrade`.
>
>If you are not getting the latest version by running the above command, you
can try adding a constraint like the following to your pubspec to start
diagnosing why you can't get the latest version:
>
> dev_dependencies:
  analyzer: ^6.4.1