### PR TITLE
Add `app-ads.txt` to our website to verify our domain for AdMob

### DIFF
--- a/website/web/app-ads.txt
+++ b/website/web/app-ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-7730914075870960, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
https://sharezone.net/app-ads.txt