### PR TITLE
Fix invisible selection color for title text fields

### DIFF
--- a/app/lib/blackboard/blackboard_dialog.dart
+++ b/app/lib/blackboard/blackboard_dialog.dart
@@ -339,27 +339,35 @@ class _TitleField extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[
-                PrefilledTextField(
-                  prefilledText: initialTitle,
-                  focusNode: focusNode,
-                  cursorColor: Colors.white,
-                  maxLines: null,
-                  style: const TextStyle(
-                    color: Colors.white,
-                    fontSize: 20.0,
-                    fontWeight: FontWeight.w400,
+                Theme(
+                  data: Theme.of(context).copyWith(
+                    textSelectionTheme: !context.isDarkThemeEnabled
+                        ? const TextSelectionThemeData(
+                            selectionColor: Colors.white24)
+                        : null,
                   ),
-                  decoration: const InputDecoration(
-                    hintText: "Titel eingeben",
-                    hintStyle: TextStyle(color: Colors.white),
-                    border: InputBorder.none,
-                    enabledBorder: InputBorder.none,
-                    focusedBorder: InputBorder.none,
-                    contentPadding: EdgeInsets.zero,
-                    fillColor: Colors.transparent,
+                  child: PrefilledTextField(
+                    prefilledText: initialTitle,
+                    focusNode: focusNode,
+                    cursorColor: Colors.white,
+                    maxLines: null,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 20.0,
+                      fontWeight: FontWeight.w400,
+                    ),
+                    decoration: const InputDecoration(
+                      hintText: "Titel eingeben",
+                      hintStyle: TextStyle(color: Colors.white),
+                      border: InputBorder.none,
+                      enabledBorder: InputBorder.none,
+                      focusedBorder: InputBorder.none,
+                      contentPadding: EdgeInsets.zero,
+                      fillColor: Colors.transparent,
+                    ),
+                    onChanged: (String title) => bloc.changeTitle(title),
+                    textCapitalization: TextCapitalization.sentences,
                   ),
-                  onChanged: (String title) => bloc.changeTitle(title),
-                  textCapitalization: TextCapitalization.sentences,
                 ),
                 Text(
                   snapshot.error?.toString() ?? "",

--- a/app/lib/homework/homework_dialog/homework_dialog.dart
+++ b/app/lib/homework/homework_dialog/homework_dialog.dart
@@ -957,28 +957,36 @@ class _TitleFieldBase extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
-              PrefilledTextField(
-                key: HwDialogKeys.titleTextField,
-                prefilledText: prefilledTitle,
-                focusNode: focusNode,
-                cursorColor: Colors.white,
-                maxLines: null,
-                style: const TextStyle(
-                  color: Colors.white,
-                  fontSize: 22,
-                  fontWeight: FontWeight.w400,
+              Theme(
+                data: Theme.of(context).copyWith(
+                  textSelectionTheme: !context.isDarkThemeEnabled
+                      ? const TextSelectionThemeData(
+                          selectionColor: Colors.white24)
+                      : null,
                 ),
-                decoration: const InputDecoration(
-                  hintText: "Titel eingeben (z.B. AB Nr. 1 - 3)",
-                  hintStyle: TextStyle(color: Colors.white),
-                  border: InputBorder.none,
-                  enabledBorder: InputBorder.none,
-                  focusedBorder: InputBorder.none,
-                  contentPadding: EdgeInsets.zero,
-                  fillColor: Colors.transparent,
+                child: PrefilledTextField(
+                  key: HwDialogKeys.titleTextField,
+                  prefilledText: prefilledTitle,
+                  focusNode: focusNode,
+                  cursorColor: Colors.white,
+                  maxLines: null,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 22,
+                    fontWeight: FontWeight.w400,
+                  ),
+                  decoration: const InputDecoration(
+                    hintText: "Titel eingeben (z.B. AB Nr. 1 - 3)",
+                    hintStyle: TextStyle(color: Colors.white),
+                    border: InputBorder.none,
+                    enabledBorder: InputBorder.none,
+                    focusedBorder: InputBorder.none,
+                    contentPadding: EdgeInsets.zero,
+                    fillColor: Colors.transparent,
+                  ),
+                  onChanged: onChanged,
+                  textCapitalization: TextCapitalization.sentences,
                 ),
-                onChanged: onChanged,
-                textCapitalization: TextCapitalization.sentences,
               ),
               Text(
                 errorText ?? "",

--- a/app/lib/ical_links/dialog/ical_links_dialog.dart
+++ b/app/lib/ical_links/dialog/ical_links_dialog.dart
@@ -6,6 +6,7 @@
 //
 // SPDX-License-Identifier: EUPL-1.2
 
+import 'package:build_context/build_context.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:sharezone/ical_links/dialog/ical_links_dialog_controller.dart';
@@ -158,27 +159,35 @@ class _TitleFieldBase extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
-              PrefilledTextField(
-                prefilledText: prefilledTitle,
-                focusNode: focusNode,
-                cursorColor: Colors.white,
-                maxLines: null,
-                style: const TextStyle(
-                  color: Colors.white,
-                  fontSize: 22,
-                  fontWeight: FontWeight.w400,
+              Theme(
+                data: Theme.of(context).copyWith(
+                  textSelectionTheme: !context.isDarkThemeEnabled
+                      ? const TextSelectionThemeData(
+                          selectionColor: Colors.white24)
+                      : null,
                 ),
-                decoration: const InputDecoration(
-                  hintText: "Name eingeben (z.B. Meine Prüfungen)",
-                  hintStyle: TextStyle(color: Colors.white),
-                  border: InputBorder.none,
-                  enabledBorder: InputBorder.none,
-                  focusedBorder: InputBorder.none,
-                  contentPadding: EdgeInsets.zero,
-                  fillColor: Colors.transparent,
+                child: PrefilledTextField(
+                  prefilledText: prefilledTitle,
+                  focusNode: focusNode,
+                  cursorColor: Colors.white,
+                  maxLines: null,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 22,
+                    fontWeight: FontWeight.w400,
+                  ),
+                  decoration: const InputDecoration(
+                    hintText: "Name eingeben (z.B. Meine Prüfungen)",
+                    hintStyle: TextStyle(color: Colors.white),
+                    border: InputBorder.none,
+                    enabledBorder: InputBorder.none,
+                    focusedBorder: InputBorder.none,
+                    contentPadding: EdgeInsets.zero,
+                    fillColor: Colors.transparent,
+                  ),
+                  onChanged: onChanged,
+                  textCapitalization: TextCapitalization.sentences,
                 ),
-                onChanged: onChanged,
-                textCapitalization: TextCapitalization.sentences,
               ),
               Text(
                 errorText ?? "",

--- a/app/lib/timetable/timetable_add_event/timetable_add_event_dialog.dart
+++ b/app/lib/timetable/timetable_add_event/timetable_add_event_dialog.dart
@@ -310,28 +310,36 @@ class _TitleFieldBase extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
-              PrefilledTextField(
-                key: HwDialogKeys.titleTextField,
-                prefilledText: prefilledTitle,
-                focusNode: focusNode,
-                cursorColor: Colors.white,
-                maxLines: null,
-                style: const TextStyle(
-                  color: Colors.white,
-                  fontSize: 22,
-                  fontWeight: FontWeight.w400,
+              Theme(
+                data: Theme.of(context).copyWith(
+                  textSelectionTheme: !context.isDarkThemeEnabled
+                      ? const TextSelectionThemeData(
+                          selectionColor: Colors.white24)
+                      : null,
                 ),
-                decoration: InputDecoration(
-                  hintText: hintText,
-                  hintStyle: const TextStyle(color: Colors.white),
-                  border: InputBorder.none,
-                  enabledBorder: InputBorder.none,
-                  focusedBorder: InputBorder.none,
-                  contentPadding: EdgeInsets.zero,
-                  fillColor: Colors.transparent,
+                child: PrefilledTextField(
+                  key: HwDialogKeys.titleTextField,
+                  prefilledText: prefilledTitle,
+                  focusNode: focusNode,
+                  cursorColor: Colors.white,
+                  maxLines: null,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 22,
+                    fontWeight: FontWeight.w400,
+                  ),
+                  decoration: InputDecoration(
+                    hintText: hintText,
+                    hintStyle: const TextStyle(color: Colors.white),
+                    border: InputBorder.none,
+                    enabledBorder: InputBorder.none,
+                    focusedBorder: InputBorder.none,
+                    contentPadding: EdgeInsets.zero,
+                    fillColor: Colors.transparent,
+                  ),
+                  onChanged: onChanged,
+                  textCapitalization: TextCapitalization.sentences,
                 ),
-                onChanged: onChanged,
-                textCapitalization: TextCapitalization.sentences,
               ),
               Text(
                 errorText ?? "",


### PR DESCRIPTION
## Description

In light mode, the selection color was the same as the background. Therefore, it was invisible.

## Before


https://github.com/SharezoneApp/sharezone-app/assets/24459435/ce0f2f68-fabc-41e9-9362-3cca74225b7b

## After


https://github.com/SharezoneApp/sharezone-app/assets/24459435/f8e3c378-068b-4218-be5b-760127670556

(in the future, we should extract these title widgets into one widget to avoid code duplication)