### PR TITLE
Remove anonymous option from feedback page

### DIFF
--- a/app/lib/feedback/feedback_box_page.dart
+++ b/app/lib/feedback/feedback_box_page.dart
@@ -67,7 +67,7 @@ class FeedbackPageBody extends StatelessWidget {
               const _DislikeField(),
               const _MissingField(),
               const _HeardFromField(),
-              const _AnonymousCheckbox(),
+              const _ContactInformation(),
               const FeedbackPageSubmitButton(key: Key("submitButton")),
               const SizedBox(height: _padding)
             ],
@@ -94,59 +94,20 @@ class FeedbackPageBody extends StatelessWidget {
 //   }
 // }
 
-class _AnonymousCheckbox extends StatelessWidget {
-  const _AnonymousCheckbox();
+class _ContactInformation extends StatelessWidget {
+  const _ContactInformation();
 
   @override
   Widget build(BuildContext context) {
     final bloc = BlocProvider.of<FeedbackBloc>(context);
-    return StreamBuilder<bool>(
-      stream: bloc.isAnonymous,
-      builder: (context, isAnonymousSnapshot) {
-        final isAnonymous = isAnonymousSnapshot.data ?? false;
-        return Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            const Divider(),
-            const SizedBox(height: 8),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 0),
-              child: CheckboxListTile(
-                value: isAnonymous,
-                onChanged: (v) {
-                  if (v == null) return;
-                  bloc.changeIsAnonymous(v);
-                },
-                secondary: const Icon(Icons.security),
-                title: const Text(
-                  "Ich möchte mein Feedback anonym abschicken",
-                ),
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 4),
-              child: AnimatedSwitcher(
-                duration: const Duration(milliseconds: 250),
-                child: isAnonymous
-                    ? const Text(
-                        "Bitte beachte, dass wenn du einen Fehler bei dir melden möchtest, wir dir nicht weiterhelfen können, wenn du das Feedback anonym abschickst.",
-                        style: TextStyle(fontSize: 12, color: Colors.grey),
-                      )
-                    : Padding(
-                        padding: const EdgeInsets.only(top: 8),
-                        child: _FeedbackTextField(
-                          labelText: "Kontaktdaten für Rückfragen",
-                          icon: const Icon(Icons.question_answer),
-                          onChanged: bloc.changeContactOptions,
-                          stream: bloc.contactOptions,
-                        ),
-                      ),
-              ),
-            ),
-            SizedBox(height: isAnonymous ? 8 : 16),
-          ],
-        );
-      },
+    return Padding(
+      padding: const EdgeInsets.only(top: 8),
+      child: _FeedbackTextField(
+        labelText: "Kontaktdaten für Rückfragen",
+        icon: const Icon(Icons.question_answer),
+        onChanged: bloc.changeContactOptions,
+        stream: bloc.contactOptions,
+      ),
     );
   }
 }

--- a/app/test/feedback/feedback_bloc_test.dart
+++ b/app/test/feedback/feedback_bloc_test.dart
@@ -35,7 +35,6 @@ void main() {
     MockPlatformInformationRetriever platformInformationRetriever;
     late FeedbackBloc bloc;
     UserFeedback? expectedResponseWithIdentifiableInfo;
-    UserFeedback? expectedAnonymousResponse;
     late MockFeedbackAnalytics analytics;
 
     setUp(() {
@@ -60,32 +59,9 @@ void main() {
             appName: "appName",
             packageName: "packageName",
           ));
-
-      expectedAnonymousResponse = UserFeedback.create().copyWith(
-        rating: rating,
-        likes: likes,
-        dislikes: dislikes,
-        missing: missing,
-        heardFrom: heardFrom,
-        uid: "",
-        userContactInformation: "",
-        deviceInformation: null,
-      );
     });
 
-    test(
-        "Feedback is send with no identifiable information if the anonymous option is enable",
-        () async {
-      fillInAllFields(bloc);
-      bloc.changeIsAnonymous(true);
-
-      await bloc.submit();
-
-      expect(api.wasOnlyInvokedWith(expectedAnonymousResponse), true);
-    });
-    test(
-        "Feedback is send with uid, contact and device information, when not anonymous",
-        () async {
+    test("Feedback is send with uid, contact and device information", () async {
       writeRdmValues(bloc);
       fillInAllFields(bloc);
 
@@ -239,7 +215,6 @@ void fillInAllFields(FeedbackBloc bloc) {
   bloc.changeDislike(dislikes);
   bloc.changeMissing(missing);
   bloc.changeHeardFrom(heardFrom);
-  bloc.changeIsAnonymous(false);
   bloc.changeContactOptions(contactInfo);
 }
 

--- a/app/test/feedback/feedback_page_test.dart
+++ b/app/test/feedback/feedback_page_test.dart
@@ -36,7 +36,6 @@ void main() {
     MockPlatformInformationRetriever platformInformationRetriever;
     late FeedbackBloc bloc;
     UserFeedback? expectedResponseWithIdentifiableInfo;
-    UserFeedback? expectedAnonymousResponse;
 
     setUp(() {
       api = MockFeedbackApi();
@@ -58,16 +57,6 @@ void main() {
             appName: "appName",
             packageName: "packageName",
           ));
-
-      expectedAnonymousResponse = UserFeedback.create().copyWith(
-        likes: likes,
-        dislikes: dislikes,
-        missing: missing,
-        heardFrom: heardFrom,
-        uid: "",
-        userContactInformation: "",
-        deviceInformation: null,
-      );
     });
 
     tearDown(() {
@@ -87,19 +76,7 @@ void main() {
       );
     }
 
-    test(
-        "Feedback is send with no identifiable information if the anonymous option is enable",
-        () async {
-      fillInAllFields(bloc);
-      bloc.changeIsAnonymous(true);
-
-      await bloc.submit();
-
-      expect(api.wasOnlyInvokedWith(expectedAnonymousResponse), true);
-    });
-    test(
-        "Feedback is send with uid, contact and device information, when not anonymous",
-        () async {
+    test("Feedback is send with uid, contact and device information", () async {
       writeRdmValues(bloc);
       fillInAllFields(bloc);
 
@@ -146,7 +123,6 @@ void fillInAllFields(FeedbackBloc bloc) {
   bloc.changeDislike(dislikes);
   bloc.changeMissing(missing);
   bloc.changeHeardFrom(heardFrom);
-  bloc.changeIsAnonymous(false);
   bloc.changeContactOptions(contactInfo);
 }
 


### PR DESCRIPTION
Since plenty of users asking for support in the feedback form but checking the anonymous option, we can't help them because we don't have their user ID. Additionally, we can't send them a thank-you message.