### PR TITLE
Replace reclaim.ai with cal.com

### DIFF
--- a/website/firebase.json
+++ b/website/firebase.json
@@ -201,7 +201,7 @@
       },
       {
         "source": "/sharezone-plus-video-call-support",
-        "destination": "https://app.reclaim.ai/m/sharezone/plus-support",
+        "destination": "https://cal.com/sharezone/plus-support",
         "type": 302
       }
     ],


### PR DESCRIPTION
Switching from Reclaim.ai to cal.com because cal.com:

* Is open source: https://github.com/calcom/cal.com
* More privacy-friendly (but still hosted in the US)
* Has the option for self-hosting
* Still have the option to connect multiple calendars (my private & Sharezone calendar)
* Has the option to set fields via the URL (this allows us to directly set the Sharezone User ID)

Copied from https://github.com/SharezoneApp/website/pull/60 (somehow this commit was missing when I copied the website to our `sharezone-app` repo)