### PR TITLE
Ignore `Pods` folders for license headers

### DIFF
--- a/bin/source_of_truth/commands_source_of_truth.yaml
+++ b/bin/source_of_truth/commands_source_of_truth.yaml
@@ -23,8 +23,8 @@
 
 # Note: The directory at the end of the command is missing.
 # The programs using these commands need to add it themselves.
-check_license_headers: addlicense -check -c "Sharezone UG (haftungsbeschränkt)" -f header_template.txt -ignore "**/GeneratedPluginRegistrant.swift" -ignore "**/**.g.dart" -ignore "**/**.mocks.dart"
-add_license_headers: addlicense -c "Sharezone UG (haftungsbeschränkt)" -f header_template.txt -ignore "**/GeneratedPluginRegistrant.swift" -ignore "**/**.g.dart" -ignore "**/**.mocks.dart"
+check_license_headers: addlicense -check -c "Sharezone UG (haftungsbeschränkt)" -f header_template.txt -ignore "**/GeneratedPluginRegistrant.swift" -ignore "**/**.g.dart" -ignore "**/**.mocks.dart" -ignore "**/macos/Pods/**" -ignore "**/ios/Pods/**"
+add_license_headers: addlicense -c "Sharezone UG (haftungsbeschränkt)" -f header_template.txt -ignore "**/GeneratedPluginRegistrant.swift" -ignore "**/**.g.dart" -ignore "**/**.mocks.dart" -ignore "**/macos/Pods/**" -ignore "**/ios/Pods/**"
 format_action_files: prettier ".github/workflows/" --write
 check_format_action_files: prettier ".github/workflows/" --check
 format_markdown_files: prettier "**/*.md" --write


### PR DESCRIPTION
![image](https://github.com/SharezoneApp/sharezone-app/assets/24459435/11b82dce-f639-4fea-9adb-59fba804510e)

The PR adds to ignore the `Pods` folder in `macos` and `ios`. Fixes the `permission denied` error when executing one of `sz license-headers` commands.