### PR TITLE
Move `sz_plus_subscribed` analytics event after purchase

### DIFF
--- a/app/lib/sharezone_plus/page/sharezone_plus_page_controller.dart
+++ b/app/lib/sharezone_plus/page/sharezone_plus_page_controller.dart
@@ -137,16 +137,16 @@ class SharezonePlusPageController extends ChangeNotifier {
     }
 
     try {
-      _analytics.logSubscribed(
-        selectedPurchasePeriod.name,
-        PlatformCheck.currentPlatform.name,
-      );
-
       if (PlatformCheck.isWeb) {
         await _buyOnWeb();
       } else {
         await _purchaseService.purchase(_getProductId());
       }
+
+      _analytics.logSubscribed(
+        selectedPurchasePeriod.name,
+        PlatformCheck.currentPlatform.name,
+      );
     } catch (e, s) {
       isPurchaseButtonLoading = false;
       notifyListeners();


### PR DESCRIPTION
The current order also counts users who cancel the purchase process the `sz_plus_subscribed` event.