### PR TITLE
Fix `onPressed` on macOS using `CupertinoAlertDialog`

### DIFF
--- a/app/lib/navigation/drawer/sign_out_dialogs/src/sign_out_and_delete_anonymous_user.dart
+++ b/app/lib/navigation/drawer/sign_out_dialogs/src/sign_out_and_delete_anonymous_user.dart
@@ -98,7 +98,7 @@ Bitte stell dabei sicher, dass dein Gerät eine Verbindung zum Internet hat.
           ),
         ),
         actions: <Widget>[
-          CupertinoActionSheetAction(
+          CupertinoDialogAction(
             child: const Text("Abbrechen"),
             onPressed: () => Navigator.pop(context, false),
           ),
@@ -112,7 +112,7 @@ Bitte stell dabei sicher, dass dein Gerät eine Verbindung zum Internet hat.
               ],
             ),
           if (confirmedToDeleteAccount && !isLoading)
-            CupertinoActionSheetAction(
+            CupertinoDialogAction(
                 isDefaultAction: true,
                 isDestructiveAction: true,
                 onPressed: () => tryToSignOutAndDeleteUser(context),

--- a/app/lib/settings/src/subpages/my_profile/my_profile_page.dart
+++ b/app/lib/settings/src/subpages/my_profile/my_profile_page.dart
@@ -458,10 +458,7 @@ class _DeleteAccountDialogContentState
     final provider = api.user.authUser!.provider;
     const text = "Ja, ich möchte mein Konto löschen.";
 
-    // Because of https://github.com/flutter/flutter/issues/154793 we shouldn't
-    // show the CupertinoAlertDialog on macOS. Can be removed when the issue is
-    // fixed and rolled out to the stable channel.
-    if (ThemePlatform.isCupertino && !PlatformCheck.isMacOS) {
+    if (ThemePlatform.isCupertino) {
       return CupertinoAlertDialog(
         title: const _DeleteAccountDialogTitle(),
         content: SingleChildScrollView(
@@ -516,7 +513,7 @@ class _DeleteAccountDialogContentState
           ),
         ),
         actions: <Widget>[
-          CupertinoActionSheetAction(
+          CupertinoDialogAction(
             child: const Text("Abbrechen"),
             onPressed: () => Navigator.pop(context),
           ),
@@ -533,7 +530,7 @@ class _DeleteAccountDialogContentState
                   ? isNotEmptyOrNull(password)
                   : signOut!) &&
               !isLoading)
-            CupertinoActionSheetAction(
+            CupertinoDialogAction(
               isDefaultAction: true,
               isDestructiveAction: true,
               onPressed: () => tryToDeleteUser(context),

--- a/app/lib/settings/src/subpages/my_profile/my_profile_page.dart
+++ b/app/lib/settings/src/subpages/my_profile/my_profile_page.dart
@@ -16,7 +16,6 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:helper_functions/helper_functions.dart';
-import 'package:platform_check/platform_check.dart';
 import 'package:provider/provider.dart' as pv;
 import 'package:sharezone/account/account_page.dart';
 import 'package:sharezone/account/change_data_bloc.dart';


### PR DESCRIPTION
The problem: We used `CupertinoActionSheetAction` inside a `CupertinoActionDialog`

Related to https://github.com/flutter/flutter/issues/154793