### PR TITLE
Replace "Schwarze Brett" with "Infozettel" in the delete course dialog

### DIFF
--- a/app/lib/groups/src/pages/course/course_card.dart
+++ b/app/lib/groups/src/pages/course/course_card.dart
@@ -49,7 +49,7 @@ Future<bool?> showDeleteCourseDialog(
     defaultValue: false,
     title: "Kurs löschen?",
     content: Text(
-        'Möchtest du den Kurs "$courseName" wirklich endgültig löschen?\n\nEs werden alle Stunden & Termine aus dem Stundenplan, Hausaufgaben und Einträge aus dem Schwarzen Brett und gelöscht.\n\nAuf den Kurs kann von niemanden mehr zugegriffen werden!'),
+        'Möchtest du den Kurs "$courseName" wirklich endgültig löschen?\n\nEs werden alle Stunden & Termine aus dem Stundenplan, Hausaufgaben und Infozettel gelöscht.\n\nAuf den Kurs kann von niemanden mehr zugegriffen werden!'),
   );
 }
 


### PR DESCRIPTION
We no longer use the word "blackboard" in the codebase. That was the last vestige of the word "Blackboard" in our codebase.