### PR TITLE
Replace `list-certificates` with `certificates list` for our `sz deploy` command

### DIFF
--- a/tools/sz_repo_cli/lib/src/common/src/app_store_connect_utils.dart
+++ b/tools/sz_repo_cli/lib/src/common/src/app_store_connect_utils.dart
@@ -81,7 +81,8 @@ Future<void> _listMacCertificates(ProcessRunner processRunner) async {
   await processRunner.run(
     [
       'app-store-connect',
-      'list-certificates',
+      'certificates',
+      'list',
       '--type',
       'MAC_INSTALLER_DISTRIBUTION',
       '--save',


### PR DESCRIPTION
`app-storec-connect list-certificates` are deprecated, see: 

https://github.com/codemagic-ci-cd/cli-tools/blob/0bed134d36130ae0408fe973bd5fcd982f98f251/CHANGELOG.md?plain=1#L90

We need to replace it with `app-storec-connect certificates list`.