### PR TITLE
Fix text height for folder cards to avoid cutting off text

### DIFF
--- a/app/lib/filesharing/widgets/card_with_icon_and_text.dart
+++ b/app/lib/filesharing/widgets/card_with_icon_and_text.dart
@@ -41,7 +41,7 @@ class CardWithIconAndText extends StatelessWidget {
                   Expanded(
                     child: Text(
                       text!,
-                      style: const TextStyle(fontSize: 16),
+                      style: const TextStyle(fontSize: 16, height: 1.3),
                       overflow: TextOverflow.ellipsis,
                       maxLines: 2,
                     ),


### PR DESCRIPTION
Fixes #1746