### PR TITLE
Fix settings page for dark mode

### DIFF
--- a/lib/sharezone_widgets/lib/src/theme/brightness/dark_theme.dart
+++ b/lib/sharezone_widgets/lib/src/theme/brightness/dark_theme.dart
@@ -51,6 +51,7 @@ ThemeData getDarkTheme({
     bottomSheetTheme: _bottomSheetTheme,
     dialogTheme: _dialogTheme,
     listTileTheme: ListTileThemeData(
+      iconColor: const Color(0xFFC1C7CE),
       shape: listTileShape,
     ),
     colorScheme: ColorScheme.fromSeed(


### PR DESCRIPTION
![image](https://github.com/SharezoneApp/sharezone-app/assets/24459435/4679a7a8-a28a-4f25-a248-dfb4434b6cf6)

Test is in #1389 

The issue was that `Theme.of(context).listTileTheme.iconColor` was `null` for the dark mode.