### PR TITLE
Make passing ids to `GradesService` optional, create `GradeInput`,`SubjectInput` classes

### DIFF
--- a/app/lib/grades/grades_service/grades_service.dart
+++ b/app/lib/grades/grades_service/grades_service.dart
@@ -301,16 +301,16 @@ class GradesService {
     return gradeId;
   }
 
-  /// Replaces an existing grade with [_Grade.id] with the [newGrade].
+  /// Replaces an existing grade with [id] with the [newGrade].
   ///
-  /// Throws [GradeNotFoundException] if no grade with the given [_Grade.id]
-  /// of [newGrade] exists.
+  /// Throws [GradeNotFoundException] if no grade with the given [id] of
+  /// [newGrade] exists.
   ///
   /// Throws [GradeTypeNotFoundException] if the grade type of [newGrade] does
   /// not exist.
   ///
-  /// Throws [InvalidGradeValueException] if the [_Grade.value] of the [newGrade]
-  /// is not valid for the [_Grade.gradingSystem] of the [newGrade].
+  /// Throws [InvalidGradeValueException] if the [_Grade.value] of the
+  /// [newGrade] is not valid for the [_Grade.gradingSystem] of the [newGrade].
   void editGrade(GradeId id, GradeInput newGrade) {
     final grade = newGrade.toGrade(id);
 

--- a/app/lib/grades/grades_service/grades_service.dart
+++ b/app/lib/grades/grades_service/grades_service.dart
@@ -499,16 +499,22 @@ class GradesService {
     return getPossibleGradeTypes().firstWhere((gt) => gt.id == finalGradeType);
   }
 
-  void addSubject(Subject subject) {
+  SubjectId addSubject(SubjectInput subjectInput,
+      {@visibleForTesting SubjectId? id}) {
+    final subjectId = id ?? SubjectId(Id.generate().value);
+    final subject = subjectInput.toSubject(subjectId);
+
     if (subject.createdOn != null) {
       throw ArgumentError(
           'The createdOn field should not be set when adding a new subject.');
     }
-    if (getSubjects().any((s) => s.id == subject.id)) {
-      throw SubjectAlreadyExistsException(subject.id);
+    if (getSubjects().any((s) => s.id == subjectId)) {
+      throw SubjectAlreadyExistsException(subjectId);
     }
     final newState = _state.copyWith(subjects: _subjects.add(subject));
     _updateState(newState);
+
+    return subjectId;
   }
 
   IList<Subject> getSubjects() {
@@ -943,8 +949,24 @@ class GradeTypeId extends Id {
   const GradeTypeId(super.value);
 }
 
-class Subject extends Equatable {
+class Subject extends SubjectInput {
   final SubjectId id;
+
+  @override
+  List<Object?> get props =>
+      [id, design, name, abbreviation, connectedCourses, createdOn];
+
+  const Subject({
+    required this.id,
+    required super.design,
+    required super.name,
+    required super.abbreviation,
+    required super.connectedCourses,
+    super.createdOn,
+  });
+}
+
+class SubjectInput extends Equatable {
   final Design design;
   final String name;
   final String abbreviation;
@@ -953,16 +975,28 @@ class Subject extends Equatable {
 
   @override
   List<Object?> get props =>
-      [id, design, name, abbreviation, connectedCourses, createdOn];
+      [design, name, abbreviation, connectedCourses, createdOn];
 
-  const Subject({
-    required this.id,
+  const SubjectInput({
     required this.design,
     required this.name,
     required this.abbreviation,
     required this.connectedCourses,
     this.createdOn,
   });
+}
+
+extension on SubjectInput {
+  Subject toSubject(SubjectId id) {
+    return Subject(
+      id: id,
+      design: design,
+      name: name,
+      abbreviation: abbreviation,
+      connectedCourses: connectedCourses,
+      createdOn: createdOn,
+    );
+  }
 }
 
 class ConnectedCourse extends Equatable {

--- a/app/lib/grades/grades_service/grades_service.dart
+++ b/app/lib/grades/grades_service/grades_service.dart
@@ -124,13 +124,15 @@ class GradesService {
     );
   }
 
-  void addTerm({
-    required TermId id,
+  TermId addTerm({
     required String name,
     required GradeTypeId finalGradeType,
     required GradingSystem gradingSystem,
     required bool isActiveTerm,
+    @visibleForTesting TermId? id,
   }) {
+    final termId = id ?? TermId(Id.generate().value);
+
     IList<TermModel> newTerms = _terms;
     if (isActiveTerm) {
       newTerms = newTerms.map((term) => term.setIsActiveTerm(false)).toIList();
@@ -142,7 +144,7 @@ class GradesService {
 
     newTerms = newTerms.add(
       TermModel(
-        id: id,
+        id: termId,
         isActiveTerm: isActiveTerm,
         name: name,
         finalGradeType: finalGradeType,
@@ -150,6 +152,7 @@ class GradesService {
       ),
     );
     _updateTerms(newTerms);
+    return termId;
   }
 
   /// Edits the given values of the term (does not edit if the value is null).

--- a/app/lib/grades/grades_service/grades_service.dart
+++ b/app/lib/grades/grades_service/grades_service.dart
@@ -407,14 +407,23 @@ class GradesService {
   /// Creates a custom grade type.
   ///
   /// If the grade type already exists, nothing will happen.
-  void addCustomGradeType(GradeType gradeType) {
-    if (_hasGradeTypeWithId(gradeType.id)) {
-      // Already exists
-      return;
+  GradeTypeId addCustomGradeType({
+    required String displayName,
+    @visibleForTesting GradeTypeId? id,
+  }) {
+    final gradeTypeId = id ?? GradeTypeId(Id.generate().value);
+    final gradeType = GradeType(id: gradeTypeId, displayName: displayName);
+
+    if (_hasGradeTypeWithId(gradeTypeId)) {
+      // Already exists.
+      return gradeTypeId;
     }
+
     final newState =
         _state.copyWith(customGradeTypes: _customGradeTypes.add(gradeType));
     _updateState(newState);
+
+    return gradeTypeId;
   }
 
   /// Edits properties of a custom grade type.

--- a/app/lib/grades/grades_service/grades_service.dart
+++ b/app/lib/grades/grades_service/grades_service.dart
@@ -273,7 +273,7 @@ class GradesService {
     _updateTerm(newTerm);
   }
 
-  void addGrade({
+  GradeId addGrade({
     required SubjectId subjectId,
     required TermId termId,
     required GradeInput value,
@@ -297,6 +297,8 @@ class GradesService {
     }
     newTerm = newTerm.addGrade(grade, toSubject: subjectId);
     _updateTerm(newTerm);
+
+    return gradeId;
   }
 
   /// Replaces an existing grade with [_Grade.id] with the [newGrade].

--- a/app/lib/grades/grades_service/src/term.dart
+++ b/app/lib/grades/grades_service/src/term.dart
@@ -6,6 +6,8 @@
 //
 // SPDX-License-Identifier: EUPL-1.2
 
+// ignore_for_file: library_private_types_in_public_api
+
 part of '../grades_service.dart';
 
 @visibleForTesting
@@ -174,7 +176,7 @@ class TermModel extends Equatable {
     return _copyWith(finalGradeType: gradeType, subjects: newSubjects);
   }
 
-  TermModel addGrade(Grade grade, {required SubjectId toSubject}) {
+  TermModel addGrade(_Grade grade, {required SubjectId toSubject}) {
     var subject = subjects.firstWhere(
       (s) => s.id == toSubject,
       orElse: () => throw SubjectNotFoundException(toSubject),
@@ -189,7 +191,7 @@ class TermModel extends Equatable {
         : _copyWith(subjects: subjects.add(subject));
   }
 
-  TermModel replaceGrade(Grade grade) {
+  TermModel replaceGrade(_Grade grade) {
     final subject = subjects.firstWhere((s) => s.hasGrade(grade.id));
     final gradeModel = _toGradeModel(grade, subjectId: subject.id);
 
@@ -213,7 +215,7 @@ class TermModel extends Equatable {
     );
   }
 
-  GradeModel _toGradeModel(Grade grade, {required SubjectId subjectId}) {
+  GradeModel _toGradeModel(_Grade grade, {required SubjectId subjectId}) {
     final originalInput = grade.value;
     final gradingSystem = grade.gradingSystem.toGradingSystemModel();
     final gradeVal = gradingSystem.toNumOrThrow(grade.value);

--- a/app/lib/grades/pages/create_term_page/create_term_page_controller.dart
+++ b/app/lib/grades/pages/create_term_page/create_term_page_controller.dart
@@ -6,7 +6,6 @@
 //
 // SPDX-License-Identifier: EUPL-1.2
 
-import 'package:common_domain_models/common_domain_models.dart';
 import 'package:crash_analytics/crash_analytics.dart';
 import 'package:flutter/material.dart';
 import 'package:sharezone/grades/grades_service/grades_service.dart';
@@ -57,9 +56,7 @@ class CreateTermPageController extends ChangeNotifier {
     }
 
     try {
-      final termId = TermId(Id.generate().value);
-      gradesService.addTerm(
-        id: termId,
+      final termId = gradesService.addTerm(
         name: view.name!,
         isActiveTerm: view.isActiveTerm,
         finalGradeType: GradeType.schoolReportGrade.id,

--- a/app/lib/grades/pages/grades_dialog/grades_dialog_controller.dart
+++ b/app/lib/grades/pages/grades_dialog/grades_dialog_controller.dart
@@ -17,7 +17,6 @@ import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:flutter/material.dart';
 import 'package:group_domain_models/group_domain_models.dart';
 import 'package:sharezone/grades/grades_service/grades_service.dart';
-import 'package:sharezone_utils/random_string.dart';
 
 import 'grades_dialog_view.dart';
 
@@ -448,12 +447,10 @@ class GradesDialogController extends ChangeNotifier {
     };
 
     try {
-      final gradeId = GradeId(randomIDString(20));
       gradesService.addGrade(
         subjectId: _selectSubjectId!,
         termId: _selectedTermId!,
-        value: Grade(
-          id: gradeId,
+        value: GradeInput(
           type: _gradeType.id,
           value: _grade!,
           date: _date,

--- a/app/lib/grades/pages/grades_dialog/grades_dialog_controller.dart
+++ b/app/lib/grades/pages/grades_dialog/grades_dialog_controller.dart
@@ -486,10 +486,10 @@ class GradesDialogController extends ChangeNotifier {
     final connectedCourses = _getConnectedCourses(subject.id);
 
     gradesService.addSubject(
-      Subject(
+      id: subject.id,
+      SubjectInput(
         abbreviation: subject.abbreviation,
         design: subject.design,
-        id: subject.id,
         name: subject.name,
         connectedCourses: connectedCourses,
       ),

--- a/app/lib/grades/pages/grades_dialog/grades_dialog_controller.dart
+++ b/app/lib/grades/pages/grades_dialog/grades_dialog_controller.dart
@@ -486,6 +486,9 @@ class GradesDialogController extends ChangeNotifier {
     final connectedCourses = _getConnectedCourses(subject.id);
 
     gradesService.addSubject(
+      // Not passing the id here would require some refactoring, so for now we
+      // just pass the id of the subject.
+      // ignore: invalid_use_of_visible_for_testing_member
       id: subject.id,
       SubjectInput(
         abbreviation: subject.abbreviation,

--- a/app/lib/grades/pages/term_dialog/term_dialog_controller.dart
+++ b/app/lib/grades/pages/term_dialog/term_dialog_controller.dart
@@ -29,7 +29,6 @@ class TermDialogController extends ChangeNotifier {
 
   Future<void> addTerm() async {
     gradesService.addTerm(
-      id: TermId(termName),
       gradingSystem: gradingSystem,
       name: termName,
       finalGradeType: GradeType.schoolReportGrade.id,

--- a/app/lib/grades/pages/term_settings_page/term_settings_page_controller.dart
+++ b/app/lib/grades/pages/term_settings_page/term_settings_page_controller.dart
@@ -185,12 +185,9 @@ class TermSettingsPageController extends ChangeNotifier {
   SubjectId _createSubject(SubjectId subjectId) {
     final subject = view.subjects.firstWhere((s) => s.id == subjectId);
     final connectedCourses = _getConnectedCourses(subjectId);
-    // We generate a new subject ID because the previous subject ID was just the
-    // course ID (as temporary ID).
-    final newSubjectId = SubjectId(Id.generate().value);
-    gradesService.addSubject(
-      Subject(
-        id: newSubjectId,
+
+    final newSubjectId = gradesService.addSubject(
+      SubjectInput(
         design: subject.design,
         name: subject.displayName,
         abbreviation: subject.abbreviation,

--- a/app/test/grades/grades_repository_test.dart
+++ b/app/test/grades/grades_repository_test.dart
@@ -170,34 +170,38 @@ void main() {
         isActiveTerm: false,
       );
 
-      service.addSubject(Subject(
+      service.addSubject(
         id: const SubjectId('mathe'),
-        design: Design.random(random),
-        name: 'Mathe',
-        abbreviation: 'M',
-        connectedCourses: const IListConst([
-          ConnectedCourse(
-            id: CourseId('connected-mathe-course'),
-            name: 'Mathe 8a',
-            abbreviation: 'M',
-            subjectName: 'Mathe',
-          )
-        ]),
-      ));
-      service.addSubject(Subject(
+        SubjectInput(
+          design: Design.random(random),
+          name: 'Mathe',
+          abbreviation: 'M',
+          connectedCourses: const IListConst([
+            ConnectedCourse(
+              id: CourseId('connected-mathe-course'),
+              name: 'Mathe 8a',
+              abbreviation: 'M',
+              subjectName: 'Mathe',
+            )
+          ]),
+        ),
+      );
+      service.addSubject(
         id: const SubjectId('englisch'),
-        design: Design.random(random),
-        name: 'Englisch',
-        abbreviation: 'E',
-        connectedCourses: const IListConst([
-          ConnectedCourse(
-            id: CourseId('connected-englisch-course'),
-            name: 'Englisch 8a',
-            abbreviation: 'E',
-            subjectName: 'Englisch',
-          )
-        ]),
-      ));
+        SubjectInput(
+          design: Design.random(random),
+          name: 'Englisch',
+          abbreviation: 'E',
+          connectedCourses: const IListConst([
+            ConnectedCourse(
+              id: CourseId('connected-englisch-course'),
+              name: 'Englisch 8a',
+              abbreviation: 'E',
+              subjectName: 'Englisch',
+            )
+          ]),
+        ),
+      );
 
       service.addGrade(
           id: const GradeId('grade-1'),

--- a/app/test/grades/grades_repository_test.dart
+++ b/app/test/grades/grades_repository_test.dart
@@ -149,10 +149,8 @@ void main() {
       final random = Random(42);
 
       service.addCustomGradeType(
-        const GradeType(
-          id: GradeTypeId('my-custom-grade-type'),
-          displayName: 'My Custom Grade Type',
-        ),
+        id: const GradeTypeId('my-custom-grade-type'),
+        displayName: 'My Custom Grade Type',
       );
 
       service.addTerm(

--- a/app/test/grades/grades_repository_test.dart
+++ b/app/test/grades/grades_repository_test.dart
@@ -200,10 +200,10 @@ void main() {
       ));
 
       service.addGrade(
+          id: const GradeId('grade-1'),
           subjectId: const SubjectId('mathe'),
           termId: const TermId('02-10-term'),
-          value: Grade(
-            id: const GradeId('grade-1'),
+          value: GradeInput(
             value: '13',
             gradingSystem: GradingSystem.zeroToFifteenPoints,
             type: const GradeTypeId('my-custom-grade-type'),
@@ -213,10 +213,10 @@ void main() {
             details: 'hello',
           ));
       service.addGrade(
+          id: const GradeId('grade-2'),
           subjectId: const SubjectId('mathe'),
           termId: const TermId('02-10-term'),
-          value: Grade(
-            id: const GradeId('grade-2'),
+          value: GradeInput(
             value: '3',
             gradingSystem: GradingSystem.zeroToFifteenPoints,
             type: GradeType.vocabularyTest.id,
@@ -227,10 +227,10 @@ void main() {
           ));
 
       service.addGrade(
+          id: const GradeId('grade-3'),
           subjectId: const SubjectId('englisch'),
           termId: const TermId('01-10-term'),
-          value: Grade(
-            id: const GradeId('grade-3'),
+          value: GradeInput(
             value: '2-',
             gradingSystem: GradingSystem.oneToSixWithPlusAndMinus,
             type: const GradeTypeId('my-custom-grade-type'),
@@ -240,10 +240,10 @@ void main() {
             details: 'ollah',
           ));
       service.addGrade(
+          id: const GradeId('grade-4'),
           subjectId: const SubjectId('englisch'),
           termId: const TermId('01-10-term'),
-          value: Grade(
-            id: const GradeId('grade-4'),
+          value: GradeInput(
             value: 'Sehr zufriedenstellend',
             gradingSystem: GradingSystem.austrianBehaviouralGrades,
             type: GradeType.oralParticipation.id,

--- a/app/test/grades/grades_test_common.dart
+++ b/app/test/grades/grades_test_common.dart
@@ -40,10 +40,8 @@ class GradesTestController {
     if (createMissingGradeTypes) {
       for (var id in _getAllGradeTypeIds(testTerm)) {
         service.addCustomGradeType(
-          GradeType(
-            id: id,
-            displayName: randomAlpha(5),
-          ),
+          id: id,
+          displayName: randomAlpha(5),
         );
       }
     }
@@ -231,7 +229,10 @@ class GradesTestController {
   }
 
   void createCustomGradeType(GradeType gradeType) {
-    return service.addCustomGradeType(gradeType);
+    service.addCustomGradeType(
+      displayName: gradeType.displayName ?? gradeType.predefinedType.toString(),
+      id: gradeType.id,
+    );
   }
 
   void addGrade({

--- a/app/test/grades/grades_test_common.dart
+++ b/app/test/grades/grades_test_common.dart
@@ -80,6 +80,7 @@ class GradesTestController {
       // other settings (weights) that refer to the term.
       for (var grade in subject.grades) {
         service.addGrade(
+          id: grade.id,
           subjectId: subject.id,
           termId: termId,
           value: _toGrade(grade),
@@ -138,9 +139,8 @@ class GradesTestController {
         .addAll(testSubject.grades.map((g) => g.type));
   }
 
-  Grade _toGrade(TestGrade testGrade) {
-    return Grade(
-      id: testGrade.id,
+  GradeInput _toGrade(TestGrade testGrade) {
+    return GradeInput(
       value: testGrade.value,
       date: testGrade.date,
       takeIntoAccount: testGrade.includeInGradeCalculations,
@@ -238,6 +238,7 @@ class GradesTestController {
     required TestGrade value,
   }) {
     return service.addGrade(
+      id: value.id,
       subjectId: subjectId,
       termId: termId,
       value: _toGrade(value),
@@ -299,7 +300,7 @@ class GradesTestController {
     if (grade.weight != null) {
       throw UnimplementedError();
     }
-    service.editGrade(_toGrade(grade));
+    service.editGrade(grade.id, _toGrade(grade));
   }
 
   void deleteGrade({required GradeId gradeId}) {

--- a/app/test/grades/grades_test_common.dart
+++ b/app/test/grades/grades_test_common.dart
@@ -67,13 +67,15 @@ class GradesTestController {
     }
 
     for (var subject in testTerm.subjects.values) {
-      service.addSubject(Subject(
+      service.addSubject(
         id: subject.id,
-        name: subject.name,
-        abbreviation: subject.abbreviation,
-        design: subject.design,
-        connectedCourses: subject.connectedCourses,
-      ));
+        SubjectInput(
+          name: subject.name,
+          abbreviation: subject.abbreviation,
+          design: subject.design,
+          connectedCourses: subject.connectedCourses,
+        ),
+      );
 
       // A subject is added to a term implicitly when adding a grade with the
       // subject id. So we need to add the grades here first before setting the
@@ -237,7 +239,7 @@ class GradesTestController {
     required SubjectId subjectId,
     required TestGrade value,
   }) {
-    return service.addGrade(
+    service.addGrade(
       id: value.id,
       subjectId: subjectId,
       termId: termId,
@@ -246,13 +248,15 @@ class GradesTestController {
   }
 
   void addSubject(TestSubject subject) {
-    service.addSubject(Subject(
+    service.addSubject(
       id: subject.id,
-      name: subject.name,
-      abbreviation: subject.abbreviation,
-      design: subject.design,
-      connectedCourses: subject.connectedCourses,
-    ));
+      SubjectInput(
+        name: subject.name,
+        abbreviation: subject.abbreviation,
+        design: subject.design,
+        connectedCourses: subject.connectedCourses,
+      ),
+    );
 
     if (subject.grades.isNotEmpty) {
       throw ArgumentError('Use addGrade to add grades to a subject');

--- a/app/test_goldens/grades/pages/create_term_page/create_term_page_test.mocks.dart
+++ b/app/test_goldens/grades/pages/create_term_page/create_term_page_test.mocks.dart
@@ -8,15 +8,15 @@ import 'dart:async' as _i10;
 import 'package:analytics/src/analytics/analytics.dart' as _i12;
 import 'package:crash_analytics/src/crash_analytics.dart' as _i9;
 import 'package:fast_immutable_collections/fast_immutable_collections.dart'
-    as _i3;
+    as _i5;
 import 'package:flutter/material.dart' as _i11;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:mockito/src/dummies.dart' as _i8;
 import 'package:rxdart/rxdart.dart' as _i2;
-import 'package:sharezone/grades/grades_service/grades_service.dart' as _i4;
-import 'package:sharezone/grades/models/grade_id.dart' as _i7;
-import 'package:sharezone/grades/models/subject_id.dart' as _i6;
-import 'package:sharezone/grades/models/term_id.dart' as _i5;
+import 'package:sharezone/grades/grades_service/grades_service.dart' as _i6;
+import 'package:sharezone/grades/models/grade_id.dart' as _i4;
+import 'package:sharezone/grades/models/subject_id.dart' as _i7;
+import 'package:sharezone/grades/models/term_id.dart' as _i3;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -42,8 +42,28 @@ class _FakeBehaviorSubject_0<T> extends _i1.SmartFake
         );
 }
 
-class _FakeIList_1<T> extends _i1.SmartFake implements _i3.IList<T> {
-  _FakeIList_1(
+class _FakeTermId_1 extends _i1.SmartFake implements _i3.TermId {
+  _FakeTermId_1(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeGradeId_2 extends _i1.SmartFake implements _i4.GradeId {
+  _FakeGradeId_2(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeIList_3<T> extends _i1.SmartFake implements _i5.IList<T> {
+  _FakeIList_3(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -55,55 +75,102 @@ class _FakeIList_1<T> extends _i1.SmartFake implements _i3.IList<T> {
   String toString([bool? prettyPrint]) => super.toString();
 }
 
+class _FakeGradeTypeId_4 extends _i1.SmartFake implements _i6.GradeTypeId {
+  _FakeGradeTypeId_4(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeSubjectId_5 extends _i1.SmartFake implements _i7.SubjectId {
+  _FakeSubjectId_5(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
 /// A class which mocks [GradesService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockGradesService extends _i1.Mock implements _i4.GradesService {
+class MockGradesService extends _i1.Mock implements _i6.GradesService {
   @override
-  _i2.BehaviorSubject<_i3.IList<_i4.TermResult>> get terms =>
+  _i2.BehaviorSubject<_i5.IList<_i6.TermResult>> get terms =>
       (super.noSuchMethod(
         Invocation.getter(#terms),
-        returnValue: _FakeBehaviorSubject_0<_i3.IList<_i4.TermResult>>(
+        returnValue: _FakeBehaviorSubject_0<_i5.IList<_i6.TermResult>>(
           this,
           Invocation.getter(#terms),
         ),
         returnValueForMissingStub:
-            _FakeBehaviorSubject_0<_i3.IList<_i4.TermResult>>(
+            _FakeBehaviorSubject_0<_i5.IList<_i6.TermResult>>(
           this,
           Invocation.getter(#terms),
         ),
-      ) as _i2.BehaviorSubject<_i3.IList<_i4.TermResult>>);
+      ) as _i2.BehaviorSubject<_i5.IList<_i6.TermResult>>);
 
   @override
-  void addTerm({
-    required _i5.TermId? id,
+  _i3.TermId addTerm({
     required String? name,
-    required _i4.GradeTypeId? finalGradeType,
-    required _i4.GradingSystem? gradingSystem,
+    required _i6.GradeTypeId? finalGradeType,
+    required _i6.GradingSystem? gradingSystem,
     required bool? isActiveTerm,
+    _i3.TermId? id,
   }) =>
-      super.noSuchMethod(
+      (super.noSuchMethod(
         Invocation.method(
           #addTerm,
           [],
           {
-            #id: id,
             #name: name,
             #finalGradeType: finalGradeType,
             #gradingSystem: gradingSystem,
             #isActiveTerm: isActiveTerm,
+            #id: id,
           },
         ),
-        returnValueForMissingStub: null,
-      );
+        returnValue: _FakeTermId_1(
+          this,
+          Invocation.method(
+            #addTerm,
+            [],
+            {
+              #name: name,
+              #finalGradeType: finalGradeType,
+              #gradingSystem: gradingSystem,
+              #isActiveTerm: isActiveTerm,
+              #id: id,
+            },
+          ),
+        ),
+        returnValueForMissingStub: _FakeTermId_1(
+          this,
+          Invocation.method(
+            #addTerm,
+            [],
+            {
+              #name: name,
+              #finalGradeType: finalGradeType,
+              #gradingSystem: gradingSystem,
+              #isActiveTerm: isActiveTerm,
+              #id: id,
+            },
+          ),
+        ),
+      ) as _i3.TermId);
 
   @override
   void editTerm({
-    required _i5.TermId? id,
+    required _i3.TermId? id,
     bool? isActiveTerm,
     String? name,
-    _i4.GradeTypeId? finalGradeType,
-    _i4.GradingSystem? gradingSystem,
+    _i6.GradeTypeId? finalGradeType,
+    _i6.GradingSystem? gradingSystem,
   }) =>
       super.noSuchMethod(
         Invocation.method(
@@ -121,7 +188,7 @@ class MockGradesService extends _i1.Mock implements _i4.GradesService {
       );
 
   @override
-  void deleteTerm(_i5.TermId? id) => super.noSuchMethod(
+  void deleteTerm(_i3.TermId? id) => super.noSuchMethod(
         Invocation.method(
           #deleteTerm,
           [id],
@@ -131,9 +198,9 @@ class MockGradesService extends _i1.Mock implements _i4.GradesService {
 
   @override
   void changeSubjectWeightForTermGrade({
-    required _i6.SubjectId? id,
-    required _i5.TermId? termId,
-    required _i4.Weight? weight,
+    required _i7.SubjectId? id,
+    required _i3.TermId? termId,
+    required _i6.Weight? weight,
   }) =>
       super.noSuchMethod(
         Invocation.method(
@@ -150,9 +217,9 @@ class MockGradesService extends _i1.Mock implements _i4.GradesService {
 
   @override
   void changeSubjectWeightTypeSettings({
-    required _i6.SubjectId? id,
-    required _i5.TermId? termId,
-    required _i4.WeightType? perGradeType,
+    required _i7.SubjectId? id,
+    required _i3.TermId? termId,
+    required _i6.WeightType? perGradeType,
   }) =>
       super.noSuchMethod(
         Invocation.method(
@@ -169,10 +236,10 @@ class MockGradesService extends _i1.Mock implements _i4.GradesService {
 
   @override
   void changeGradeTypeWeightForSubject({
-    required _i6.SubjectId? id,
-    required _i5.TermId? termId,
-    required _i4.GradeTypeId? gradeType,
-    required _i4.Weight? weight,
+    required _i7.SubjectId? id,
+    required _i3.TermId? termId,
+    required _i6.GradeTypeId? gradeType,
+    required _i6.Weight? weight,
   }) =>
       super.noSuchMethod(
         Invocation.method(
@@ -190,9 +257,9 @@ class MockGradesService extends _i1.Mock implements _i4.GradesService {
 
   @override
   void removeGradeTypeWeightForSubject({
-    required _i6.SubjectId? id,
-    required _i5.TermId? termId,
-    required _i4.GradeTypeId? gradeType,
+    required _i7.SubjectId? id,
+    required _i3.TermId? termId,
+    required _i6.GradeTypeId? gradeType,
   }) =>
       super.noSuchMethod(
         Invocation.method(
@@ -208,12 +275,13 @@ class MockGradesService extends _i1.Mock implements _i4.GradesService {
       );
 
   @override
-  void addGrade({
-    required _i6.SubjectId? subjectId,
-    required _i5.TermId? termId,
-    required _i4.Grade? value,
+  _i4.GradeId addGrade({
+    required _i7.SubjectId? subjectId,
+    required _i3.TermId? termId,
+    required _i6.GradeInput? value,
+    _i4.GradeId? id,
   }) =>
-      super.noSuchMethod(
+      (super.noSuchMethod(
         Invocation.method(
           #addGrade,
           [],
@@ -221,13 +289,55 @@ class MockGradesService extends _i1.Mock implements _i4.GradesService {
             #subjectId: subjectId,
             #termId: termId,
             #value: value,
+            #id: id,
           },
+        ),
+        returnValue: _FakeGradeId_2(
+          this,
+          Invocation.method(
+            #addGrade,
+            [],
+            {
+              #subjectId: subjectId,
+              #termId: termId,
+              #value: value,
+              #id: id,
+            },
+          ),
+        ),
+        returnValueForMissingStub: _FakeGradeId_2(
+          this,
+          Invocation.method(
+            #addGrade,
+            [],
+            {
+              #subjectId: subjectId,
+              #termId: termId,
+              #value: value,
+              #id: id,
+            },
+          ),
+        ),
+      ) as _i4.GradeId);
+
+  @override
+  void editGrade(
+    _i4.GradeId? id,
+    _i6.GradeInput? newGrade,
+  ) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #editGrade,
+          [
+            id,
+            newGrade,
+          ],
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  void deleteGrade(_i7.GradeId? gradeId) => super.noSuchMethod(
+  void deleteGrade(_i4.GradeId? gradeId) => super.noSuchMethod(
         Invocation.method(
           #deleteGrade,
           [gradeId],
@@ -237,9 +347,9 @@ class MockGradesService extends _i1.Mock implements _i4.GradesService {
 
   @override
   void changeGradeWeight({
-    required _i7.GradeId? id,
-    required _i5.TermId? termId,
-    required _i4.Weight? weight,
+    required _i4.GradeId? id,
+    required _i3.TermId? termId,
+    required _i6.Weight? weight,
   }) =>
       super.noSuchMethod(
         Invocation.method(
@@ -256,9 +366,9 @@ class MockGradesService extends _i1.Mock implements _i4.GradesService {
 
   @override
   void changeGradeTypeWeightForTerm({
-    required _i5.TermId? termId,
-    required _i4.GradeTypeId? gradeType,
-    required _i4.Weight? weight,
+    required _i3.TermId? termId,
+    required _i6.GradeTypeId? gradeType,
+    required _i6.Weight? weight,
   }) =>
       super.noSuchMethod(
         Invocation.method(
@@ -275,8 +385,8 @@ class MockGradesService extends _i1.Mock implements _i4.GradesService {
 
   @override
   void removeGradeTypeWeightForTerm({
-    required _i5.TermId? termId,
-    required _i4.GradeTypeId? gradeType,
+    required _i3.TermId? termId,
+    required _i6.GradeTypeId? gradeType,
   }) =>
       super.noSuchMethod(
         Invocation.method(
@@ -292,9 +402,9 @@ class MockGradesService extends _i1.Mock implements _i4.GradesService {
 
   @override
   void changeSubjectFinalGradeType({
-    required _i6.SubjectId? id,
-    required _i5.TermId? termId,
-    required _i4.GradeTypeId? gradeType,
+    required _i7.SubjectId? id,
+    required _i3.TermId? termId,
+    required _i6.GradeTypeId? gradeType,
   }) =>
       super.noSuchMethod(
         Invocation.method(
@@ -310,99 +420,174 @@ class MockGradesService extends _i1.Mock implements _i4.GradesService {
       );
 
   @override
-  _i4.PossibleGradesResult getPossibleGrades(
-          _i4.GradingSystem? gradingSystem) =>
+  _i6.PossibleGradesResult getPossibleGrades(
+          _i6.GradingSystem? gradingSystem) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPossibleGrades,
           [gradingSystem],
         ),
-        returnValue: _i8.dummyValue<_i4.PossibleGradesResult>(
+        returnValue: _i8.dummyValue<_i6.PossibleGradesResult>(
           this,
           Invocation.method(
             #getPossibleGrades,
             [gradingSystem],
           ),
         ),
-        returnValueForMissingStub: _i8.dummyValue<_i4.PossibleGradesResult>(
+        returnValueForMissingStub: _i8.dummyValue<_i6.PossibleGradesResult>(
           this,
           Invocation.method(
             #getPossibleGrades,
             [gradingSystem],
           ),
         ),
-      ) as _i4.PossibleGradesResult);
+      ) as _i6.PossibleGradesResult);
 
   @override
-  _i3.IList<_i4.GradeType> getPossibleGradeTypes() => (super.noSuchMethod(
+  _i5.IList<_i6.GradeType> getPossibleGradeTypes() => (super.noSuchMethod(
         Invocation.method(
           #getPossibleGradeTypes,
           [],
         ),
-        returnValue: _FakeIList_1<_i4.GradeType>(
+        returnValue: _FakeIList_3<_i6.GradeType>(
           this,
           Invocation.method(
             #getPossibleGradeTypes,
             [],
           ),
         ),
-        returnValueForMissingStub: _FakeIList_1<_i4.GradeType>(
+        returnValueForMissingStub: _FakeIList_3<_i6.GradeType>(
           this,
           Invocation.method(
             #getPossibleGradeTypes,
             [],
           ),
         ),
-      ) as _i3.IList<_i4.GradeType>);
+      ) as _i5.IList<_i6.GradeType>);
 
   @override
-  void addCustomGradeType(_i4.GradeType? gradeType) => super.noSuchMethod(
+  _i6.GradeTypeId addCustomGradeType({
+    required String? displayName,
+    _i6.GradeTypeId? id,
+  }) =>
+      (super.noSuchMethod(
         Invocation.method(
           #addCustomGradeType,
-          [gradeType],
+          [],
+          {
+            #displayName: displayName,
+            #id: id,
+          },
+        ),
+        returnValue: _FakeGradeTypeId_4(
+          this,
+          Invocation.method(
+            #addCustomGradeType,
+            [],
+            {
+              #displayName: displayName,
+              #id: id,
+            },
+          ),
+        ),
+        returnValueForMissingStub: _FakeGradeTypeId_4(
+          this,
+          Invocation.method(
+            #addCustomGradeType,
+            [],
+            {
+              #displayName: displayName,
+              #id: id,
+            },
+          ),
+        ),
+      ) as _i6.GradeTypeId);
+
+  @override
+  void editCustomGradeType({
+    required _i6.GradeTypeId? id,
+    required String? displayName,
+  }) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #editCustomGradeType,
+          [],
+          {
+            #id: id,
+            #displayName: displayName,
+          },
         ),
         returnValueForMissingStub: null,
       );
 
   @override
-  void addSubject(_i4.Subject? subject) => super.noSuchMethod(
+  void deleteCustomGradeType(_i6.GradeTypeId? id) => super.noSuchMethod(
+        Invocation.method(
+          #deleteCustomGradeType,
+          [id],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i7.SubjectId addSubject(
+    _i6.SubjectInput? subjectInput, {
+    _i7.SubjectId? id,
+  }) =>
+      (super.noSuchMethod(
         Invocation.method(
           #addSubject,
-          [subject],
+          [subjectInput],
+          {#id: id},
         ),
-        returnValueForMissingStub: null,
-      );
+        returnValue: _FakeSubjectId_5(
+          this,
+          Invocation.method(
+            #addSubject,
+            [subjectInput],
+            {#id: id},
+          ),
+        ),
+        returnValueForMissingStub: _FakeSubjectId_5(
+          this,
+          Invocation.method(
+            #addSubject,
+            [subjectInput],
+            {#id: id},
+          ),
+        ),
+      ) as _i7.SubjectId);
 
   @override
-  _i3.IList<_i4.Subject> getSubjects() => (super.noSuchMethod(
+  _i5.IList<_i6.Subject> getSubjects() => (super.noSuchMethod(
         Invocation.method(
           #getSubjects,
           [],
         ),
-        returnValue: _FakeIList_1<_i4.Subject>(
+        returnValue: _FakeIList_3<_i6.Subject>(
           this,
           Invocation.method(
             #getSubjects,
             [],
           ),
         ),
-        returnValueForMissingStub: _FakeIList_1<_i4.Subject>(
+        returnValueForMissingStub: _FakeIList_3<_i6.Subject>(
           this,
           Invocation.method(
             #getSubjects,
             [],
           ),
         ),
-      ) as _i3.IList<_i4.Subject>);
+      ) as _i5.IList<_i6.Subject>);
 
   @override
-  _i4.Subject? getSubject(_i6.SubjectId? id) => (super.noSuchMethod(
+  _i6.Subject? getSubject(_i7.SubjectId? id) => (super.noSuchMethod(
         Invocation.method(
           #getSubject,
           [id],
         ),
         returnValueForMissingStub: null,
-      ) as _i4.Subject?);
+      ) as _i6.Subject?);
 }
 
 /// A class which mocks [CrashAnalytics].


### PR DESCRIPTION
This PR enables the users of the `GradesService` to not need to generate Ids.

* Adds `SubjectInput` and `GradeInput` class (have no Id field)
* Make add methods return the Id of the newly created thing (term, subject, ...)
* `addCustomGradeType` no longer takes `GradeType`, but rather properties
* Make `Grade` class private since its only used for internal usage of `GradesService` now