### PR TITLE
Show material dialog for deleting the account on macos due to a Flutter bug

### DIFF
--- a/app/lib/settings/src/subpages/my_profile/my_profile_page.dart
+++ b/app/lib/settings/src/subpages/my_profile/my_profile_page.dart
@@ -459,7 +459,8 @@ class _DeleteAccountDialogContentState
     const text = "Ja, ich möchte mein Konto löschen.";
 
     // Because of https://github.com/flutter/flutter/issues/154793 we shouldn't
-    // show the CupertinoAlertDialog on macOS.
+    // show the CupertinoAlertDialog on macOS. Can be removed when the issue is
+    // fixed and rolled out to the stable channel.
     if (ThemePlatform.isCupertino && !PlatformCheck.isMacOS) {
       return CupertinoAlertDialog(
         title: const _DeleteAccountDialogTitle(),

--- a/app/lib/settings/src/subpages/my_profile/my_profile_page.dart
+++ b/app/lib/settings/src/subpages/my_profile/my_profile_page.dart
@@ -16,6 +16,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:helper_functions/helper_functions.dart';
+import 'package:platform_check/platform_check.dart';
 import 'package:provider/provider.dart' as pv;
 import 'package:sharezone/account/account_page.dart';
 import 'package:sharezone/account/change_data_bloc.dart';
@@ -457,7 +458,9 @@ class _DeleteAccountDialogContentState
     final provider = api.user.authUser!.provider;
     const text = "Ja, ich möchte mein Konto löschen.";
 
-    if (ThemePlatform.isCupertino) {
+    // Because of https://github.com/flutter/flutter/issues/154793 we shouldn't
+    // show the CupertinoAlertDialog on macOS.
+    if (ThemePlatform.isCupertino && !PlatformCheck.isMacOS) {
       return CupertinoAlertDialog(
         title: const _DeleteAccountDialogTitle(),
         content: SingleChildScrollView(


### PR DESCRIPTION
Because of https://github.com/flutter/flutter/issues/154793 `onPressed` of `CupertinoActionSheetAction` isn't called. Therefore, the Cupertino dialog shouldn't be shown when the user uses macOS.