### PR TITLE
Add option to copy the user ID

### DIFF
--- a/app/lib/account/account_page.dart
+++ b/app/lib/account/account_page.dart
@@ -8,9 +8,8 @@
 
 import 'package:authentification_base/authentification.dart';
 import 'package:bloc_provider/bloc_provider.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
+import 'package:platform_check/platform_check.dart';
 import 'package:sharezone/account/account_page_bloc.dart';
 import 'package:sharezone/account/register_account_section.dart';
 import 'package:sharezone/navigation/logic/navigation_bloc.dart';
@@ -22,7 +21,6 @@ import 'package:sharezone/settings/src/subpages/my_profile/change_state.dart';
 import 'package:sharezone/settings/src/subpages/my_profile/my_profile_page.dart';
 import 'package:sharezone/settings/src/subpages/web_app.dart';
 import 'package:sharezone/widgets/avatar_card.dart';
-import 'package:platform_check/platform_check.dart';
 import 'package:sharezone_widgets/sharezone_widgets.dart';
 
 import 'account_page_bloc_factory.dart';
@@ -166,7 +164,6 @@ class _MainAccountInformationCard extends StatelessWidget {
               if (user.provider?.hasEmailAddress == true) _EmailText(user),
               _TypeOfUserText(userType: user.userType, uid: user.id),
               if (isAnonymous) const RegisterAccountSection(),
-              if (kDebugMode) _UserId(user: user),
             ],
           ),
           const _EditProfilButton(),
@@ -197,37 +194,6 @@ class _EditProfilButton extends StatelessWidget {
         ),
       ),
     );
-  }
-}
-
-class _UserId extends StatelessWidget {
-  const _UserId({required this.user});
-
-  final UserView user;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(top: 25.0),
-      child: InkWell(
-        onTap: () => _copyUidAndShowConfirmationSnackBar(context),
-        onLongPress: () => _copyUidAndShowConfirmationSnackBar(context),
-        child: Text(user.id),
-      ),
-    );
-  }
-
-  void _copyUidAndShowConfirmationSnackBar(BuildContext context) {
-    _copyUidToClipboard();
-    _showConfirmationSnackBar(context);
-  }
-
-  void _copyUidToClipboard() {
-    Clipboard.setData(ClipboardData(text: user.id));
-  }
-
-  void _showConfirmationSnackBar(BuildContext context) {
-    showSnack(context: context, text: 'UID wurde kopiert');
   }
 }
 

--- a/app/lib/settings/src/subpages/my_profile/my_profile_page.dart
+++ b/app/lib/settings/src/subpages/my_profile/my_profile_page.dart
@@ -15,6 +15,7 @@ import 'package:crash_analytics/crash_analytics.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:helper_functions/helper_functions.dart';
 import 'package:provider/provider.dart' as pv;
 import 'package:sharezone/account/account_page.dart';
@@ -66,6 +67,7 @@ class MyProfilePage extends StatelessWidget {
                       _PasswordTile(provider: user.provider),
                       _StateTile(state: user.state),
                       _ProviderTile(provider: user.provider),
+                      _UserId(user.id),
                       _EnterActivationTile(),
                       _PrivacyOptOut(),
                       const Divider(),
@@ -290,6 +292,27 @@ class _PrivacyOptOut extends StatelessWidget {
           ),
         );
       },
+    );
+  }
+}
+
+class _UserId extends StatelessWidget {
+  const _UserId(this.userID);
+
+  final String userID;
+
+  void copyUserId(BuildContext context) {
+    Clipboard.setData(ClipboardData(text: userID));
+    showSnack(context: context, text: 'User ID wurde kopiert');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      leading: const Icon(Icons.tag),
+      title: const Text("User ID"),
+      subtitle: Text(userID),
+      onTap: () => copyUserId(context),
     );
   }
 }


### PR DESCRIPTION
When helping users to fix their problems / answering their questions, it's sometimes helpful to have their account. For that, the user ID is required. With this new button, we can ask the users to send us their user ID.

![image](https://github.com/user-attachments/assets/42875e3c-dbec-4074-b10e-4691a6098e43)

Closes #812 