### PR TITLE
Add sending verification email after linking email address

### DIFF
--- a/app/lib/util/api/user_api.dart
+++ b/app/lib/util/api/user_api.dart
@@ -195,6 +195,11 @@ class UserGateway implements UserGatewayAuthentifcation {
     return;
   }
 
+  @override
+  Future<void> sendVerificationEmail() async {
+    await authUser!.firebaseUser.sendEmailVerification();
+  }
+
   Future<bool> deleteUser(SharezoneGateway gateway) async {
     if (await hasInternetAccess()) {
       final currentUser = references.firebaseAuth!.currentUser!;

--- a/lib/authentification/authentification_base/lib/src/gateways/link_provider_gateway.dart
+++ b/lib/authentification/authentification_base/lib/src/gateways/link_provider_gateway.dart
@@ -45,6 +45,7 @@ class LinkProviderGateway extends BlocBase {
     final credential =
         EmailAuthProvider.credential(email: email, password: password);
     await userGateway.linkWithCredential(credential);
+    await userGateway.sendVerificationEmail();
 
     _analytics.logEmailAndPasswordLink();
 

--- a/lib/authentification/authentification_base/lib/src/gateways/user_gateway_authentifcation.dart
+++ b/lib/authentification/authentification_base/lib/src/gateways/user_gateway_authentifcation.dart
@@ -10,4 +10,5 @@ import 'package:firebase_auth/firebase_auth.dart';
 
 abstract class UserGatewayAuthentifcation {
   Future<void> linkWithCredential(AuthCredential credential);
+  Future<void> sendVerificationEmail();
 }


### PR DESCRIPTION
In the future, we should only send emails to verified email addresses. Otherwise, it's likely that we'll have a high bounce rate, which could cause our emails to be flagged as spam.

Users with Google and Apple providers don't need to verify their email address.