### PR TITLE
Center to the advantage tiles in the sign up process

### DIFF
--- a/app/lib/onboarding/sign_up/pages/advantages.dart
+++ b/app/lib/onboarding/sign_up/pages/advantages.dart
@@ -19,32 +19,38 @@ class _Advantages extends StatelessWidget {
       body: Center(
         child: SingleChildScrollView(
           padding: const EdgeInsets.all(16),
-          child: AnimationLimiter(
-            child: Column(
-              children: AnimationConfiguration.toStaggeredList(
-                duration: const Duration(milliseconds: 300),
-                childAnimationBuilder: (widget) => SlideAnimation(
-                  verticalOffset: 20,
-                  child: FadeInAnimation(child: widget),
+          child: Column(
+            children: <Widget>[
+              SizedBox(
+                height: 100,
+                child: PlatformSvg.asset(
+                  "assets/icons/strong.svg",
+                  fit: BoxFit.fitHeight,
                 ),
-                children: <Widget>[
-                  SizedBox(
-                    height: 100,
-                    child: PlatformSvg.asset(
-                      "assets/icons/strong.svg",
-                      fit: BoxFit.fitHeight,
-                    ),
-                  ),
-                  const SizedBox(height: 10),
-                  const Text("Vorteile von Sharezone",
-                      style: TextStyle(fontSize: 26)),
-                  const _AdvantageAllInOne(),
-                  const _AdvantageCloud(),
-                  const _AdvantageSaveTime(),
-                  const _AdvantageNotifications(),
-                ],
               ),
-            ),
+              const SizedBox(height: 10),
+              const Text("Vorteile von Sharezone",
+                  style: TextStyle(fontSize: 26)),
+              MaxWidthConstraintBox(
+                maxWidth: 650,
+                child: Column(
+                  children: AnimationConfiguration.toStaggeredList(
+                    delay: const Duration(milliseconds: 100),
+                    duration: const Duration(milliseconds: 1000),
+                    childAnimationBuilder: (widget) => SlideAnimation(
+                      verticalOffset: 20,
+                      child: FadeInAnimation(child: widget),
+                    ),
+                    children: const [
+                      _AdvantageAllInOne(),
+                      _AdvantageCloud(),
+                      _AdvantageSaveTime(),
+                      _AdvantageNotifications(),
+                    ],
+                  ),
+                ),
+              )
+            ],
           ),
         ),
       ),

--- a/app/lib/onboarding/sign_up/pages/data_protection_overview.dart
+++ b/app/lib/onboarding/sign_up/pages/data_protection_overview.dart
@@ -22,29 +22,33 @@ class _DataProtectionOverview extends StatelessWidget {
         child: SingleChildScrollView(
           padding: const EdgeInsets.all(16),
           child: SafeArea(
-            child: AnimationLimiter(
-              child: Column(
-                children: AnimationConfiguration.toStaggeredList(
-                  duration: const Duration(milliseconds: 300),
-                  childAnimationBuilder: (widget) => SlideAnimation(
-                    verticalOffset: 20,
-                    child: FadeInAnimation(child: widget),
+            child: Column(children: [
+              const _DataProtectionLockAnimation(),
+              const SizedBox(height: 10),
+              const Text("Datenschutz", style: TextStyle(fontSize: 26)),
+              MaxWidthConstraintBox(
+                maxWidth: 600,
+                child: Column(
+                  children: AnimationConfiguration.toStaggeredList(
+                    delay: const Duration(milliseconds: 100),
+                    duration: const Duration(milliseconds: 1000),
+                    childAnimationBuilder: (widget) => SlideAnimation(
+                      verticalOffset: 20,
+                      child: FadeInAnimation(child: widget),
+                    ),
+                    children: [
+                      const _DataProtectionServerLocation(),
+                      const _DataProtectionTLS(),
+                      const _DataProtectionAES(),
+                      const _DataProtectionAnonymousSignIn(),
+                      const _DataProtectionISO(),
+                      const _DataProtectionSOC(),
+                      const _DataProtectionDeleteData(),
+                    ],
                   ),
-                  children: const <Widget>[
-                    _DataProtectionLockAnimation(),
-                    SizedBox(height: 10),
-                    Text("Datenschutz", style: TextStyle(fontSize: 26)),
-                    _DataProtectionServerLocation(),
-                    _DataProtectionTLS(),
-                    _DataProtectionAES(),
-                    _DataProtectionAnonymousSignIn(),
-                    _DataProtectionISO(),
-                    _DataProtectionSOC(),
-                    _DataProtectionDeleteData(),
-                  ],
                 ),
               ),
-            ),
+            ]),
           ),
         ),
       ),

--- a/app/lib/onboarding/sign_up/sign_up_page.dart
+++ b/app/lib/onboarding/sign_up/sign_up_page.dart
@@ -116,9 +116,8 @@ class _AdvancedListTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final width = MediaQuery.of(context).size.width;
     return Padding(
-      padding: EdgeInsets.only(left: width > 720 ? width * 0.125 : 0, top: 16),
+      padding: const EdgeInsets.only(top: 16),
       child: ListTile(
         leading: leading,
         title: Text(title, style: const TextStyle(fontSize: 22)),


### PR DESCRIPTION
Fixed an issue where the advantage tiles weren't centered on larger screens.

## Before

![image](https://github.com/SharezoneApp/sharezone-app/assets/24459435/5b1396f3-b8ec-49dd-a7b0-4eb77f05b086)


## After

![image](https://github.com/SharezoneApp/sharezone-app/assets/24459435/ed2284df-34a9-4c79-9f97-86ff37011480)
