### PR TITLE
Only show ad info dialog for free users

### DIFF
--- a/app/lib/ads/ads_controller.dart
+++ b/app/lib/ads/ads_controller.dart
@@ -28,6 +28,7 @@ class AdsController extends ChangeNotifier {
 
   /// Defines if ads are visible for the current user.
   bool areAdsVisible = false;
+  bool shouldShowInfoDialog = false;
   StreamSubscription<bool>? _subscription;
 
   AdsController({
@@ -56,19 +57,19 @@ class AdsController extends ChangeNotifier {
   /// Determines if the user should be shown an info dialog about ads.
   ///
   /// We show an info dialog about our ads experiment after the first app open.
-  bool shouldShowInfoDialog() {
+  bool _shouldShowInfoDialog() {
     if (!isQualifiedForAds()) {
       return false;
     }
 
     final hasShownDialog =
-        keyValueStore.getBool('ads-info-dialog-shown') ?? false;
-    if (!hasShownDialog) {
-      keyValueStore.setBool('ads-info-dialog-shown', true);
-      return true;
+        keyValueStore.getBool('ads-info-dialog-shown22') ?? false;
+    if (hasShownDialog) {
+      return false;
     }
 
-    return false;
+    keyValueStore.setBool('ads-info-dialog-shown', true);
+    return true;
   }
 
   // Returns the test ad unit ID for the given [format].
@@ -112,6 +113,7 @@ class AdsController extends ChangeNotifier {
       if (hasUnlocked) {
         areAdsVisible = false;
       } else {
+        shouldShowInfoDialog = _shouldShowInfoDialog();
         areAdsVisible = isQualifiedForAds();
       }
       notifyListeners();

--- a/app/lib/dashboard/dashboard_page.dart
+++ b/app/lib/dashboard/dashboard_page.dart
@@ -123,6 +123,8 @@ class _AdsInfoDialogListener extends StatefulWidget {
 }
 
 class _AdsInfoDialogListenerState extends State<_AdsInfoDialogListener> {
+  // The AdsController already has a flag for this, but just to be safe for race
+  // conditions, we also keep track of it here.
   bool hasShownDialog = false;
 
   @override
@@ -130,6 +132,8 @@ class _AdsInfoDialogListenerState extends State<_AdsInfoDialogListener> {
     final showDialog = context.watch<AdsController>().shouldShowInfoDialog;
     if (showDialog && !hasShownDialog) {
       hasShownDialog = true;
+      context.read<AdsController>().shouldShowInfoDialog = false;
+
       WidgetsBinding.instance.addPostFrameCallback((_) {
         showAdInfoDialog(context);
       });

--- a/app/lib/dashboard/dashboard_page.dart
+++ b/app/lib/dashboard/dashboard_page.dart
@@ -88,37 +88,53 @@ class _DashboardPageState extends State<DashboardPage> {
   void initState() {
     super.initState();
     showTipCardIfIsAvailable(context);
-    maybeShowAdInfoDialog();
-  }
-
-  void maybeShowAdInfoDialog() {
-    final controller = context.read<AdsController>();
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      final shouldShowDialog = controller.shouldShowInfoDialog();
-      if (shouldShowDialog) {
-        showAdInfoDialog(context);
-      }
-    });
   }
 
   @override
   Widget build(BuildContext context) {
-    return SharezoneCustomScaffold(
-      appBarConfiguration: SliverAppBarConfiguration(
-        title: const _AppBarTitle(),
-        backgroundColor:
-            Theme.of(context).isDarkTheme ? ElevationColors.dp8 : blueColor,
-        expandedHeight: 210,
-        elevation: 1,
-        pinned: true,
-        actions: const <Widget>[_ProfileAvatar()],
-        flexibleSpace: _AppBarBottom(),
-        drawerIconColor: Colors.white,
+    return _AdsInfoDialogListener(
+      child: SharezoneCustomScaffold(
+        appBarConfiguration: SliverAppBarConfiguration(
+          title: const _AppBarTitle(),
+          backgroundColor:
+              Theme.of(context).isDarkTheme ? ElevationColors.dp8 : blueColor,
+          expandedHeight: 210,
+          elevation: 1,
+          pinned: true,
+          actions: const <Widget>[_ProfileAvatar()],
+          flexibleSpace: _AppBarBottom(),
+          drawerIconColor: Colors.white,
+        ),
+        navigationItem: NavigationItem.overview,
+        body: const DashboardPageBody(),
+        floatingActionButton: const _DashboardPageFAB(),
       ),
-      navigationItem: NavigationItem.overview,
-      body: const DashboardPageBody(),
-      floatingActionButton: const _DashboardPageFAB(),
     );
+  }
+}
+
+class _AdsInfoDialogListener extends StatefulWidget {
+  const _AdsInfoDialogListener({required this.child});
+
+  final Widget child;
+
+  @override
+  State<_AdsInfoDialogListener> createState() => _AdsInfoDialogListenerState();
+}
+
+class _AdsInfoDialogListenerState extends State<_AdsInfoDialogListener> {
+  bool hasShownDialog = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final showDialog = context.watch<AdsController>().shouldShowInfoDialog;
+    if (showDialog && !hasShownDialog) {
+      hasShownDialog = true;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        showAdInfoDialog(context);
+      });
+    }
+    return widget.child;
   }
 }
 


### PR DESCRIPTION
This PR fixes that we showed the dialog also to plus users. To fix this, we listen to the `shouldShowInfoDialog`. It's better to transform this to a listenable value because the `SubscriptionService` will need a short moment to load the user document.