### PR TITLE
Add placeholder for ads

### DIFF
--- a/app/lib/ads/ad_banner.dart
+++ b/app/lib/ads/ad_banner.dart
@@ -66,6 +66,8 @@ class _AdBannerState extends State<AdBanner> {
               setState(() {
                 _isLoaded = true;
                 if (this.ad?.size != null) {
+                  // Updating the height again in case the ad size changed
+                  // (shouldn't be the case).
                   adHeight = this.ad!.size.height.toDouble();
                 }
               });

--- a/app/lib/dashboard/sections/ad_section.dart
+++ b/app/lib/dashboard/sections/ad_section.dart
@@ -6,6 +6,8 @@
 //
 // SPDX-License-Identifier: EUPL-1.2
 
+import 'dart:math';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
@@ -13,6 +15,7 @@ import 'package:platform_check/platform_check.dart';
 import 'package:provider/provider.dart';
 import 'package:sharezone/ads/ads_controller.dart';
 import 'package:sharezone/sharezone_plus/page/sharezone_plus_page.dart';
+import 'package:sharezone_widgets/sharezone_widgets.dart';
 
 class DashboardAds extends StatefulWidget {
   const DashboardAds({super.key});
@@ -93,7 +96,7 @@ class _DashboardAdsState extends State<DashboardAds> {
   @override
   Widget build(BuildContext context) {
     final areAdsVisible = context.watch<AdsController>().areAdsVisible;
-    if (!areAdsVisible || !_nativeAdIsLoaded) {
+    if (!areAdsVisible) {
       return Container();
     }
 
@@ -134,9 +137,34 @@ class _DashboardAdsState extends State<DashboardAds> {
               maxWidth: 500,
               maxHeight: 100,
             ),
-            child: AdWidget(ad: nativeAd!),
+            child: AnimatedSwitcher(
+              duration: const Duration(milliseconds: 300),
+              child: _nativeAdIsLoaded
+                  ? AdWidget(ad: nativeAd!)
+                  : const _Placeholder(),
+            ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+class _Placeholder extends StatelessWidget {
+  const _Placeholder();
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 100,
+      width: min(500, MediaQuery.of(context).size.width - 24),
+      child: Material(
+        borderRadius: BorderRadius.circular(10),
+        color:
+            Theme.of(context).isDarkTheme ? Colors.grey[900] : Colors.grey[100],
+        child: const Center(
+          child: Text('Anzeige lädt...'),
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Description

This PR adds a placeholder when the ads are loading. However, for the homework and timetable page, we don't know the height at the beginning. This depends on the device height. In the future, we could also cache this information (I already created a ticket: #1772).

## Demo

### iPhone

https://github.com/user-attachments/assets/6bea572a-2270-4063-8a12-8f9c27a31b22

### iPad Pro 13"

https://github.com/user-attachments/assets/8ec4842a-ba4d-47c5-aa86-94f1c2bf6c75

### iPhone SE

https://github.com/user-attachments/assets/888c503e-c8bb-4cc0-8866-c7bf50874fdc


