### PR TITLE
Fix deletion of subjects if final type of term was changed.

### DIFF
--- a/app/lib/grades/grades_service/src/term.dart
+++ b/app/lib/grades/grades_service/src/term.dart
@@ -158,8 +158,9 @@ class TermModel extends Equatable {
   }
 
   TermModel setFinalGradeType(GradeTypeId gradeType) {
-    final newSubjects =
-        subjects.where((s) => s.isFinalGradeTypeOverridden == false).map((s) {
+    final newSubjects = subjects.map((s) {
+      if (s.isFinalGradeTypeOverridden) return s;
+
       final newSubject = s.copyWith(finalGradeType: gradeType);
       return newSubject;
     }).toIList();

--- a/app/test/grades/grades_test.dart
+++ b/app/test/grades/grades_test.dart
@@ -1388,4 +1388,45 @@ void main() {
           throwsA(const SubjectNotFoundException(SubjectId('Unknown'))));
     });
   });
+  test(
+      'Regression test: Changing the final grade type of a term shouldnt delete any subjects',
+      () {
+    final controller = GradesTestController();
+
+    controller.createTerm(
+      termWith(
+        id: const TermId('term1'),
+        finalGradeType: GradeType.other.id,
+        subjects: [
+          subjectWith(
+            id: const SubjectId('Deutsch'),
+            finalGradeType: GradeType.vocabularyTest.id,
+            grades: [gradeWith(value: 2)],
+          ),
+          subjectWith(
+            id: const SubjectId('Sport'),
+            grades: [gradeWith(value: 2)],
+          ),
+        ],
+      ),
+    );
+
+    // This would delete any subject with no overridden final grade type before
+    // fixing the bug.
+    controller.editTerm(
+      const TermId('term1'),
+      finalGradeType: GradeType.vocabularyTest.id,
+    );
+
+    expect(
+        controller
+            .term(const TermId('term1'))
+            .subjects
+            .map((sub) => sub.id)
+            .toList(),
+        [
+          const SubjectId('Deutsch'),
+          const SubjectId('Sport'),
+        ]);
+  });
 }


### PR DESCRIPTION
Fix the bug that would cause subjects that have no overridden final grade type to be deleted when changing the final grade type of a term.