### PR TITLE
Enable video player for macOS

### DIFF
--- a/app/lib/filesharing/logic/open_cloud_file.dart
+++ b/app/lib/filesharing/logic/open_cloud_file.dart
@@ -144,12 +144,7 @@ class FirestoreFilePage extends StatelessWidget {
       );
     }
 
-    // Video Page for Android, iOS und Web
-    //
-    // We just download the video for macOS because the video_player package is
-    // not available on macOS yet. Tracking issue:
-    // https://github.com/flutter/flutter/issues/41688
-    if (fileFormat == FileFormat.video && !PlatformCheck.isMacOS) {
+    if (fileFormat == FileFormat.video) {
       return VideoFilePage(
         name: name!,
         nameStream: nameStream,


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/41688 is closed and video player is supported on macOS now.


https://github.com/SharezoneApp/sharezone-app/assets/24459435/b156fe0d-b72c-4e29-8ec8-61727b34a7f4

