### PR TITLE
Fix typo in "/content-creator-programm" link

### DIFF
--- a/website/firebase.json
+++ b/website/firebase.json
@@ -225,7 +225,7 @@
         "type": 302
       },
       {
-        "source": "/content-creator-program",
+        "source": "/content-creator-programm",
         "destination": "https://docs.sharezone.net/more/content-creator-program",
         "type": 302
       }


### PR DESCRIPTION
We use "/content-creator-programm" in our app.