### PR TITLE
Fix deleting account when Google / Apple is used as sign in method

### DIFF
--- a/app/lib/settings/src/subpages/my_profile/my_profile_page.dart
+++ b/app/lib/settings/src/subpages/my_profile/my_profile_page.dart
@@ -413,7 +413,7 @@ class _DeleteAccountDialogContentState
     final authUser = api.user.authUser!;
     final fbUser = authUser.firebaseUser;
     final provider = authUser.provider;
-    if (provider != Provider.anonymous) {
+    if (provider == Provider.email) {
       if (isEmptyOrNull(password)) {
         return;
       }


### PR DESCRIPTION
The problem was that `isEmptyOrNull(password)` always returns true when using Google / Apple because the text field for the password isn't needed.

Closes #1685