### PR TITLE
Fix setting grade type weights for subject and term

### DIFF
--- a/app/lib/grades/pages/subject_settings_page/subject_settings_page_controller.dart
+++ b/app/lib/grades/pages/subject_settings_page/subject_settings_page_controller.dart
@@ -106,7 +106,7 @@ class SubjectSettingsPageController extends ChangeNotifier {
       weight: weight,
     );
     _selectableGradeTypes = gradesService.getPossibleGradeTypes();
-    _weights = _getSubject()!.gradeTypeWeights;
+    _weights = _weights.add(gradeTypeId, weight);
     state = SubjectSettingsLoaded(view);
     notifyListeners();
   }
@@ -118,7 +118,7 @@ class SubjectSettingsPageController extends ChangeNotifier {
       gradeType: gradeTypeId,
     );
     _selectableGradeTypes = gradesService.getPossibleGradeTypes();
-    _weights = _getSubject()!.gradeTypeWeights;
+    _weights = _weights.remove(gradeTypeId);
     state = SubjectSettingsLoaded(view);
     notifyListeners();
   }

--- a/app/lib/grades/pages/term_settings_page/term_settings_page_controller.dart
+++ b/app/lib/grades/pages/term_settings_page/term_settings_page_controller.dart
@@ -139,7 +139,7 @@ class TermSettingsPageController extends ChangeNotifier {
       gradeType: gradeTypeId,
       weight: weight,
     );
-    _weights = _getTerm()!.gradeTypeWeightings;
+    _weights = _weights.add(gradeTypeId, weight);
     state = TermSettingsLoaded(view);
     notifyListeners();
   }
@@ -149,7 +149,7 @@ class TermSettingsPageController extends ChangeNotifier {
       termId: termId,
       gradeType: gradeTypeId,
     );
-    _weights = _getTerm()!.gradeTypeWeightings;
+    _weights = _weights.remove(gradeTypeId);
     state = TermSettingsLoaded(view);
     notifyListeners();
   }


### PR DESCRIPTION
## Description

This was because I used `_getSubject()` and after calling `changeGradeTypeWeightForSubject()` Firestore wasn't quick enough to pull the update. Therefore, `_getSubject` returned the old subject. Same for the term.

## Demo

https://github.com/SharezoneApp/sharezone-app/assets/24459435/9687b3c0-51ad-4d4c-bb53-ee1e51716abc
