### PR TITLE
Temporary disable screen reader for web & desktop because of Flutter bug

### DIFF
--- a/app/lib/main/run_app.dart
+++ b/app/lib/main/run_app.dart
@@ -74,7 +74,11 @@ Future<void> runFlutterApp({required Flavor flavor}) async {
     // see:
     // * https://github.com/flutter/flutter/issues/115158#issuecomment-1319080131
     // * https://github.com/gskinnerTeam/flutter-wonderous-app/issues/146
-    WidgetsFlutterBinding.ensureInitialized().ensureSemantics();
+    //
+    // Currently disabled because of:
+    // https://github.com/flutter/flutter/issues/150020
+    //
+    // WidgetsFlutterBinding.ensureInitialized().ensureSemantics();
   }
 
   if (PlatformCheck.isWeb) {


### PR DESCRIPTION
Currently, users can't delete their account using the web application because they can't enter their password. This is due to a bug in Flutter: https://github.com/flutter/flutter/issues/150020. Since deleting your account is a critical privacy issue, I would disable the screen reader for now.