### PR TITLE
Add devenv / Nix package management to repo

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+source_url "https://raw.githubusercontent.com/cachix/devenv/95f329d49a8a5289d31e0982652f7058a189bfca/direnvrc" "sha256-d+8cBpDfDBj41inrADaJt+bDWhOktwslgoP5YiGJ1v0="
+
+use devenv

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,12 @@ coverage/
 #
 # Source: https://fvm.app/documentation/getting-started/configuration
 .fvm/
+# Devenv
+.devenv*
+devenv.local.nix
+
+# direnv
+.direnv
+
+# pre-commit
+.pre-commit-config.yaml

--- a/bin/source_of_truth/commands_source_of_truth.yaml
+++ b/bin/source_of_truth/commands_source_of_truth.yaml
@@ -23,8 +23,8 @@
 
 # Note: The directory at the end of the command is missing.
 # The programs using these commands need to add it themselves.
-check_license_headers: addlicense -check -c "Sharezone UG (haftungsbeschränkt)" -f header_template.txt -ignore "**/GeneratedPluginRegistrant.swift" -ignore "**/**.g.dart" -ignore "**/**.mocks.dart" -ignore "**/macos/Pods/**" -ignore "**/ios/Pods/**"
-add_license_headers: addlicense -c "Sharezone UG (haftungsbeschränkt)" -f header_template.txt -ignore "**/GeneratedPluginRegistrant.swift" -ignore "**/**.g.dart" -ignore "**/**.mocks.dart" -ignore "**/macos/Pods/**" -ignore "**/ios/Pods/**"
+check_license_headers: addlicense -check -c "Sharezone UG (haftungsbeschränkt)" -f header_template.txt -ignore "**/GeneratedPluginRegistrant.swift" -ignore "**/**.g.dart" -ignore "**/**.mocks.dart" -ignore "**/macos/Pods/**" -ignore "**/ios/Pods/**" -ignore *.devenv*
+add_license_headers: addlicense -c "Sharezone UG (haftungsbeschränkt)" -f header_template.txt -ignore "**/GeneratedPluginRegistrant.swift" -ignore "**/**.g.dart" -ignore "**/**.mocks.dart" -ignore "**/macos/Pods/**" -ignore "**/ios/Pods/**" -ignore *.devenv*
 format_action_files: prettier ".github/workflows/" --write
 check_format_action_files: prettier ".github/workflows/" --check
 format_markdown_files: prettier "**/*.md" --write

--- a/devenv.lock
+++ b/devenv.lock
@@ -1,0 +1,156 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1712059314,
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "a18e86ab317a82c2e7d626d28ba1b3a9eb11d23b",
+        "treeHash": "13e19e729bf8bd0206d1ff6e716a19b31912004b",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "treeHash": "2addb7b71a20a25ea74feeaf5c2f6a6b30898ecb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "treeHash": "bd263f021e345cb4a39d80c126ab650bebc3c10c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "treeHash": "ca14199cabdfe1a06a7b1654c76ed49100a689f9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1710796454,
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "06fb0f1c643aee3ae6838dda3b37ef0abc3c763b",
+        "treeHash": "9bb13f7f39e825a5d91bbe4139fbc129243b907d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1711668574,
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "219951b495fc2eac67b1456824cc1ec1fd2ee659",
+        "treeHash": "51ec3259d600ba0dbef93d23999da1141e943713",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1712055707,
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "e35aed5fda3cc79f88ed7f1795021e559582093a",
+        "treeHash": "41bee5f5bd9314a987ef3d7cba730fb6aa264a4e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "treeHash": "cce81f2a0f0743b2eb61bc2eb6c7adbe2f2c6beb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -40,13 +40,18 @@ in
   packages = [
     pkgs.git
     pkgs.nixpkgs-fmt
-    pkgs.addlicense
-    pkgs.nodePackages.prettier
+
     # Running `fvm flutter` -> 'Missing "unzip" tool. Unable to extract Dart SDK.'
     pkgs.unzip
     android-sdk
-    pkgs.nodePackages.firebase-tools
+
+    # For Flutter Web development
     pkgs.google-chrome
+
+    # Used by sharezone developers / sz cli
+    pkgs.addlicense
+    pkgs.nodePackages.prettier
+    pkgs.nodePackages.firebase-tools
   ];
 
   enterShell = ''

--- a/devenv.nix
+++ b/devenv.nix
@@ -109,6 +109,11 @@ in
       jdk.package = pkgs.jdk17;
     };
 
+    # We're using this standalone version of Dart to run
+    # `dart pub global activate fvm` in enterShell.
+    # This will install fvm and it in turn flutter with 
+    # the actual Dart version that will be used to build,
+    # test, run etc the app.
     dart.enable = true;
   };
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -97,15 +97,6 @@ in
     fvm dart pub get --directory ./tools/sz_repo_cli
   '';
 
-  # https://devenv.sh/tests/
-  enterTest = ''
-    echo "Running tests"
-    git --version | grep "2.42.0"
-  '';
-
-  # https://devenv.sh/services/
-  # services.postgres.enable = true;
-
   languages = {
     # Needed for Android SDK
     java = {
@@ -115,12 +106,6 @@ in
 
     dart.enable = true;
   };
-
-  # https://devenv.sh/pre-commit-hooks/
-  # pre-commit.hooks.shellcheck.enable = true;
-
-  # https://devenv.sh/processes/
-  # processes.ping.exec = "ping example.com";
 
   # See full reference at https://devenv.sh/reference/options/
 }

--- a/devenv.nix
+++ b/devenv.nix
@@ -63,7 +63,8 @@ in
   ];
 
   enterShell = ''
-    # Make pub work
+    # Make pub cache work so that we can execute
+    # e.g. `dart pub global activate fvm`
     export PATH="$PATH":"$HOME/.pub-cache/bin"
 
     # Make sz cli work
@@ -78,24 +79,22 @@ in
     fvm dart --disable-analytics
     fvm flutter --disable-analytics
 
-    # So that we can use the sz cli instantly.
-    # Otherwise if this is a first install we would first
-    # need to manually get the packages there so that
-    # we can run `sz pub get` afterwards for the other packages.
-    if [ ! -d $DEVENV_ROOT/tools/sz_repo_cli/.dart_tool ]; then
-      fvm dart pub get --directory ./tools/sz_repo_cli
-    fi
-
     if ! command -v fvm &> /dev/null
     then
-        echo "fvm could not be found. Installing FVM."
+        echo "fvm could not be found. Installing FVM via dart pub global."
         dart pub global activate fvm
+        
         # fvm install will fail getting dependencies if we dont
         # cd to app. Using && will only change it for the fvm
         # install command
         cd app && fvm install
-        
     fi
+    
+    # We get the package in the sz cli folder so that one can
+    # start running e.g. `sz pub get` right away. Without this 
+    # one would first have to run pub get in the sz cli folder 
+    # manually.
+    fvm dart pub get --directory ./tools/sz_repo_cli
   '';
 
   # https://devenv.sh/tests/

--- a/devenv.nix
+++ b/devenv.nix
@@ -33,6 +33,7 @@ in
     ANDROID_HOME = "${android-sdk-root}";
     ANDROID_SDK_ROOT = "${android-sdk-root}";
     FLUTTER_ROOT = "${pkgs.flutter}";
+    CHROME_EXECUTABLE = "${pkgs.google-chrome}/bin/google-chrome-stable";
   };
 
   # https://devenv.sh/packages/
@@ -45,6 +46,7 @@ in
     pkgs.unzip
     android-sdk
     pkgs.nodePackages.firebase-tools
+    pkgs.google-chrome
   ];
 
   enterShell = ''

--- a/devenv.nix
+++ b/devenv.nix
@@ -72,6 +72,17 @@ in
     if [ ! -d $DEVENV_ROOT/tools/sz_repo_cli/.dart_tool ]; then
       fvm dart pub get --directory ./tools/sz_repo_cli
     fi
+
+    if ! command -v fvm &> /dev/null
+    then
+        echo "fvm could not be found. Installing FVM."
+        dart pub global activate fvm
+        # fvm install will fail getting dependencies if we dont
+        # cd to app. Using && will only change it for the fvm
+        # install command
+        cd app && fvm install
+        
+    fi
   '';
 
   # https://devenv.sh/tests/

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,3 +1,11 @@
+# Copyright (c) 2024 Sharezone UG (haftungsbeschränkt)
+# Licensed under the EUPL-1.2-or-later.
+#
+# You may obtain a copy of the Licence at:
+# https://joinup.ec.europa.eu/software/page/eupl
+#
+# SPDX-License-Identifier: EUPL-1.2
+
 { pkgs, ... }:
 
 let

--- a/devenv.nix
+++ b/devenv.nix
@@ -76,14 +76,14 @@ in
     # will cause the task to fail (maybe because so many signals
     # are sent in a short time). So we just disable analytics
     # so that they can not fail because of this reason.
-    fvm dart --disable-analytics
+    fvm dart --disable-analytics &
     fvm flutter --disable-analytics
 
     if ! command -v fvm &> /dev/null
     then
         echo "fvm could not be found. Installing FVM via dart pub global."
         dart pub global activate fvm
-        
+
         # fvm install will fail getting dependencies if we dont
         # cd to app. Using && will only change it for the fvm
         # install command

--- a/devenv.nix
+++ b/devenv.nix
@@ -10,10 +10,15 @@
 
 let
   androidenv = android-pkgs.androidenv.override {
+    # Seems to only work when androidenv.buildApp is used 
+    # afterwards (we don't).
+    # We accept the licenses below via extraLicenses.
     licenseAccepted = true;
   };
   android-comp = androidenv.composeAndroidPackages {
     buildToolsVersions = [ "34.0.0" ];
+    # We probably don't need all of those?
+    # These were copied from another devenv.nix from GitHub.
     platformVersions = [ "29" "30" "31" "33" "34" ];
 
     # The `licenseAccepted = true;` seems to only work when androidenv.buildApp

--- a/devenv.nix
+++ b/devenv.nix
@@ -47,11 +47,6 @@ in
     pkgs.nodePackages.firebase-tools
   ];
 
-
-
-  # https://devenv.sh/scripts/
-  scripts.create-avd.exec = "avdmanager create avd --force --name phone --package 'system-images;android-34;google_apis_playstore;x86_64'";
-
   enterShell = ''
     # Make pub work
     export PATH="$PATH":"$HOME/.pub-cache/bin"

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,0 +1,106 @@
+{ pkgs, ... }:
+
+let
+  androidenv = android-pkgs.androidenv.override {
+    licenseAccepted = true;
+  };
+  android-comp = androidenv.composeAndroidPackages {
+    buildToolsVersions = [ "34.0.0" ];
+    platformVersions = [ "29" "30" "31" "33" "34" ];
+
+    # The `licenseAccepted = true;` seems to only work when androidenv.buildApp
+    # is used. Since Flutter doesn't use that it doesn't work.
+    # Therefore we can manually accept the different licenses here.
+    # Copied from: https://github.com/NixOS/nixpkgs/issues/267263#issuecomment-1833769682
+    extraLicenses = [
+      "android-googletv-license"
+      "android-sdk-arm-dbt-license"
+      "android-sdk-license"
+      "android-sdk-preview-license"
+      "google-gdk-license"
+      "intel-android-extra-license"
+      "intel-android-sysimage-license"
+      "mips-android-sysimage-license"
+    ];
+  };
+  android-pkgs = if pkgs.stdenv.system == "aarch64-darwin" then pkgs.pkgsx86_64Darwin else pkgs;
+  android-sdk = android-comp.androidsdk;
+  android-sdk-root = "${android-sdk}/libexec/android-sdk";
+in
+{
+
+  env = {
+    ANDROID_HOME = "${android-sdk-root}";
+    ANDROID_SDK_ROOT = "${android-sdk-root}";
+    FLUTTER_ROOT = "${pkgs.flutter}";
+  };
+
+  # https://devenv.sh/packages/
+  packages = [
+    pkgs.git
+    pkgs.nixpkgs-fmt
+    pkgs.addlicense
+    pkgs.nodePackages.prettier
+    # Running `fvm flutter` -> 'Missing "unzip" tool. Unable to extract Dart SDK.'
+    pkgs.unzip
+    android-sdk
+    pkgs.nodePackages.firebase-tools
+  ];
+
+
+
+  # https://devenv.sh/scripts/
+  scripts.create-avd.exec = "avdmanager create avd --force --name phone --package 'system-images;android-34;google_apis_playstore;x86_64'";
+
+  enterShell = ''
+    # Make pub work
+    export PATH="$PATH":"$HOME/.pub-cache/bin"
+
+    # Make sz cli work
+    export PATH="$PATH":"$DEVENV_ROOT/bin"
+
+    fvm flutter config --android-sdk ${android-sdk-root}
+
+    # When running e.g. `sz pub get -c 0` the analytics
+    # will cause the task to fail (maybe because so many signals
+    # are sent in a short time). So we just disable analytics
+    # so that they can not fail because of this reason.
+    fvm dart --disable-analytics
+    fvm flutter --disable-analytics
+
+    # So that we can use the sz cli instantly.
+    # Otherwise if this is a first install we would first
+    # need to manually get the packages there so that
+    # we can run `sz pub get` afterwards for the other packages.
+    if [ ! -d $DEVENV_ROOT/tools/sz_repo_cli/.dart_tool ]; then
+      fvm dart pub get --directory ./tools/sz_repo_cli
+    fi
+  '';
+
+  # https://devenv.sh/tests/
+  enterTest = ''
+    echo "Running tests"
+    git --version | grep "2.42.0"
+  '';
+
+  # https://devenv.sh/services/
+  # services.postgres.enable = true;
+
+  languages = {
+    # Needed for Android SDK
+    java = {
+      enable = true;
+      jdk.package = pkgs.jdk17;
+    };
+
+    dart.enable = true;
+  };
+
+  # https://devenv.sh/pre-commit-hooks/
+  # pre-commit.hooks.shellcheck.enable = true;
+
+  # https://devenv.sh/processes/
+  # processes.ping.exec = "ping example.com";
+
+  # See full reference at https://devenv.sh/reference/options/
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -75,15 +75,6 @@ in
     # Make sz cli work
     export PATH="$PATH":"$DEVENV_ROOT/bin"
 
-    fvm flutter config --android-sdk ${android-sdk-root}
-
-    # When running e.g. `sz pub get -c 0` the analytics
-    # will cause the task to fail (maybe because so many signals
-    # are sent in a short time). So we just disable analytics
-    # so that they can not fail because of this reason.
-    fvm dart --disable-analytics &
-    fvm flutter --disable-analytics
-
     if ! command -v fvm &> /dev/null
     then
         echo "fvm could not be found. Installing FVM via dart pub global."
@@ -94,6 +85,15 @@ in
         # install command
         cd app && fvm install
     fi
+
+    fvm flutter config --android-sdk ${android-sdk-root}
+
+    # When running e.g. `sz pub get -c 0` the analytics
+    # will cause the task to fail (maybe because so many signals
+    # are sent in a short time). So we just disable analytics
+    # so that they can not fail because of this reason.
+    fvm dart --disable-analytics &
+    fvm flutter --disable-analytics
     
     # We get the package in the sz cli folder so that one can
     # start running e.g. `sz pub get` right away. Without this 

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,0 +1,14 @@
+inputs:
+  nixpkgs:
+    url: github:cachix/devenv-nixpkgs/rolling
+
+# If you're using non-OSS software, you can set allowUnfree to true.
+allowUnfree: true
+
+# If you're willing to use a package that's vulnerable
+# permittedInsecurePackages:
+#  - "openssl-1.1.1w"
+
+# If you have more than one devenv you can merge them
+#imports:
+# - ./backend

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -11,6 +11,7 @@ inputs:
     url: github:cachix/devenv-nixpkgs/rolling
 
 # If you're using non-OSS software, you can set allowUnfree to true.
+# We need it for the Android SDK and Google Chrome
 allowUnfree: true
 
 # If you're willing to use a package that's vulnerable

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,3 +1,11 @@
+# Copyright (c) 2024 Sharezone UG (haftungsbeschränkt)
+# Licensed under the EUPL-1.2-or-later.
+#
+# You may obtain a copy of the Licence at:
+# https://joinup.ec.europa.eu/software/page/eupl
+#
+# SPDX-License-Identifier: EUPL-1.2
+
 inputs:
   nixpkgs:
     url: github:cachix/devenv-nixpkgs/rolling


### PR DESCRIPTION
[Devenv](devenv.sh) (in combination with [direnv](https://direnv.net/)) allows developers to automatically and deterministically fetch required dependencies that are used in the project.  
The language / package management used is called [Nix](https://nixos.org/).

To use it [install devenv](https://devenv.sh/getting-started/) and [install direnv](https://direnv.net/).  
By switching into the sharezone-app directory one will automatically be dropped into a shell. This shell will have all the packages, environment variables etc installed that are specified in `devenv.nix`.   

Note: Building it the first time took a very long time because of  "androidenv.composeAndroidPackages". This is only half working, flutter doctor shows ✅ on Android but one can't run an actual emulator yet. Haven't tried building an apk. Its a WIP that I just want to submit in the currently "hopefully good enough" state. Running web via chrome did work though.  

Right now I can't really recommend it for a system where flutter etc is already set up and works. Or just try it out for lulz, idk 🤷‍♂️

Note: Nix natively support Linux and MacOS, Windows is (I think) only partially supported by using [WSL](https://learn.microsoft.com/en-us/windows/wsl/install). I'm using Linux right now.