### PR TITLE
Add editing custom grade types

### DIFF
--- a/app/lib/grades/grades_service/grades_service.dart
+++ b/app/lib/grades/grades_service/grades_service.dart
@@ -392,6 +392,13 @@ class GradesService {
     if (!_hasGradeTypeWithId(id)) {
       throw GradeTypeNotFoundException(id);
     }
+
+    final newCustomGradeTypes = _customGradeTypes.replaceAllWhere(
+        (element) => element.id == id,
+        GradeType(id: id, displayName: displayName));
+
+    final newState = _state.copyWith(customGradeTypes: newCustomGradeTypes);
+    _updateState(newState);
   }
 
   /// Deletes a custom grade type and removes it from all weight maps.

--- a/app/lib/grades/grades_service/grades_service.dart
+++ b/app/lib/grades/grades_service/grades_service.dart
@@ -389,6 +389,9 @@ class GradesService {
     if (isPredefinedGradeType) {
       throw ArgumentError('Cannot edit a predefined grade type.');
     }
+    if (!_hasGradeTypeWithId(id)) {
+      throw GradeTypeNotFoundException(id);
+    }
   }
 
   /// Deletes a custom grade type and removes it from all weight maps.

--- a/app/lib/grades/grades_service/grades_service.dart
+++ b/app/lib/grades/grades_service/grades_service.dart
@@ -382,6 +382,15 @@ class GradesService {
     _updateState(newState);
   }
 
+  void editCustomGradeType(
+      {required GradeTypeId id, required String displayName}) {
+    final isPredefinedGradeType =
+        GradeType.predefinedGradeTypes.map((gt) => gt.id).contains(id);
+    if (isPredefinedGradeType) {
+      throw ArgumentError('Cannot edit a predefined grade type.');
+    }
+  }
+
   /// Deletes a custom grade type and removes it from all weight maps.
   ///
   /// A custom grade type can only be deleted if it is not assigned to any grade

--- a/app/lib/grades/grades_service/grades_service.dart
+++ b/app/lib/grades/grades_service/grades_service.dart
@@ -384,6 +384,9 @@ class GradesService {
 
   void editCustomGradeType(
       {required GradeTypeId id, required String displayName}) {
+    if (displayName.isEmpty) {
+      throw ArgumentError('The display name must not be empty.');
+    }
     final isPredefinedGradeType =
         GradeType.predefinedGradeTypes.map((gt) => gt.id).contains(id);
     if (isPredefinedGradeType) {

--- a/app/lib/grades/grades_service/grades_service.dart
+++ b/app/lib/grades/grades_service/grades_service.dart
@@ -384,7 +384,7 @@ class GradesService {
 
   /// Edits properties of a custom grade type.
   ///
-  /// Throws [ArgumentError] if the display name is empty.
+  /// Throws [ArgumentError] if the [displayName] is empty.
   ///
   /// Throws [GradeTypeNotFoundException] if the grade type with the given [id]
   /// does not exist.

--- a/app/lib/grades/grades_service/grades_service.dart
+++ b/app/lib/grades/grades_service/grades_service.dart
@@ -382,11 +382,21 @@ class GradesService {
     _updateState(newState);
   }
 
+  /// Edits properties of a custom grade type.
+  ///
+  /// Throws [ArgumentError] if the display name is empty.
+  ///
+  /// Throws [GradeTypeNotFoundException] if the grade type with the given [id]
+  /// does not exist.
+  ///
+  /// Throws [ArgumentError] if the grade type with the given [id] is a
+  /// predefined grade type.
   void editCustomGradeType(
       {required GradeTypeId id, required String displayName}) {
     if (displayName.isEmpty) {
       throw ArgumentError('The display name must not be empty.');
     }
+
     final isPredefinedGradeType =
         GradeType.predefinedGradeTypes.map((gt) => gt.id).contains(id);
     if (isPredefinedGradeType) {

--- a/app/test/grades/grade_types_test.dart
+++ b/app/test/grades/grade_types_test.dart
@@ -371,5 +371,16 @@ void main() {
       expect(gradeTypeIds, containsOnce(const GradeTypeId('custom')));
       expect(gradeTypeIds, containsOnce(GradeType.oralParticipation.id));
     });
+    test('Trying to edit a predefined grade type will throw an ArgumentError',
+        () {
+      final controller = GradesTestController();
+
+      for (final gradeType in controller.getPossibleGradeTypes()) {
+        expect(
+            () => controller.editCustomGradeType(gradeType.id,
+                displayName: 'foo'),
+            throwsArgumentError);
+      }
+    });
   });
 }

--- a/app/test/grades/grade_types_test.dart
+++ b/app/test/grades/grade_types_test.dart
@@ -392,5 +392,15 @@ void main() {
               displayName: 'foo'),
           throwsA(const GradeTypeNotFoundException(GradeTypeId('foo'))));
     });
+    test('One can change the name of a custom grade type', () {
+      final controller = GradesTestController();
+
+      controller.createCustomGradeType(
+          const GradeType(id: GradeTypeId('foo'), displayName: 'foo'));
+      controller.editCustomGradeType(const GradeTypeId('foo'),
+          displayName: 'bar');
+
+      expect(controller.getCustomGradeTypes().single.displayName, 'bar');
+    });
   });
 }

--- a/app/test/grades/grade_types_test.dart
+++ b/app/test/grades/grade_types_test.dart
@@ -422,5 +422,17 @@ void main() {
       expect(controller.term(const TermId('foo')).finalGradeType.displayName,
           'bar');
     });
+    test(
+        'Trying to edit the name of a custom grade type to an empty string throws an $ArgumentError',
+        () {
+      final controller = GradesTestController();
+      controller.createCustomGradeType(
+          const GradeType(id: GradeTypeId('foo'), displayName: 'foo'));
+
+      expect(
+          () => controller.editCustomGradeType(const GradeTypeId('foo'),
+              displayName: ''),
+          throwsArgumentError);
+    });
   });
 }

--- a/app/test/grades/grade_types_test.dart
+++ b/app/test/grades/grade_types_test.dart
@@ -382,5 +382,15 @@ void main() {
             throwsArgumentError);
       }
     });
+    test(
+        'Trying to edit an unknown custom grade type will throw an $GradeTypeNotFoundException',
+        () {
+      final controller = GradesTestController();
+
+      expect(
+          () => controller.editCustomGradeType(const GradeTypeId('foo'),
+              displayName: 'foo'),
+          throwsA(const GradeTypeNotFoundException(GradeTypeId('foo'))));
+    });
   });
 }

--- a/app/test/grades/grade_types_test.dart
+++ b/app/test/grades/grade_types_test.dart
@@ -394,13 +394,33 @@ void main() {
     });
     test('One can change the name of a custom grade type', () {
       final controller = GradesTestController();
-
       controller.createCustomGradeType(
           const GradeType(id: GradeTypeId('foo'), displayName: 'foo'));
+
+      controller.createTerm(termWith(
+        id: const TermId('foo'),
+        finalGradeType: const GradeTypeId('foo'),
+        subjects: [
+          subjectWith(
+            id: const SubjectId('bar'),
+            finalGradeType: const GradeTypeId('foo'),
+            grades: [
+              gradeWith(
+                id: const GradeId('bar'),
+                type: const GradeTypeId('foo'),
+                value: 3,
+              ),
+            ],
+          ),
+        ],
+      ));
+
       controller.editCustomGradeType(const GradeTypeId('foo'),
           displayName: 'bar');
 
       expect(controller.getCustomGradeTypes().single.displayName, 'bar');
+      expect(controller.term(const TermId('foo')).finalGradeType.displayName,
+          'bar');
     });
   });
 }

--- a/app/test/grades/grades_test_common.dart
+++ b/app/test/grades/grades_test_common.dart
@@ -307,6 +307,10 @@ class GradesTestController {
       {required TermId termId, required GradeTypeId gradeTypeId}) {
     service.editTerm(id: termId, finalGradeType: gradeTypeId);
   }
+
+  void editCustomGradeType(GradeTypeId id, {required String displayName}) {
+    service.editCustomGradeType(id: id, displayName: displayName);
+  }
 }
 
 TestTerm termWith({


### PR DESCRIPTION
Adds `GradeService.editCustomGradeType` that can be used to edit a custom grade type. Currently this means that the display name can be changed, in the future maybe an icon as well.

Fixes #1531