### PR TITLE
Remove contact information field from feedback box

### DIFF
--- a/app/lib/feedback/feedback_box_page.dart
+++ b/app/lib/feedback/feedback_box_page.dart
@@ -161,46 +161,11 @@ class FeedbackPageBody extends StatelessWidget {
               const _DislikeField(),
               const _MissingField(),
               const _HeardFromField(),
-              const _ContactInformation(),
               const FeedbackPageSubmitButton(key: Key("submitButton")),
               const SizedBox(height: _padding)
             ],
           ),
         ),
-      ),
-    );
-  }
-}
-
-// class _FeedbackBoxWallpaper extends StatelessWidget {
-//   const _FeedbackBoxWallpaper({Key key}) : super(key: key);
-
-//   @override
-//   Widget build(BuildContext context) {
-//     return ConstrainedBox(
-//       constraints: BoxConstraints(maxHeight: 400),
-//       child: Image.asset(
-//         "assets/wallpaper/feedback-box.png",
-//         width: MediaQuery.of(context).size.width,
-//         fit: BoxFit.fitWidth,
-//       ),
-//     );
-//   }
-// }
-
-class _ContactInformation extends StatelessWidget {
-  const _ContactInformation();
-
-  @override
-  Widget build(BuildContext context) {
-    final bloc = BlocProvider.of<FeedbackBloc>(context);
-    return Padding(
-      padding: const EdgeInsets.only(top: 8),
-      child: _FeedbackTextField(
-        labelText: "Kontaktdaten für Rückfragen",
-        icon: const Icon(Icons.question_answer),
-        onChanged: bloc.changeContactOptions,
-        stream: bloc.contactOptions,
       ),
     );
   }

--- a/app/lib/feedback/src/bloc/feedback_bloc.dart
+++ b/app/lib/feedback/src/bloc/feedback_bloc.dart
@@ -30,7 +30,6 @@ class FeedbackBloc extends BlocBase {
   final _dislikeSubject = BehaviorSubject<String?>();
   final _missingSubject = BehaviorSubject<String?>();
   final _heardFromSubject = BehaviorSubject<String?>();
-  final _contactOptions = BehaviorSubject<String?>();
 
   FeedbackBloc(this._api, this._cache, this._platformInformationRetriever,
       this.uid, this.feedbackAnalytics);
@@ -40,20 +39,17 @@ class FeedbackBloc extends BlocBase {
   Function(String?) get changeDislike => _dislikeSubject.sink.add;
   Function(String?) get changeMissing => _missingSubject.sink.add;
   Function(String?) get changeHeardFrom => _heardFromSubject.sink.add;
-  Function(String?) get changeContactOptions => _contactOptions.sink.add;
 
   ValueStream<double?> get rating => _ratingSubject;
   ValueStream<String?> get like => _likeSubject;
   ValueStream<String?> get dislike => _dislikeSubject;
   ValueStream<String?> get missing => _missingSubject;
   ValueStream<String?> get heardFrom => _heardFromSubject;
-  ValueStream<String?> get contactOptions => _contactOptions;
 
   /// Submits the feedback given to the [FeedbackApi].
   ///
-  /// Will add uid, contact information and platform information to the
-  /// [UserFeedback] and platform information will be read from the
-  /// [PlatformInformationRetriever].
+  /// Will add uid and platform information to the [UserFeedback] and platform
+  /// information will be read from the [PlatformInformationRetriever].
   ///
   /// Throws a [CoolDownException] if
   /// [FeedbackCache.hasFeedbackSubmissionCoolDown] returns true.
@@ -75,7 +71,6 @@ class FeedbackBloc extends BlocBase {
     final dislikes = _dislikeSubject.valueOrNull;
     final missing = _missingSubject.valueOrNull;
     final heardFrom = _heardFromSubject.valueOrNull;
-    final userContactInformation = _contactOptions.valueOrNull;
 
     await _platformInformationRetriever.init();
 
@@ -93,7 +88,6 @@ class FeedbackBloc extends BlocBase {
       missing: missing,
       heardFrom: heardFrom,
       uid: uid,
-      userContactInformation: userContactInformation,
       deviceInformation: deviceInfo,
     );
 
@@ -114,12 +108,10 @@ class FeedbackBloc extends BlocBase {
     changeMissing(null);
     changeLike(null);
     changeHeardFrom(null);
-    changeContactOptions(null);
   }
 
   @override
   void dispose() {
-    _contactOptions.close();
     _dislikeSubject.close();
     _heardFromSubject.close();
     _likeSubject.close();

--- a/app/test/feedback/feedback_bloc_test.dart
+++ b/app/test/feedback/feedback_bloc_test.dart
@@ -25,7 +25,6 @@ const dislikes = "dislikes";
 const missing = "missing";
 const heardFrom = "heardFrom";
 const uid = "uidABCDEF123891a";
-const contactInfo = "Instagram: @jsan_l";
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -54,14 +53,13 @@ void main() {
           missing: missing,
           heardFrom: heardFrom,
           uid: uid,
-          userContactInformation: contactInfo,
           deviceInformation: FeedbackDeviceInformation.create().copyWith(
             appName: "appName",
             packageName: "packageName",
           ));
     });
 
-    test("Feedback is send with uid, contact and device information", () async {
+    test("Feedback is send with uid and device information", () async {
       writeRdmValues(bloc);
       fillInAllFields(bloc);
 
@@ -97,8 +95,7 @@ void main() {
       expect(analytics.feedbackSentLogged, true);
     });
 
-    test(
-        'submits Feedback if at least one of the text fields (except contact info) was filled out',
+    test('submits Feedback if at least one of the text fields was filled out',
         () async {
       final fillOutTextFieldActions = [
         [() => bloc.changeLike('Sehr toller Hecht hier'), 'Mag ich'],
@@ -170,18 +167,6 @@ void main() {
       expect(exec, throwsA(isA<EmptyFeedbackException>()));
       expect(api.wasInvoked, false);
     });
-
-    test('throws EmptyFeedback if only contact info is given', () {
-      // Arrange
-      bloc.changeContactOptions('Twitter: @realdonaldtrump 🐒');
-
-      // Act
-      void exec() => bloc.submit();
-
-      // Assert
-      expect(exec, throwsA(isA<EmptyFeedbackException>()));
-      expect(api.wasInvoked, false);
-    });
   });
 }
 
@@ -215,7 +200,6 @@ void fillInAllFields(FeedbackBloc bloc) {
   bloc.changeDislike(dislikes);
   bloc.changeMissing(missing);
   bloc.changeHeardFrom(heardFrom);
-  bloc.changeContactOptions(contactInfo);
 }
 
 void writeRdmValues(FeedbackBloc bloc) {
@@ -224,5 +208,4 @@ void writeRdmValues(FeedbackBloc bloc) {
   bloc.changeDislike(random.randomString(10));
   bloc.changeMissing(random.randomString(10));
   bloc.changeHeardFrom(random.randomString(10));
-  bloc.changeContactOptions(random.randomString(10));
 }

--- a/app/test/feedback/feedback_page_test.dart
+++ b/app/test/feedback/feedback_page_test.dart
@@ -26,7 +26,6 @@ const dislikes = "dislikes";
 const missing = "missing";
 const heardFrom = "heardFrom";
 const uid = "uidABCDEF123891a";
-const contactInfo = "Instagram: @jsan_l";
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -52,7 +51,6 @@ void main() {
           missing: missing,
           heardFrom: heardFrom,
           uid: uid,
-          userContactInformation: contactInfo,
           deviceInformation: FeedbackDeviceInformation.create().copyWith(
             appName: "appName",
             packageName: "packageName",
@@ -76,7 +74,7 @@ void main() {
       );
     }
 
-    test("Feedback is send with uid, contact and device information", () async {
+    test("Feedback is send with uid and device information", () async {
       writeRdmValues(bloc);
       fillInAllFields(bloc);
 
@@ -113,7 +111,6 @@ void main() {
       expect(find.text(dislikes), findsOneWidget);
       expect(find.text(missing), findsOneWidget);
       expect(find.text(heardFrom), findsOneWidget);
-      expect(find.text(contactInfo), findsOneWidget);
     });
   });
 }
@@ -123,7 +120,6 @@ void fillInAllFields(FeedbackBloc bloc) {
   bloc.changeDislike(dislikes);
   bloc.changeMissing(missing);
   bloc.changeHeardFrom(heardFrom);
-  bloc.changeContactOptions(contactInfo);
 }
 
 void writeRdmValues(FeedbackBloc bloc) {
@@ -131,5 +127,4 @@ void writeRdmValues(FeedbackBloc bloc) {
   bloc.changeDislike(random.randomString(10));
   bloc.changeMissing(random.randomString(10));
   bloc.changeHeardFrom(random.randomString(10));
-  bloc.changeContactOptions(random.randomString(10));
 }

--- a/lib/feedback_shared_implementation/lib/src/models/user_feedback.dart
+++ b/lib/feedback_shared_implementation/lib/src/models/user_feedback.dart
@@ -28,7 +28,6 @@ class UserFeedback {
   final String missing;
   final String heardFrom;
   final String uid;
-  final String userContactInformation;
   final FeedbackDeviceInformation? deviceInformation;
   final Map<UserId, UnreadMessageStatus>? unreadMessagesStatus;
   final FeedbackChatMessage? lastMessage;
@@ -50,7 +49,6 @@ class UserFeedback {
     required this.missing,
     required this.heardFrom,
     required this.uid,
-    required this.userContactInformation,
     required this.deviceInformation,
     required this.unreadMessagesStatus,
     required this.lastMessage,
@@ -66,7 +64,6 @@ class UserFeedback {
       missing: "",
       heardFrom: "",
       uid: "",
-      userContactInformation: "",
       deviceInformation: null,
       unreadMessagesStatus: null,
       lastMessage: null,
@@ -81,7 +78,6 @@ class UserFeedback {
       'missing': missing,
       'heardFrom': heardFrom,
       'uid': uid,
-      'userContactInformation': userContactInformation,
       'createdOn': FieldValue.serverTimestamp(),
       'deviceInformation': deviceInformation?.toJson(),
     }..removeWhere((string, object) =>
@@ -98,7 +94,6 @@ class UserFeedback {
       missing: map['missing'] ?? '',
       heardFrom: map['heardFrom'] ?? '',
       uid: map['uid'] ?? '',
-      userContactInformation: map['userContactInformation'] ?? '',
       deviceInformation: map['deviceInformation'] != null
           ? FeedbackDeviceInformation.fromJson(map['deviceInformation'])
           : null,
@@ -131,7 +126,6 @@ class UserFeedback {
     String? missing,
     String? heardFrom,
     String? uid,
-    String? userContactInformation,
     FeedbackDeviceInformation? deviceInformation,
     Map<UserId, UnreadMessageStatus>? unreadMessagesStatus,
     FeedbackChatMessage? lastMessage,
@@ -145,8 +139,6 @@ class UserFeedback {
       missing: missing ?? this.missing,
       heardFrom: heardFrom ?? this.heardFrom,
       uid: uid ?? this.uid,
-      userContactInformation:
-          userContactInformation ?? this.userContactInformation,
       deviceInformation: deviceInformation ?? this.deviceInformation,
       unreadMessagesStatus: unreadMessagesStatus ?? this.unreadMessagesStatus,
       lastMessage: lastMessage ?? this.lastMessage,
@@ -166,7 +158,6 @@ class UserFeedback {
         other.missing == missing &&
         other.heardFrom == heardFrom &&
         other.uid == uid &&
-        other.userContactInformation == userContactInformation &&
         other.deviceInformation == deviceInformation;
   }
 
@@ -180,13 +171,12 @@ class UserFeedback {
         missing.hashCode ^
         heardFrom.hashCode ^
         uid.hashCode ^
-        userContactInformation.hashCode ^
         deviceInformation.hashCode;
   }
 
   @override
   String toString() {
-    return 'UserFeedback(createdOn: $createdOn, id: $id, rating: $rating, likes: $likes, dislikes: $dislikes, missing: $missing, heardFrom: $heardFrom, uid: $uid, userContactInformation: $userContactInformation, deviceInformation: $deviceInformation)';
+    return 'UserFeedback(createdOn: $createdOn, id: $id, rating: $rating, likes: $likes, dislikes: $dislikes, missing: $missing, heardFrom: $heardFrom, uid: $uid, deviceInformation: $deviceInformation)';
   }
 }
 

--- a/lib/feedback_shared_implementation/test/models/feedback_test.dart
+++ b/lib/feedback_shared_implementation/test/models/feedback_test.dart
@@ -13,22 +13,22 @@ void main() {
   group('Feedback', () {
     test('equality', () {
       UserFeedback a = UserFeedback.create().copyWith(
-          rating: 5.0,
-          dislikes: "d",
-          heardFrom: "h",
-          likes: "l",
-          missing: "m",
-          uid: "u",
-          userContactInformation: "uci");
+        rating: 5.0,
+        dislikes: "d",
+        heardFrom: "h",
+        likes: "l",
+        missing: "m",
+        uid: "u",
+      );
 
       UserFeedback b = UserFeedback.create().copyWith(
-          rating: 5.0,
-          dislikes: "d",
-          heardFrom: "h",
-          likes: "l",
-          missing: "m",
-          uid: "u",
-          userContactInformation: "uci");
+        rating: 5.0,
+        dislikes: "d",
+        heardFrom: "h",
+        likes: "l",
+        missing: "m",
+        uid: "u",
+      );
 
       UserFeedback c = UserFeedback.create().copyWith(dislikes: "d");
       expect(a, equals(b));


### PR DESCRIPTION
Since we have a chat option in our feedback, we don't need the contact information field anymore.