### PR TITLE
Use adaptive platform density for privacy policy.

### DIFF
--- a/app/lib/legal/privacy_policy/privacy_policy_page.dart
+++ b/app/lib/legal/privacy_policy/privacy_policy_page.dart
@@ -54,14 +54,14 @@ class PrivacyPolicyPage extends StatelessWidget {
                     Provider.of<ThemeSettings>(context, listen: false);
                 final newSettings = _createPrivacyPolicyThemeSettings(
                     context, themeSettings, config);
-                // As of writing this we always use
+                // As of this writing, we always use
                 // VisualDensitySetting.standard() instead of
                 // VisualDensitySetting.adaptivePlatformDensity() on all
-                // platforms. This might sense for the general UI, but
-                // for the privacy policy page it is way better use the adaptive
-                // spacing. This will make the TOC tiles to be more compact for
-                // desktop (since users will most probably use a mouse there)
-                // and more spaced out for users using touch.
+                // platforms. This may make sense for the general UI, but for
+                // the privacy policy page it is much better to use the adaptive
+                // spacing. This will make the TOC tiles more compact for
+                // desktop (since users will most likely be using a mouse there)
+                // and more spread out for touch users.
                 newSettings.visualDensitySetting =
                     VisualDensitySetting.adaptivePlatformDensity();
                 return newSettings;

--- a/app/lib/legal/privacy_policy/privacy_policy_page.dart
+++ b/app/lib/legal/privacy_policy/privacy_policy_page.dart
@@ -52,8 +52,19 @@ class PrivacyPolicyPage extends StatelessWidget {
               create: (context) {
                 final themeSettings =
                     Provider.of<ThemeSettings>(context, listen: false);
-                return _createPrivacyPolicyThemeSettings(
+                final newSettings = _createPrivacyPolicyThemeSettings(
                     context, themeSettings, config);
+                // As of writing this we always use
+                // VisualDensitySetting.standard() instead of
+                // VisualDensitySetting.adaptivePlatformDensity() on all
+                // platforms. This might sense for the general UI, but
+                // for the privacy policy page it is way better use the adaptive
+                // spacing. This will make the TOC tiles to be more compact for
+                // desktop (since users will most probably use a mouse there)
+                // and more spaced out for users using touch.
+                newSettings.visualDensitySetting =
+                    VisualDensitySetting.adaptivePlatformDensity();
+                return newSettings;
               },
             ),
             Provider<DocumentController>(


### PR DESCRIPTION
With 219bea1093928fa3192b99a215eb5c6e1f53fb7e we started to use `VisualDensitySetting.standard()` on all platforms instead of `VisualDensitySetting.adaptivePlatformDensity()`. Since the latter is better for the privacy policy UI on desktops we override it on this page.

| Before | After |
| - | - |
| <img width="1440" alt="grafik" src="https://github.com/user-attachments/assets/43a18405-f589-4949-930e-0d96c447f7bf"> | <img width="1439" alt="grafik" src="https://github.com/user-attachments/assets/bb0979cd-98fd-4294-b9f4-f02464c643ab"> |
