### PR TITLE
Fix: Deleting a term now sets `currentTerm` in Firestore doc to `null`.

### DIFF
--- a/app/lib/grades/grades_service/src/grades_repository.dart
+++ b/app/lib/grades/grades_service/src/grades_repository.dart
@@ -50,19 +50,19 @@ class InMemoryGradesStateRepository extends GradesStateRepository {
     ));
   }
 
-  Map<String, Object> _data = {};
+  Map<String, Object?> data = {};
 
   @override
   void updateState(GradesState state) {
     // We use the Firestore Repository methods so we test the (de)serialization
     // even in our unit tests, which means a bigger test coverage.
-    _data = FirestoreGradesStateRepository.toDto(state);
+    data = FirestoreGradesStateRepository.toDto(state);
     // debugPrint(json.encode(data, toEncodable: (val) {
     //   if (val is Timestamp) {
     //     return val.millisecondsSinceEpoch;
     //   }
     // }));
-    this.state.add(FirestoreGradesStateRepository.fromData(_data));
+    this.state.add(FirestoreGradesStateRepository.fromData(data));
   }
 }
 
@@ -123,11 +123,11 @@ class FirestoreGradesStateRepository extends GradesStateRepository {
     }
   }
 
-  static Map<String, Object> toDto(GradesState state) {
+  static Map<String, Object?> toDto(GradesState state) {
     final currentTermOrNull =
         state.terms.firstWhereOrNull((term) => term.isActiveTerm)?.id.value;
     return {
-      if (currentTermOrNull != null) 'currentTerm': currentTermOrNull,
+      'currentTerm': currentTermOrNull,
       'terms': state.terms
           .map((term) =>
               MapEntry(term.id.value, TermDto.fromTerm(term).toData()))

--- a/app/test/grades/grades_repository_test.dart
+++ b/app/test/grades/grades_repository_test.dart
@@ -99,6 +99,20 @@ void main() {
         expect(controller.terms, isEmpty);
       });
     });
+    test('when deleting a term the currentTerm is set to null', () {
+      final repository = TestFirestoreGradesStateRepository();
+      final controller = GradesTestController(
+          gradesService: GradesService(repository: repository));
+
+      final term = termWith(name: 'term1');
+      controller.createTerm(term);
+      controller.deleteTerm(term.id);
+
+      // containsKey should be true as otherwise Firestore won't change the
+      // currentTerm to null
+      expect(repository.data.containsKey('currentTerm'), isTrue);
+      expect(repository.data['currentTerm'], isNull);
+    });
     test('serializes expected data map for empty state', () {
       final res = FirestoreGradesStateRepository.toDto((
         customGradeTypes: const IListConst([]),
@@ -107,6 +121,7 @@ void main() {
       ));
 
       expect(res, {
+        'currentTerm': null,
         'customGradeTypes': {},
         'subjects': {},
         'grades': {},
@@ -115,6 +130,7 @@ void main() {
     });
     test('deserializes expected state from data map', () {
       final res = FirestoreGradesStateRepository.fromData({
+        'currentTerm': null,
         'customGradeTypes': {},
         'subjects': {},
         'grades': {},
@@ -915,7 +931,7 @@ void main() {
 /// We use the Firestore (de-)serialization methods to test the repository.
 /// This lets us not depend on Firestore here (and having to mock it).
 class TestFirestoreGradesStateRepository extends GradesStateRepository {
-  Map<String, Object> data = {};
+  Map<String, Object?> data = {};
 
   @override
   BehaviorSubject<GradesState> state = BehaviorSubject<GradesState>.seeded(


### PR DESCRIPTION
When deleting all terms `currentTerm` would still be set to the old current term before. This is because if no current/active term was existing we didn't add the `currentTerm` key to the data map at all. This would leave the value unchanged. Now we explicitly set the field to null in this case.

Fixes #1573 
