### PR TITLE
Copy weights from term to subject for subjects settings page

### DIFF
--- a/app/lib/grades/pages/subject_settings_page/subject_settings_page_controller.dart
+++ b/app/lib/grades/pages/subject_settings_page/subject_settings_page_controller.dart
@@ -12,6 +12,7 @@ import 'package:flutter/material.dart';
 
 import 'package:sharezone/grades/grades_service/grades_service.dart';
 import 'package:sharezone/grades/pages/subject_settings_page/subject_settings_page_view.dart';
+import 'package:cloud_firestore_helper/cloud_firestore_helper.dart';
 
 class SubjectSettingsPageController extends ChangeNotifier {
   final GradesService gradesService;
@@ -35,7 +36,14 @@ class SubjectSettingsPageController extends ChangeNotifier {
     _finalGradeTypeDisplayName = _getFinalGradeTypeDisplayName(finalGradeType);
     _finalGradeTypeIcon = _getFinalGradeTypeIcon(finalGradeType);
     _selectableGradeTypes = gradesService.getPossibleGradeTypes();
-    _weights = subject.gradeTypeWeights;
+
+    if (subject.weightType == WeightType.inheritFromTerm) {
+      // We show the weights from the term, but we need to copy them into the
+      // subject if the user changes them.
+      _weights = _getTerm()!.gradeTypeWeightings;
+    } else {
+      _weights = subject.gradeTypeWeights;
+    }
 
     state = SubjectSettingsLoaded(view);
   }
@@ -95,10 +103,43 @@ class SubjectSettingsPageController extends ChangeNotifier {
     );
   }
 
-  void setGradeWeight({
+  /// Copies the weights from the term to the subject if the subject is set to
+  /// inherit the weights from the term.
+  ///
+  /// This method is called before changing the weights of a subject.
+  Future<void> _maybeCopyWeightsFromTerm() async {
+    if (_getSubject()!.weightType != WeightType.inheritFromTerm) {
+      // Subject has its own weights, no need to copy from term.
+      return;
+    }
+
+    // In the constructor, we already copied the weights from the term. But they
+    // were only copied into the state. Now we need to copy them into the
+    // database.
+    for (final gradeType in _weights.keys) {
+      gradesService.changeGradeTypeWeightForSubject(
+        id: subjectId,
+        termId: termId,
+        gradeType: gradeType,
+        weight: _weights[gradeType]!,
+      );
+      await waitForFirestoreWriteLimit();
+    }
+
+    gradesService.changeSubjectWeightTypeSettings(
+      id: subjectId,
+      termId: termId,
+      perGradeType: WeightType.perGradeType,
+    );
+    await waitForFirestoreWriteLimit();
+  }
+
+  Future<void> setGradeWeight({
     required GradeTypeId gradeTypeId,
     required Weight weight,
-  }) {
+  }) async {
+    await _maybeCopyWeightsFromTerm();
+
     gradesService.changeGradeTypeWeightForSubject(
       id: subjectId,
       termId: termId,
@@ -111,7 +152,9 @@ class SubjectSettingsPageController extends ChangeNotifier {
     notifyListeners();
   }
 
-  void removeGradeType(GradeTypeId gradeTypeId) {
+  Future<void> removeGradeType(GradeTypeId gradeTypeId) async {
+    await _maybeCopyWeightsFromTerm();
+
     gradesService.removeGradeTypeWeightForSubject(
       id: subjectId,
       termId: termId,

--- a/app/lib/grades/pages/subject_settings_page/subject_settings_page_controller.dart
+++ b/app/lib/grades/pages/subject_settings_page/subject_settings_page_controller.dart
@@ -106,7 +106,7 @@ class SubjectSettingsPageController extends ChangeNotifier {
       weight: weight,
     );
     _selectableGradeTypes = gradesService.getPossibleGradeTypes();
-    _weights = _getSubject()!.gradeTypeWeights;
+    _weights = _weights.add(gradeTypeId, weight);
     state = SubjectSettingsLoaded(view);
     notifyListeners();
   }
@@ -118,7 +118,7 @@ class SubjectSettingsPageController extends ChangeNotifier {
       gradeType: gradeTypeId,
     );
     _selectableGradeTypes = gradesService.getPossibleGradeTypes();
-    _weights = _getSubject()!.gradeTypeWeights;
+    _weights = _weights.remove(gradeTypeId);
     state = SubjectSettingsLoaded(view);
     notifyListeners();
   }

--- a/app/lib/grades/pages/term_settings_page/term_settings_page_controller.dart
+++ b/app/lib/grades/pages/term_settings_page/term_settings_page_controller.dart
@@ -139,7 +139,7 @@ class TermSettingsPageController extends ChangeNotifier {
       gradeType: gradeTypeId,
       weight: weight,
     );
-    _weights = _getTerm()!.gradeTypeWeightings;
+    _weights = _weights.add(gradeTypeId, weight);
     state = TermSettingsLoaded(view);
     notifyListeners();
   }
@@ -149,7 +149,7 @@ class TermSettingsPageController extends ChangeNotifier {
       termId: termId,
       gradeType: gradeTypeId,
     );
-    _weights = _getTerm()!.gradeTypeWeightings;
+    _weights = _weights.remove(gradeTypeId);
     state = TermSettingsLoaded(view);
     notifyListeners();
   }

--- a/lib/cloud_firestore_helper/lib/src/cloud_firestore_helper.dart
+++ b/lib/cloud_firestore_helper/lib/src/cloud_firestore_helper.dart
@@ -58,8 +58,8 @@ DateTime? dateTimeFromTimestampOrNull(dynamic timestamp) {
 /// the delay to be on the safe side.
 ///
 /// See:
-///   * https://stackoverflow.com/q/74454570
-///   * https://firebase.google.com/docs/firestore/best-practices#updates_to_a_single_document
+/// * https://stackoverflow.com/q/74454570
+/// * https://firebase.google.com/docs/firestore/best-practices#updates_to_a_single_document
 Future<void> waitForFirestoreWriteLimit({
   Duration delay = const Duration(milliseconds: 200),
 }) async {

--- a/lib/cloud_firestore_helper/lib/src/cloud_firestore_helper.dart
+++ b/lib/cloud_firestore_helper/lib/src/cloud_firestore_helper.dart
@@ -52,3 +52,16 @@ DateTime? dateTimeFromTimestampOrNull(dynamic timestamp) {
   final microsecondsSinceEpoch = timestamp.microsecondsSinceEpoch;
   return DateTime.fromMicrosecondsSinceEpoch(microsecondsSinceEpoch);
 }
+
+/// Firestore had a soft limit of 1 write per second per document. However,
+/// this limit isn't mentioned in the documentation anymore. We still keep
+/// the delay to be on the safe side.
+///
+/// See:
+///   * https://stackoverflow.com/q/74454570
+///   * https://firebase.google.com/docs/firestore/best-practices#updates_to_a_single_document
+Future<void> waitForFirestoreWriteLimit({
+  Duration delay = const Duration(milliseconds: 200),
+}) async {
+  await Future.delayed(delay);
+}


### PR DESCRIPTION
When subjects inherit the weights from the term, we will display the weights in the UI (better UX). When the user changes something, we copy the weights to the subjects and change the weight type to `GradeType` (instead of inherit from term).