### PR TITLE
Fix deploy macOS pipeline: `Asset validation failed (90255) The installer package includes files that are only readable by the root user.`

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -16,6 +16,8 @@ concurrency:
   group: app-release
 
 on:
+  # temp
+  pull_request:
   push:
     branches:
       - main
@@ -280,6 +282,7 @@ jobs:
         uses: kuhnroyal/flutter-fvm-config-action@34c3905bc939a4ff9d9cb07d5a977493fa73b2aa
 
       - uses: subosito/flutter-action@44ac965b96f18d999802d4b807e3256d5a3f9fa1
+        id: flutter-action
         with:
           flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
           channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
@@ -303,6 +306,7 @@ jobs:
           APP_STORE_CONNECT_KEY_IDENTIFIER: ${{ secrets.SHAREZONE_APP_STORE_CONNECT_KEY_IDENTIFIER }}
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.SHAREZONE_APP_STORE_CONNECT_ISSUER_ID }}
           APP_STORE_CONNECT_PRIVATE_KEY: ${{ secrets.SHAREZONE_APP_STORE_CONNECT_PRIVATE_KEY }}
+        shell: bash
         run: |
           # Because we are publishing every commit a new alpha version, we are
           # able to use the last commit message (title and description) as release
@@ -318,6 +322,9 @@ jobs:
           # longer than 4000 characters.
           SHORT_LAST_COMMIT_MESSAGE=${LAST_COMMIT_MESSAGE:0:4000}
 
+          # Required for workaround https://github.com/flutter/flutter/issues/148354
+          export FLUTTER_ROOT=${{ steps.flutter-action.outputs.VERSION }}
+          
           sz deploy app macos \
             --stage alpha \
             --whats-new "$SHORT_LAST_COMMIT_MESSAGE"

--- a/tools/sz_repo_cli/lib/src/commands/src/deploy_app_macos_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/deploy_app_macos_command.dart
@@ -133,6 +133,16 @@ class DeployAppMacOsCommand extends CommandBase {
         workingDirectory: repo.sharezoneFlutterApp.path,
       );
 
+      // Workaround for https://github.com/flutter/flutter/issues/148354
+      await processRunner.run(
+        [
+          'chmod',
+          '755',
+          '\$FLUTTER_ROOT/bin/cache/artifacts/engine/darwin-x64-release/FlutterMacOS.xcframework/macos-arm64_x86_64/FlutterMacOS.framework',
+        ],
+        workingDirectory: repo.sharezoneFlutterApp.location,
+      );
+
       await _buildApp(processRunner, buildNumber: buildNumber);
 
       await _createSignedPackage();


### PR DESCRIPTION
See more information about this issue in https://github.com/flutter/flutter/issues/148354. Copied the workaround from there.

Fixes #1640 