### PR TITLE
Stop using `fvm` in devenv.nix

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -3,11 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1720853497,
+        "lastModified": 1712059314,
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "7f569a0f2473b9f6000fd9e4c32511fd1b0d37c1",
-        "treeHash": "4d452ecc8223834e39d507f9ea92308f007ee05d",
+        "rev": "a18e86ab317a82c2e7d626d28ba1b3a9eb11d23b",
+        "treeHash": "13e19e729bf8bd0206d1ff6e716a19b31912004b",
         "type": "github"
       },
       "original": {
@@ -30,6 +30,24 @@
       "original": {
         "owner": "edolstra",
         "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "treeHash": "bd263f021e345cb4a39d80c126ab650bebc3c10c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
         "type": "github"
       }
     },
@@ -56,11 +74,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1716977621,
+        "lastModified": 1710796454,
         "owner": "cachix",
         "repo": "devenv-nixpkgs",
-        "rev": "4267e705586473d3e5c8d50299e71503f16a6fb6",
-        "treeHash": "6d9f1f7ca0faf1bc2eeb397c78a49623260d3412",
+        "rev": "06fb0f1c643aee3ae6838dda3b37ef0abc3c763b",
+        "treeHash": "9bb13f7f39e825a5d91bbe4139fbc129243b907d",
         "type": "github"
       },
       "original": {
@@ -72,32 +90,16 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1720954236,
+        "lastModified": 1711668574,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "53e81e790209e41f0c1efa9ff26ff2fd7ab35e27",
-        "treeHash": "ca1f1273cf201da604f7c704535d4b7fac62cdb2",
+        "rev": "219951b495fc2eac67b1456824cc1ec1fd2ee659",
+        "treeHash": "51ec3259d600ba0dbef93d23999da1141e943713",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-unstable": {
-      "locked": {
-        "lastModified": 1721016451,
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "a14c5d651cee9ed70f9cd9e83f323f1e531002db",
-        "treeHash": "efb702dfab66ebbac794ae69207c7fbadb39bf49",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixos-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -105,6 +107,7 @@
     "pre-commit-hooks": {
       "inputs": {
         "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
         "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
@@ -112,11 +115,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1721042469,
+        "lastModified": 1712055707,
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "f451c19376071a90d8c58ab1a953c6e9840527fd",
-        "treeHash": "91f40b7a3b9f6886bd77482cba5b5cd890415a2e",
+        "rev": "e35aed5fda3cc79f88ed7f1795021e559582093a",
+        "treeHash": "41bee5f5bd9314a987ef3d7cba730fb6aa264a4e",
         "type": "github"
       },
       "original": {
@@ -129,8 +132,22 @@
       "inputs": {
         "devenv": "devenv",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-unstable": "nixpkgs-unstable",
         "pre-commit-hooks": "pre-commit-hooks"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "treeHash": "cce81f2a0f0743b2eb61bc2eb6c7adbe2f2c6beb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,11 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1712059314,
+        "lastModified": 1720853497,
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "a18e86ab317a82c2e7d626d28ba1b3a9eb11d23b",
-        "treeHash": "13e19e729bf8bd0206d1ff6e716a19b31912004b",
+        "rev": "7f569a0f2473b9f6000fd9e4c32511fd1b0d37c1",
+        "treeHash": "4d452ecc8223834e39d507f9ea92308f007ee05d",
         "type": "github"
       },
       "original": {
@@ -30,24 +30,6 @@
       "original": {
         "owner": "edolstra",
         "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1710146030,
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
-        "treeHash": "bd263f021e345cb4a39d80c126ab650bebc3c10c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
         "type": "github"
       }
     },
@@ -74,11 +56,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1710796454,
+        "lastModified": 1716977621,
         "owner": "cachix",
         "repo": "devenv-nixpkgs",
-        "rev": "06fb0f1c643aee3ae6838dda3b37ef0abc3c763b",
-        "treeHash": "9bb13f7f39e825a5d91bbe4139fbc129243b907d",
+        "rev": "4267e705586473d3e5c8d50299e71503f16a6fb6",
+        "treeHash": "6d9f1f7ca0faf1bc2eeb397c78a49623260d3412",
         "type": "github"
       },
       "original": {
@@ -90,16 +72,32 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1711668574,
+        "lastModified": 1720954236,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "219951b495fc2eac67b1456824cc1ec1fd2ee659",
-        "treeHash": "51ec3259d600ba0dbef93d23999da1141e943713",
+        "rev": "53e81e790209e41f0c1efa9ff26ff2fd7ab35e27",
+        "treeHash": "ca1f1273cf201da604f7c704535d4b7fac62cdb2",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.11",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1721016451,
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a14c5d651cee9ed70f9cd9e83f323f1e531002db",
+        "treeHash": "efb702dfab66ebbac794ae69207c7fbadb39bf49",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -107,7 +105,6 @@
     "pre-commit-hooks": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils",
         "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
@@ -115,11 +112,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712055707,
+        "lastModified": 1721042469,
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "e35aed5fda3cc79f88ed7f1795021e559582093a",
-        "treeHash": "41bee5f5bd9314a987ef3d7cba730fb6aa264a4e",
+        "rev": "f451c19376071a90d8c58ab1a953c6e9840527fd",
+        "treeHash": "91f40b7a3b9f6886bd77482cba5b5cd890415a2e",
         "type": "github"
       },
       "original": {
@@ -132,22 +129,8 @@
       "inputs": {
         "devenv": "devenv",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable",
         "pre-commit-hooks": "pre-commit-hooks"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "treeHash": "cce81f2a0f0743b2eb61bc2eb6c7adbe2f2c6beb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/devenv.nix
+++ b/devenv.nix
@@ -6,20 +6,9 @@
 #
 # SPDX-License-Identifier: EUPL-1.2
 
-{ pkgs, inputs, lib, ... }:
+{ pkgs, ... }:
 
 let
-  pkgs-unstable = import inputs.nixpkgs-unstable { system = pkgs.stdenv.system; };
-  flutter = pkgs-unstable.flutter.overrideAttrs
-    {
-      src = pkgs-unstable.fetchFromGitHub
-        {
-          owner = "flutter";
-          repo = "flutter";
-          rev = "3.22.2";
-          sha256 = "7ndnIw72YxNB+VeeejEeRD+xxuLXOcWo322s5CMWzBM=";
-        };
-    };
   androidenv = android-pkgs.androidenv.override {
     # Seems to only work when androidenv.buildApp is used 
     # afterwards (we don't).
@@ -56,7 +45,7 @@ in
   env = {
     ANDROID_HOME = "${android-sdk-root}";
     ANDROID_SDK_ROOT = "${android-sdk-root}";
-    FLUTTER_ROOT = "${flutter}";
+    FLUTTER_ROOT = "${pkgs.flutter}";
     CHROME_EXECUTABLE = "${pkgs.google-chrome}/bin/google-chrome-stable";
   };
 
@@ -68,7 +57,6 @@ in
     # Running `fvm flutter` -> 'Missing "unzip" tool. Unable to extract Dart SDK.'
     pkgs.unzip
     android-sdk
-    flutter
 
     # For Flutter Web development
     pkgs.google-chrome
@@ -82,23 +70,36 @@ in
   enterShell = ''
     # Make pub cache work so that we can execute
     # e.g. `dart pub global activate fvm`
-    #export PATH="$PATH":"$HOME/.pub-cache/bin"
+    export PATH="$PATH":"$HOME/.pub-cache/bin"
 
     # Make sz cli work
     export PATH="$PATH":"$DEVENV_ROOT/bin"
+
+    if ! command -v fvm &> /dev/null
+    then
+        echo "fvm could not be found. Installing FVM via dart pub global."
+        dart pub global activate fvm
+
+        # fvm install will fail getting dependencies if we dont
+        # cd to app. Using && will only change it for the fvm
+        # install command
+        cd app && fvm install
+    fi
+
+    fvm flutter config --android-sdk ${android-sdk-root}
 
     # When running e.g. `sz pub get -c 0` the analytics
     # will cause the task to fail (maybe because so many signals
     # are sent in a short time). So we just disable analytics
     # so that they can not fail because of this reason.
-    dart --disable-analytics &
-    flutter --disable-analytics
+    fvm dart --disable-analytics &
+    fvm flutter --disable-analytics
     
     # We get the package in the sz cli folder so that one can
     # start running e.g. `sz pub get` right away. Without this 
     # one would first have to run pub get in the sz cli folder 
     # manually.
-    dart pub get --directory ./tools/sz_repo_cli
+    fvm dart pub get --directory ./tools/sz_repo_cli
   '';
 
   languages = {
@@ -107,6 +108,13 @@ in
       enable = true;
       jdk.package = pkgs.jdk17;
     };
+
+    # We're using this standalone version of Dart to run
+    # `dart pub global activate fvm` in enterShell.
+    # This will install fvm and it in turn flutter with 
+    # the actual Dart version that will be used to build,
+    # test, run etc the app.
+    dart.enable = true;
   };
 
   # See full reference at https://devenv.sh/reference/options/

--- a/devenv.nix
+++ b/devenv.nix
@@ -65,8 +65,6 @@ in
     pkgs.git
     pkgs.nixpkgs-fmt
 
-    # Running `fvm flutter` -> 'Missing "unzip" tool. Unable to extract Dart SDK.'
-    pkgs.unzip
     android-sdk
     flutter
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -6,9 +6,20 @@
 #
 # SPDX-License-Identifier: EUPL-1.2
 
-{ pkgs, ... }:
+{ pkgs, inputs, lib, ... }:
 
 let
+  pkgs-unstable = import inputs.nixpkgs-unstable { system = pkgs.stdenv.system; };
+  flutter = pkgs-unstable.flutter.overrideAttrs
+    {
+      src = pkgs-unstable.fetchFromGitHub
+        {
+          owner = "flutter";
+          repo = "flutter";
+          rev = "3.22.2";
+          sha256 = "7ndnIw72YxNB+VeeejEeRD+xxuLXOcWo322s5CMWzBM=";
+        };
+    };
   androidenv = android-pkgs.androidenv.override {
     # Seems to only work when androidenv.buildApp is used 
     # afterwards (we don't).
@@ -45,7 +56,7 @@ in
   env = {
     ANDROID_HOME = "${android-sdk-root}";
     ANDROID_SDK_ROOT = "${android-sdk-root}";
-    FLUTTER_ROOT = "${pkgs.flutter}";
+    FLUTTER_ROOT = "${flutter}";
     CHROME_EXECUTABLE = "${pkgs.google-chrome}/bin/google-chrome-stable";
   };
 
@@ -57,6 +68,7 @@ in
     # Running `fvm flutter` -> 'Missing "unzip" tool. Unable to extract Dart SDK.'
     pkgs.unzip
     android-sdk
+    flutter
 
     # For Flutter Web development
     pkgs.google-chrome
@@ -70,36 +82,23 @@ in
   enterShell = ''
     # Make pub cache work so that we can execute
     # e.g. `dart pub global activate fvm`
-    export PATH="$PATH":"$HOME/.pub-cache/bin"
+    #export PATH="$PATH":"$HOME/.pub-cache/bin"
 
     # Make sz cli work
     export PATH="$PATH":"$DEVENV_ROOT/bin"
-
-    if ! command -v fvm &> /dev/null
-    then
-        echo "fvm could not be found. Installing FVM via dart pub global."
-        dart pub global activate fvm
-
-        # fvm install will fail getting dependencies if we dont
-        # cd to app. Using && will only change it for the fvm
-        # install command
-        cd app && fvm install
-    fi
-
-    fvm flutter config --android-sdk ${android-sdk-root}
 
     # When running e.g. `sz pub get -c 0` the analytics
     # will cause the task to fail (maybe because so many signals
     # are sent in a short time). So we just disable analytics
     # so that they can not fail because of this reason.
-    fvm dart --disable-analytics &
-    fvm flutter --disable-analytics
+    dart --disable-analytics &
+    flutter --disable-analytics
     
     # We get the package in the sz cli folder so that one can
     # start running e.g. `sz pub get` right away. Without this 
     # one would first have to run pub get in the sz cli folder 
     # manually.
-    fvm dart pub get --directory ./tools/sz_repo_cli
+    dart pub get --directory ./tools/sz_repo_cli
   '';
 
   languages = {
@@ -108,13 +107,6 @@ in
       enable = true;
       jdk.package = pkgs.jdk17;
     };
-
-    # We're using this standalone version of Dart to run
-    # `dart pub global activate fvm` in enterShell.
-    # This will install fvm and it in turn flutter with 
-    # the actual Dart version that will be used to build,
-    # test, run etc the app.
-    dart.enable = true;
   };
 
   # See full reference at https://devenv.sh/reference/options/

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -9,11 +9,12 @@
 inputs:
   nixpkgs:
     url: github:cachix/devenv-nixpkgs/rolling
+  nixpkgs-unstable:
+    url: github:NixOS/nixpkgs/nixpkgs-unstable
 
 # If you're using non-OSS software, you can set allowUnfree to true.
 # We need it for the Android SDK and Google Chrome
 allowUnfree: true
-
 # If you're willing to use a package that's vulnerable
 # permittedInsecurePackages:
 #  - "openssl-1.1.1w"

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -9,12 +9,11 @@
 inputs:
   nixpkgs:
     url: github:cachix/devenv-nixpkgs/rolling
-  nixpkgs-unstable:
-    url: github:NixOS/nixpkgs/nixpkgs-unstable
 
 # If you're using non-OSS software, you can set allowUnfree to true.
 # We need it for the Android SDK and Google Chrome
 allowUnfree: true
+
 # If you're willing to use a package that's vulnerable
 # permittedInsecurePackages:
 #  - "openssl-1.1.1w"


### PR DESCRIPTION
I was using a workaround for installing flutter via fvm which is/was just unnecessary work and indirection.

Requires #1686 