### PR TITLE
Add help dialog for final grade type and grade type weights

### DIFF
--- a/app/lib/grades/pages/shared/final_grade_type_settings.dart
+++ b/app/lib/grades/pages/shared/final_grade_type_settings.dart
@@ -1,0 +1,84 @@
+// Copyright (c) 2024 Sharezone UG (haftungsbeschränkt)
+// Licensed under the EUPL-1.2-or-later.
+//
+// You may obtain a copy of the Licence at:
+// https://joinup.ec.europa.eu/software/page/eupl
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+import 'package:fast_immutable_collections/fast_immutable_collections.dart';
+import 'package:flutter/material.dart';
+import 'package:sharezone/grades/grades_service/grades_service.dart';
+import 'package:sharezone/grades/pages/shared/grades_help_dialog.dart';
+import 'package:sharezone/grades/pages/shared/select_grade_type_dialog.dart';
+
+class FinalGradeTypeSettings extends StatelessWidget {
+  const FinalGradeTypeSettings({
+    super.key,
+    required this.icon,
+    required this.displayName,
+    required this.selectableGradingTypes,
+    required this.onSetFinalGradeType,
+  });
+
+  final Icon icon;
+  final String displayName;
+  final IList<GradeType> selectableGradingTypes;
+  final ValueChanged<GradeType> onSetFinalGradeType;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        ListTile(
+          contentPadding: const EdgeInsets.all(0),
+          title: const Text('Endnote eines Faches'),
+          subtitle: Text(
+            'Die berechnete Fachnote kann von einem Notentyp überschrieben werden.',
+            style: TextStyle(
+                color:
+                    Theme.of(context).colorScheme.onSurface.withOpacity(0.5)),
+          ),
+          trailing: IconButton(
+            tooltip: 'Was ist die Endnote?',
+            icon: const Icon(Icons.help_outline),
+            onPressed: () => _FinalGradeTypeHelpDialog.show(context),
+          ),
+        ),
+        ListTile(
+          leading: icon,
+          title: Text(displayName),
+          onTap: () async {
+            final type = await SelectGradeTypeDialog.show(
+              context: context,
+              selectableGradingTypes: selectableGradingTypes.toList(),
+            );
+
+            if (type != null && context.mounted) {
+              onSetFinalGradeType(type);
+            }
+          },
+        ),
+      ],
+    );
+  }
+}
+
+class _FinalGradeTypeHelpDialog extends StatelessWidget {
+  const _FinalGradeTypeHelpDialog();
+
+  static void show(BuildContext context) {
+    GradesHelpDialog.show(context, const _FinalGradeTypeHelpDialog());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const GradesHelpDialog(
+      title: Text('Was ist die Endnote eines Faches?'),
+      text: Text(
+        'Die Endnote ist die abschließende Note, die du in einem Fach bekommst, zum Beispiel die Note auf deinem Zeugnis. Manchmal berücksichtigt deine Lehrkraft zusätzliche Faktoren, die von der üblichen Berechnungsformel abweichen können – etwa 50% Prüfungen und 50% mündliche Beteiligung. In solchen Fällen kannst du die in Sharezone automatisch berechnete Note durch diese finale Note ersetzen.\n\nDiese Einstellung kann entweder für alle Fächer eines Halbjahres gleichzeitig festgelegt oder für jedes Fach individuell angepasst werden. So hast du die Flexibilität, je nach Bedarf spezifische Anpassungen vorzunehmen.',
+      ),
+    );
+  }
+}

--- a/app/lib/grades/pages/shared/grades_help_dialog.dart
+++ b/app/lib/grades/pages/shared/grades_help_dialog.dart
@@ -1,0 +1,46 @@
+// Copyright (c) 2024 Sharezone UG (haftungsbeschränkt)
+// Licensed under the EUPL-1.2-or-later.
+//
+// You may obtain a copy of the Licence at:
+// https://joinup.ec.europa.eu/software/page/eupl
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+import 'package:flutter/material.dart';
+import 'package:sharezone_widgets/sharezone_widgets.dart';
+
+/// A dialog for the grades feature
+class GradesHelpDialog extends StatelessWidget {
+  const GradesHelpDialog({
+    super.key,
+    required this.title,
+    required this.text,
+  });
+
+  final Widget title;
+  final Widget text;
+
+  static void show(BuildContext context, Widget widget) {
+    showDialog(
+      context: context,
+      builder: (context) => widget,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaxWidthConstraintBox(
+      maxWidth: 550,
+      child: AlertDialog(
+        title: title,
+        content: SingleChildScrollView(child: text),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/grades/pages/shared/weight_settings.dart
+++ b/app/lib/grades/pages/shared/weight_settings.dart
@@ -46,7 +46,7 @@ class WeightSettings extends StatelessWidget {
           trailing: IconButton(
             tooltip: 'Wie wird die Note berechnet?',
             onPressed: () => _HelpDialog.show(context),
-            icon: const _HelpDialog(),
+            icon: const Icon(Icons.help_outline),
           ),
         ),
         const SizedBox(height: 8),
@@ -256,7 +256,7 @@ class _HelpDialog extends StatelessWidget {
     return const GradesHelpDialog(
       title: Text('Wie wird die Note eines Fachs berechnet?'),
       text: Text(
-        'In Sharezone kannst du genau bestimmen, wie die Note für jedes Fach berechnet wird, indem du die Gewichtung der verschiedenen Notentypen festlegst. Zum Beispiel kannst du einstellen, dass die Gesamtnote aus 50% schriftlichen Prüfungen und 50% mündlicher Beteiligung zusammengesetzt wird. Diese Flexibilität ermöglicht es dir, die Bewertungskriterien deiner Schule genau abzubilden und sicherzustellen, dass jede Art von Leistung angemessen berücksichtigt wird.',
+        'In Sharezone kannst du genau bestimmen, wie die Note für jedes Fach berechnet wird, indem du die Gewichtung der verschiedenen Notentypen festlegst. Zum Beispiel kannst du einstellen, dass die Gesamtnote aus 50% schriftlichen Prüfungen und 50% mündlicher Beteiligung zusammengesetzt wird.\n\nDiese Flexibilität ermöglicht es dir, die Bewertungskriterien deiner Schule genau abzubilden und sicherzustellen, dass jede Art von Leistung angemessen berücksichtigt wird.',
       ),
     );
   }

--- a/app/lib/grades/pages/shared/weight_settings.dart
+++ b/app/lib/grades/pages/shared/weight_settings.dart
@@ -1,0 +1,263 @@
+// Copyright (c) 2024 Sharezone UG (haftungsbeschränkt)
+// Licensed under the EUPL-1.2-or-later.
+//
+// You may obtain a copy of the Licence at:
+// https://joinup.ec.europa.eu/software/page/eupl
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+import 'package:collection/collection.dart';
+import 'package:fast_immutable_collections/fast_immutable_collections.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:sharezone/grades/grades_service/grades_service.dart';
+import 'package:sharezone/grades/pages/shared/grades_help_dialog.dart';
+import 'package:sharezone/grades/pages/shared/select_grade_type_dialog.dart';
+import 'package:sharezone_widgets/sharezone_widgets.dart';
+
+class WeightSettings extends StatelessWidget {
+  const WeightSettings({
+    super.key,
+    required this.weights,
+    required this.selectableGradingTypes,
+    required this.onSetGradeWeight,
+    required this.onRemoveGradeType,
+  });
+
+  final IMap<GradeTypeId, Weight> weights;
+  final IList<GradeType> selectableGradingTypes;
+  final void Function(GradeTypeId gradeTypeId, Weight weight) onSetGradeWeight;
+  final void Function(GradeTypeId gradeTypeId) onRemoveGradeType;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        ListTile(
+          contentPadding: const EdgeInsets.all(0),
+          title: const Text('Berechnung der Fachnote'),
+          subtitle: Text(
+            'Lege die Gewichtung der Notentypen für die Berechnung der Fachnote fest.',
+            style: TextStyle(
+                color:
+                    Theme.of(context).colorScheme.onSurface.withOpacity(0.5)),
+          ),
+          trailing: IconButton(
+            tooltip: 'Wie wird die Note berechnet?',
+            onPressed: () => _HelpDialog.show(context),
+            icon: const _HelpDialog(),
+          ),
+        ),
+        const SizedBox(height: 8),
+        for (final entry in weights.entries)
+          _GradeTypeWeight(
+            gradeTypeId: entry.key,
+            weight: entry.value,
+            onSetGradeWeight: onSetGradeWeight,
+            onRemoveGradeType: onRemoveGradeType,
+          ),
+        _AddSubjectWeight(
+          selectableGradingTypes: selectableGradingTypes,
+          onSetGradeWeight: onSetGradeWeight,
+        )
+      ],
+    );
+  }
+}
+
+class _GradeTypeWeight extends StatelessWidget {
+  const _GradeTypeWeight({
+    required this.gradeTypeId,
+    required this.weight,
+    required this.onSetGradeWeight,
+    required this.onRemoveGradeType,
+  });
+
+  final GradeTypeId gradeTypeId;
+  final Weight weight;
+  final void Function(GradeTypeId gradeTypeId, Weight weight) onSetGradeWeight;
+  final void Function(GradeTypeId gradeTypeId) onRemoveGradeType;
+
+  GradeType? getGradeType(BuildContext context) {
+    final getPossibleGrades =
+        context.read<GradesService>().getPossibleGradeTypes();
+    return getPossibleGrades
+        .firstWhereOrNull((element) => element.id == gradeTypeId);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final gradeType = getGradeType(context);
+    final name = gradeType?.predefinedType?.toUiString() ?? '?';
+    return ListTile(
+      title: Text(name),
+      onTap: () async {
+        final newValue = await showDialog<double>(
+          context: context,
+          builder: (context) => _WeightTextField(
+            initialValue: weight.asPercentage,
+          ),
+        );
+
+        if (newValue != null && context.mounted) {
+          onSetGradeWeight(gradeTypeId, Weight.percent(newValue));
+        }
+      },
+      leading: IconButton(
+        tooltip: 'Entfernen',
+        icon: const Icon(
+          Icons.remove_circle_outline,
+          color: Colors.red,
+        ),
+        onPressed: () => onRemoveGradeType(gradeTypeId),
+      ),
+      trailing: Text(
+        '${weight.asPercentage}%',
+        style: const TextStyle(
+          fontSize: 16,
+          fontWeight: FontWeight.normal,
+        ),
+      ),
+    );
+  }
+}
+
+class _WeightTextField extends StatefulWidget {
+  const _WeightTextField({
+    required this.initialValue,
+  });
+
+  final num initialValue;
+
+  @override
+  State<_WeightTextField> createState() => _WeightTextFieldState();
+}
+
+class _WeightTextFieldState extends State<_WeightTextField> {
+  String? errorText;
+  String? value;
+
+  bool get isValid => errorText == null && value != null && value!.isNotEmpty;
+
+  bool isChangeValid(String change) {
+    final isEmpty = change.isEmpty;
+    if (isEmpty) {
+      return false;
+    }
+
+    final asDouble = double.tryParse(change);
+    if (asDouble == null) {
+      return false;
+    }
+
+    return asDouble >= 0;
+  }
+
+  void popWithValue(BuildContext context) {
+    final asDouble = double.parse(value!);
+    Navigator.of(context).pop(asDouble);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      contentPadding: const EdgeInsets.fromLTRB(24, 32, 24, 24),
+      content: ConstrainedBox(
+        constraints: const BoxConstraints(
+          maxWidth: 400,
+          minWidth: 250,
+        ),
+        child: PrefilledTextField(
+          autofocus: true,
+          prefilledText: '${widget.initialValue}',
+          onChanged: (v) {
+            final isValid = isChangeValid(v);
+            setState(() {
+              value = v;
+              errorText =
+                  isValid ? null : 'Bitte gebe eine gültige Zahl (>= 0) ein.';
+            });
+          },
+          onEditingComplete: () {
+            if (isValid) {
+              popWithValue(context);
+            }
+          },
+          keyboardType: TextInputType.number,
+          decoration: InputDecoration(
+            labelText: 'Gewichtung in %',
+            hintText: 'z.B. 56.5',
+            errorText: errorText,
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Abbrechen'),
+        ),
+        AnimatedSwitcher(
+          duration: const Duration(milliseconds: 250),
+          child: FilledButton(
+            key: ValueKey(isValid),
+            onPressed: isValid ? () => popWithValue(context) : null,
+            child: const Text('Speichern'),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _AddSubjectWeight extends StatelessWidget {
+  const _AddSubjectWeight({
+    required this.selectableGradingTypes,
+    required this.onSetGradeWeight,
+  });
+
+  final IList<GradeType> selectableGradingTypes;
+  final void Function(GradeTypeId gradeTypeId, Weight weight) onSetGradeWeight;
+
+  Future<void> onTap(BuildContext context) async {
+    final type = await SelectGradeTypeDialog.show(
+      context: context,
+      selectableGradingTypes: selectableGradingTypes.toList(),
+    );
+
+    if (type != null && context.mounted) {
+      onSetGradeWeight(type.id, const Weight.factor(0));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      leading: IconButton(
+        icon: const Icon(Icons.add_circle_outline),
+        onPressed: () => onTap(context),
+        color: Theme.of(context).colorScheme.primary,
+      ),
+      title: const Text('Neue Gewichtung hinzufügen'),
+      onTap: () => onTap(context),
+    );
+  }
+}
+
+class _HelpDialog extends StatelessWidget {
+  const _HelpDialog();
+
+  static void show(BuildContext context) {
+    GradesHelpDialog.show(context, const _HelpDialog());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const GradesHelpDialog(
+      title: Text('Wie wird die Note eines Fachs berechnet?'),
+      text: Text(
+        'In Sharezone kannst du genau bestimmen, wie die Note für jedes Fach berechnet wird, indem du die Gewichtung der verschiedenen Notentypen festlegst. Zum Beispiel kannst du einstellen, dass die Gesamtnote aus 50% schriftlichen Prüfungen und 50% mündlicher Beteiligung zusammengesetzt wird. Diese Flexibilität ermöglicht es dir, die Bewertungskriterien deiner Schule genau abzubilden und sicherzustellen, dass jede Art von Leistung angemessen berücksichtigt wird.',
+      ),
+    );
+  }
+}

--- a/app/lib/grades/pages/subject_settings_page/subject_settings_page.dart
+++ b/app/lib/grades/pages/subject_settings_page/subject_settings_page.dart
@@ -6,12 +6,11 @@
 //
 // SPDX-License-Identifier: EUPL-1.2
 
-import 'package:collection/collection.dart';
-import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:sharezone/grades/grades_service/grades_service.dart';
-import 'package:sharezone/grades/pages/shared/select_grade_type_dialog.dart';
+import 'package:sharezone/grades/pages/shared/final_grade_type_settings.dart';
+import 'package:sharezone/grades/pages/shared/weight_settings.dart';
 import 'package:sharezone/grades/pages/subject_settings_page/subject_settings_page_controller.dart';
 import 'package:sharezone/grades/pages/subject_settings_page/subject_settings_page_view.dart';
 import 'package:sharezone/support/support_page.dart';
@@ -107,13 +106,9 @@ class _Loaded extends StatelessWidget {
         child: SafeArea(
           child: Column(
             children: [
-              _FinalGradeType(
-                displayName: view.finalGradeTypeDisplayName,
-                icon: view.finalGradeTypeIcon,
-                selectableGradingTypes: view.selectableGradingTypes,
-              ),
+              _FinalGradeType(view: view),
               const Divider(),
-              SubjectWeights(
+              WeightSettings(
                 selectableGradingTypes: view.selectableGradingTypes,
                 weights: view.weights,
                 onRemoveGradeType: (gradeTypeId) {
@@ -140,268 +135,21 @@ class _Loaded extends StatelessWidget {
 
 class _FinalGradeType extends StatelessWidget {
   const _FinalGradeType({
-    required this.icon,
-    required this.displayName,
-    required this.selectableGradingTypes,
+    required this.view,
   });
 
-  final Icon icon;
-  final String displayName;
-  final IList<GradeType> selectableGradingTypes;
+  final SubjectSettingsPageView view;
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        const Text(
-          'Endnote',
-          style: TextStyle(fontSize: 16),
-        ),
-        const SizedBox(height: 8),
-        Text(
-          'Solange keine Endnote für einen Kurs feststeht, wird eine vorläufige Kursnote anhand der eingetragenen Noten berechnet. Wenn eine Endnote feststeht, kann die berechnete Kursnote überschrieben werden.',
-          style: TextStyle(
-              color: Theme.of(context).colorScheme.onSurface.withOpacity(0.5)),
-        ),
-        const SizedBox(height: 8),
-        ListTile(
-          leading: icon,
-          title: Text(displayName),
-          onTap: () async {
-            final type = await SelectGradeTypeDialog.show(
-              context: context,
-              selectableGradingTypes: selectableGradingTypes.toList(),
-            );
-
-            if (type != null && context.mounted) {
-              final controller = context.read<SubjectSettingsPageController>();
-              controller.setFinalGradeType(type);
-            }
-          },
-        ),
-      ],
-    );
-  }
-}
-
-class SubjectWeights extends StatelessWidget {
-  const SubjectWeights({
-    super.key,
-    required this.weights,
-    required this.selectableGradingTypes,
-    required this.onSetGradeWeight,
-    required this.onRemoveGradeType,
-  });
-
-  final IMap<GradeTypeId, Weight> weights;
-  final IList<GradeType> selectableGradingTypes;
-  final void Function(GradeTypeId gradeTypeId, Weight weight) onSetGradeWeight;
-  final void Function(GradeTypeId gradeTypeId) onRemoveGradeType;
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        const Text('Berechnung der Fachnote', style: TextStyle(fontSize: 16)),
-        const SizedBox(height: 8),
-        Text(
-          'Lege die Gewichtung der Notentypen für die Berechnung der Fachnote fest.',
-          style: TextStyle(
-              color: Theme.of(context).colorScheme.onSurface.withOpacity(0.5)),
-        ),
-        const SizedBox(height: 8),
-        for (final entry in weights.entries)
-          _SubjectWeight(
-            gradeTypeId: entry.key,
-            weight: entry.value,
-            onSetGradeWeight: onSetGradeWeight,
-            onRemoveGradeType: onRemoveGradeType,
-          ),
-        _AddSubjectWeight(
-          selectableGradingTypes: selectableGradingTypes,
-          onSetGradeWeight: onSetGradeWeight,
-        )
-      ],
-    );
-  }
-}
-
-class _SubjectWeight extends StatelessWidget {
-  const _SubjectWeight({
-    required this.gradeTypeId,
-    required this.weight,
-    required this.onSetGradeWeight,
-    required this.onRemoveGradeType,
-  });
-
-  final GradeTypeId gradeTypeId;
-  final Weight weight;
-  final void Function(GradeTypeId gradeTypeId, Weight weight) onSetGradeWeight;
-  final void Function(GradeTypeId gradeTypeId) onRemoveGradeType;
-
-  GradeType? getGradeType(BuildContext context) {
-    final getPossibleGrades =
-        context.read<GradesService>().getPossibleGradeTypes();
-    return getPossibleGrades
-        .firstWhereOrNull((element) => element.id == gradeTypeId);
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final gradeType = getGradeType(context);
-    final name = gradeType?.predefinedType?.toUiString() ?? '?';
-    return ListTile(
-      title: Text(name),
-      onTap: () async {
-        final newValue = await showDialog<double>(
-          context: context,
-          builder: (context) => _WeightTextField(
-            initialValue: weight.asPercentage,
-          ),
-        );
-
-        if (newValue != null && context.mounted) {
-          onSetGradeWeight(gradeTypeId, Weight.percent(newValue));
-        }
+    return FinalGradeTypeSettings(
+      icon: view.finalGradeTypeIcon,
+      displayName: view.finalGradeTypeDisplayName,
+      selectableGradingTypes: view.selectableGradingTypes,
+      onSetFinalGradeType: (type) {
+        final controller = context.read<SubjectSettingsPageController>();
+        controller.setFinalGradeType(type);
       },
-      leading: IconButton(
-        tooltip: 'Entfernen',
-        icon: const Icon(
-          Icons.remove_circle_outline,
-          color: Colors.red,
-        ),
-        onPressed: () => onRemoveGradeType(gradeTypeId),
-      ),
-      trailing: Text(
-        '${weight.asPercentage}%',
-        style: const TextStyle(
-          fontSize: 16,
-          fontWeight: FontWeight.normal,
-        ),
-      ),
-    );
-  }
-}
-
-class _WeightTextField extends StatefulWidget {
-  const _WeightTextField({
-    required this.initialValue,
-  });
-
-  final num initialValue;
-
-  @override
-  State<_WeightTextField> createState() => _WeightTextFieldState();
-}
-
-class _WeightTextFieldState extends State<_WeightTextField> {
-  String? errorText;
-  String? value;
-
-  bool get isValid => errorText == null && value != null && value!.isNotEmpty;
-
-  bool isChangeValid(String change) {
-    final isEmpty = change.isEmpty;
-    if (isEmpty) {
-      return false;
-    }
-
-    final asDouble = double.tryParse(change);
-    if (asDouble == null) {
-      return false;
-    }
-
-    return asDouble >= 0;
-  }
-
-  void popWithValue(BuildContext context) {
-    final asDouble = double.parse(value!);
-    Navigator.of(context).pop(asDouble);
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return AlertDialog(
-      contentPadding: const EdgeInsets.fromLTRB(24, 32, 24, 24),
-      content: ConstrainedBox(
-        constraints: const BoxConstraints(
-          maxWidth: 400,
-          minWidth: 250,
-        ),
-        child: PrefilledTextField(
-          autofocus: true,
-          prefilledText: '${widget.initialValue}',
-          onChanged: (v) {
-            final isValid = isChangeValid(v);
-            setState(() {
-              value = v;
-              errorText =
-                  isValid ? null : 'Bitte gebe eine gültige Zahl (>= 0) ein.';
-            });
-          },
-          onEditingComplete: () {
-            if (isValid) {
-              popWithValue(context);
-            }
-          },
-          keyboardType: TextInputType.number,
-          decoration: InputDecoration(
-            labelText: 'Gewichtung in %',
-            hintText: 'z.B. 56.5',
-            errorText: errorText,
-          ),
-        ),
-      ),
-      actions: [
-        TextButton(
-          onPressed: () => Navigator.of(context).pop(),
-          child: const Text('Abbrechen'),
-        ),
-        AnimatedSwitcher(
-          duration: const Duration(milliseconds: 250),
-          child: FilledButton(
-            key: ValueKey(isValid),
-            onPressed: isValid ? () => popWithValue(context) : null,
-            child: const Text('Speichern'),
-          ),
-        ),
-      ],
-    );
-  }
-}
-
-class _AddSubjectWeight extends StatelessWidget {
-  const _AddSubjectWeight({
-    required this.selectableGradingTypes,
-    required this.onSetGradeWeight,
-  });
-
-  final IList<GradeType> selectableGradingTypes;
-  final void Function(GradeTypeId gradeTypeId, Weight weight) onSetGradeWeight;
-
-  Future<void> onTap(BuildContext context) async {
-    final type = await SelectGradeTypeDialog.show(
-      context: context,
-      selectableGradingTypes: selectableGradingTypes.toList(),
-    );
-
-    if (type != null && context.mounted) {
-      onSetGradeWeight(type.id, const Weight.factor(0));
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return ListTile(
-      leading: IconButton(
-        icon: const Icon(Icons.add_circle_outline),
-        onPressed: () => onTap(context),
-        color: Theme.of(context).colorScheme.primary,
-      ),
-      title: const Text('Neue Gewichtung hinzufügen'),
-      onTap: () => onTap(context),
     );
   }
 }

--- a/app/lib/grades/pages/term_settings_page/term_settings_page.dart
+++ b/app/lib/grades/pages/term_settings_page/term_settings_page.dart
@@ -13,9 +13,9 @@ import 'package:sharezone/grades/grades_service/grades_service.dart';
 import 'package:sharezone/grades/pages/create_term_page/create_term_page.dart';
 import 'package:sharezone/grades/pages/grades_dialog/grades_dialog_view.dart'
     hide SubjectView;
-import 'package:sharezone/grades/pages/shared/select_grade_type_dialog.dart';
+import 'package:sharezone/grades/pages/shared/final_grade_type_settings.dart';
 import 'package:sharezone/grades/pages/shared/subject_avatar.dart';
-import 'package:sharezone/grades/pages/subject_settings_page/subject_settings_page.dart';
+import 'package:sharezone/grades/pages/shared/weight_settings.dart';
 import 'package:sharezone/grades/pages/term_settings_page/term_settings_page_controller.dart';
 import 'package:sharezone/grades/pages/term_settings_page/term_settings_page_controller_factory.dart';
 import 'package:sharezone/grades/pages/term_settings_page/term_settings_page_view.dart';
@@ -138,13 +138,7 @@ class _Loaded extends StatelessWidget {
             ),
             const Divider(),
             const SizedBox(height: 8),
-            _FinalGradeType(
-              displayName:
-                  view.finalGradeType.predefinedType?.toUiString() ?? '?',
-              icon: view.finalGradeType.predefinedType?.getIcon() ??
-                  const Icon(Icons.help),
-              selectableGradingTypes: view.selectableGradingTypes,
-            ),
+            _FinalGradeType(view: view),
           ],
         ),
       ),
@@ -456,7 +450,7 @@ class _GradingTypeWeights extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SubjectWeights(
+    return WeightSettings(
       weights: weights,
       selectableGradingTypes: selectableGradingTypes,
       onRemoveGradeType: (gradeTypeId) {
@@ -492,83 +486,22 @@ class _GradingSystem extends StatelessWidget {
 
 class _FinalGradeType extends StatelessWidget {
   const _FinalGradeType({
-    required this.icon,
-    required this.displayName,
-    required this.selectableGradingTypes,
+    required this.view,
   });
 
-  final Icon icon;
-  final String displayName;
-  final IList<GradeType> selectableGradingTypes;
+  final TermSettingsPageView view;
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        ListTile(
-          contentPadding: const EdgeInsets.all(0),
-          title: const Text('Endnote eines Faches'),
-          subtitle: Text(
-            'Die berechnete Fachnote kann von einem Notentyp überschrieben werden.',
-            style: TextStyle(
-                color:
-                    Theme.of(context).colorScheme.onSurface.withOpacity(0.5)),
-          ),
-          trailing: IconButton(
-            tooltip: 'Was ist die Endnote?',
-            icon: const Icon(Icons.help_outline),
-            onPressed: () => _FinalGradeTypeHelpDialog.show(context),
-          ),
-        ),
-        ListTile(
-          leading: icon,
-          title: Text(displayName),
-          onTap: () async {
-            final type = await SelectGradeTypeDialog.show(
-              context: context,
-              selectableGradingTypes: selectableGradingTypes.toList(),
-            );
-
-            if (type != null && context.mounted) {
-              final controller = context.read<TermSettingsPageController>();
-              controller.setFinalGradeType(type);
-            }
-          },
-        ),
-      ],
-    );
-  }
-}
-
-class _FinalGradeTypeHelpDialog extends StatelessWidget {
-  const _FinalGradeTypeHelpDialog();
-
-  static void show(BuildContext context) {
-    showDialog(
-      context: context,
-      builder: (context) => const _FinalGradeTypeHelpDialog(),
-    );
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return MaxWidthConstraintBox(
-      maxWidth: 550,
-      child: AlertDialog(
-        title: const Text('Was ist die Endnote eines Faches?'),
-        content: const SingleChildScrollView(
-          child: Text(
-            'Die Endnote ist die abschließende Note, die du in einem Fach bekommst, zum Beispiel die Note auf deinem Zeugnis. Manchmal berücksichtigt deine Lehrkraft zusätzliche Faktoren, die von der üblichen Berechnungsformel abweichen können – etwa 50% Prüfungen und 50% mündliche Beteiligung. In solchen Fällen kannst du die in Sharezone automatisch berechnete Note durch diese finale Note ersetzen.\n\nDiese Einstellung kann entweder für alle Fächer eines Halbjahres gleichzeitig festgelegt oder für jedes Fach individuell angepasst werden. So hast du die Flexibilität, je nach Bedarf spezifische Anpassungen vorzunehmen.',
-          ),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(),
-            child: const Text('OK'),
-          ),
-        ],
-      ),
+    return FinalGradeTypeSettings(
+      icon: view.finalGradeType.predefinedType?.getIcon() ??
+          const Icon(Icons.help),
+      displayName: view.finalGradeType.predefinedType?.toUiString() ?? '?',
+      selectableGradingTypes: view.selectableGradingTypes,
+      onSetFinalGradeType: (type) {
+        final controller = context.read<TermSettingsPageController>();
+        controller.setFinalGradeType(type);
+      },
     );
   }
 }

--- a/app/lib/grades/pages/term_settings_page/term_settings_page.dart
+++ b/app/lib/grades/pages/term_settings_page/term_settings_page.dart
@@ -506,17 +506,21 @@ class _FinalGradeType extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const Text(
-          'Endnote eines Faches',
-          style: TextStyle(fontSize: 16),
+        ListTile(
+          contentPadding: const EdgeInsets.all(0),
+          title: const Text('Endnote eines Faches'),
+          subtitle: Text(
+            'Die berechnete Fachnote kann von einem Notentyp überschrieben werden.',
+            style: TextStyle(
+                color:
+                    Theme.of(context).colorScheme.onSurface.withOpacity(0.5)),
+          ),
+          trailing: IconButton(
+            tooltip: 'Was ist die Endnote?',
+            icon: const Icon(Icons.help_outline),
+            onPressed: () => _FinalGradeTypeHelpDialog.show(context),
+          ),
         ),
-        const SizedBox(height: 8),
-        Text(
-          'Die berechnete Fachnote kann von einem Notentyp überschrieben werden.',
-          style: TextStyle(
-              color: Theme.of(context).colorScheme.onSurface.withOpacity(0.5)),
-        ),
-        const SizedBox(height: 8),
         ListTile(
           leading: icon,
           title: Text(displayName),
@@ -533,6 +537,38 @@ class _FinalGradeType extends StatelessWidget {
           },
         ),
       ],
+    );
+  }
+}
+
+class _FinalGradeTypeHelpDialog extends StatelessWidget {
+  const _FinalGradeTypeHelpDialog();
+
+  static void show(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (context) => const _FinalGradeTypeHelpDialog(),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaxWidthConstraintBox(
+      maxWidth: 550,
+      child: AlertDialog(
+        title: const Text('Was ist die Endnote eines Faches?'),
+        content: const SingleChildScrollView(
+          child: Text(
+            'Die Endnote ist die abschließende Note, die du in einem Fach bekommst, zum Beispiel die Note auf deinem Zeugnis. Manchmal berücksichtigt deine Lehrkraft zusätzliche Faktoren, die von der üblichen Berechnungsformel abweichen können – etwa 50% Prüfungen und 50% mündliche Beteiligung. In solchen Fällen kannst du die in Sharezone automatisch berechnete Note durch diese finale Note ersetzen.\n\nDiese Einstellung kann entweder für alle Fächer eines Halbjahres gleichzeitig festgelegt oder für jedes Fach individuell angepasst werden. So hast du die Flexibilität, je nach Bedarf spezifische Anpassungen vorzunehmen.',
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('OK'),
+          ),
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
This PR adds help dialog for the final grade type and grade type weights which help the student to understand the features. I also refactored a bit of the code to reuse the widgets in term and subject settings.

https://github.com/SharezoneApp/sharezone-app/assets/24459435/0c90961e-7872-40ef-b7c3-f018c17aba3f

