### PR TITLE
Upgrade GitHub Actions jobs from `macos-13` to `macos-14`

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -127,6 +127,10 @@ jobs:
           flutter pub global activate --source path "$CI_CD_DART_SCRIPTS_PACKAGE_PATH"
           echo $(realpath ./bin) >> $GITHUB_PATH
 
+      - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
+        with:
+          python-version: "3.9"
+
       - name: Install Codemagic CLI Tools
         run: pip3 install codemagic-cli-tools==0.50.7
 
@@ -213,6 +217,10 @@ jobs:
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
 
+      - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
+        with:
+          python-version: "3.9"
+
       - name: Install Codemagic CLI Tools
         run: pip3 install codemagic-cli-tools==0.50.7
 
@@ -271,6 +279,10 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
+
+      - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
+        with:
+          python-version: "3.9"
 
       - name: Install Codemagic CLI Tools
         run: pip3 install codemagic-cli-tools==0.50.7

--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -208,7 +208,7 @@ jobs:
             --release-notes "$LAST_COMMIT_MESSAGE"
 
   deploy-alpha-ios-app:
-    runs-on: macos-13
+    runs-on: macos-14
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
@@ -267,7 +267,7 @@ jobs:
             --export-options-plist=$HOME/export_options.plist
 
   deploy-alpha-macos-app:
-    runs-on: macos-13
+    runs-on: macos-14
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -63,7 +63,7 @@ jobs:
     # We skip the deployment if no changelog is provided because we assume that
     # nothing has changed in the iOS app and therefore no new version is needed.
     if: github.event.inputs.ios-changelog != ''
-    runs-on: macos-13
+    runs-on: macos-14
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
@@ -216,7 +216,7 @@ jobs:
     # We skip the deployment if no changelog is provided because we assume that
     # nothing has changed in the macOS app and therefore no new version is needed.
     if: github.event.inputs.macos-changelog != ''
-    runs-on: macos-13
+    runs-on: macos-14
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -68,6 +68,10 @@ jobs:
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
 
+      - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
+        with:
+          python-version: "3.9"
+
       - name: Install Codemagic CLI Tools
         run: pip3 install codemagic-cli-tools==0.50.7
 
@@ -162,6 +166,10 @@ jobs:
           distribution: "oracle"
           java-version: "17"
 
+      - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
+        with:
+          python-version: "3.9"
+
       - name: Install Codemagic CLI Tools
         run: pip3 install codemagic-cli-tools==0.50.7
 
@@ -220,6 +228,10 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
+
+      - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
+        with:
+          python-version: "3.9"
 
       - name: Install Codemagic CLI Tools
         run: pip3 install codemagic-cli-tools==0.50.7

--- a/.github/workflows/integration_tests_app_ci.yml
+++ b/.github/workflows/integration_tests_app_ci.yml
@@ -272,6 +272,10 @@ jobs:
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
 
+      - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
+        with:
+          python-version: "3.9"
+
       - name: Install Codemagic CLI Tools
         run: pip3 install codemagic-cli-tools==0.50.7
 

--- a/.github/workflows/integration_tests_app_ci.yml
+++ b/.github/workflows/integration_tests_app_ci.yml
@@ -263,7 +263,7 @@ jobs:
   # macOS app.
   macos-build-test:
     needs: changes
-    runs-on: macos-13
+    runs-on: macos-14
     if: ${{ needs.changes.outputs.changesFound == 'true' }}
     timeout-minutes: 60
     defaults:

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -63,7 +63,7 @@ jobs:
     # We skip the deployment if no changelog is provided because we assume that
     # nothing has changed in the iOS app and therefore no new version is needed.
     if: github.event.inputs.ios-changelog != ''
-    runs-on: macos-13
+    runs-on: macos-14
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
@@ -218,7 +218,7 @@ jobs:
     # We skip the deployment if no changelog is provided because we assume that
     # nothing has changed in the macOS app and therefore no new version is needed.
     if: github.event.inputs.macos-changelog != ''
-    runs-on: macos-13
+    runs-on: macos-14
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -68,6 +68,10 @@ jobs:
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
 
+      - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
+        with:
+          python-version: "3.9"
+
       - name: Install Codemagic CLI Tools
         run: pip3 install codemagic-cli-tools==0.50.7
 
@@ -164,6 +168,10 @@ jobs:
           distribution: "oracle"
           java-version: "17"
 
+      - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
+        with:
+          python-version: "3.9"
+
       - name: Install Codemagic CLI Tools
         run: pip3 install codemagic-cli-tools==0.50.7
 
@@ -222,6 +230,10 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
+
+      - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
+        with:
+          python-version: "3.9"
 
       - name: Install Codemagic CLI Tools
         run: pip3 install codemagic-cli-tools==0.50.7


### PR DESCRIPTION
macos-14 is used when using macos-default
