### PR TITLE
Fix that when you launch Mail with a template, the space character is a '+'.

### DIFF
--- a/lib/url_launcher_extended/lib/src/url_launcher_extended.dart
+++ b/lib/url_launcher_extended/lib/src/url_launcher_extended.dart
@@ -107,21 +107,22 @@ class UrlLauncherExtended {
     String? subject,
     String? body,
   }) async {
-    final emailLaunchString = Uri(
-      scheme: 'mailto',
-      path: address,
-      queryParameters: {
-        if (subject != null) 'subject': subject,
-        if (body != null) 'body': body,
-      },
-    );
+    String url = 'mailto:$address';
+    if (subject != null) {
+      url += '?subject=$subject';
+    }
+    if (body != null) {
+      url += subject == null ? '?' : '&';
+      url += 'body=$body';
+    }
 
-    final canLaunch = await canLaunchUrl(emailLaunchString);
+    final uri = Uri.parse(url);
+    final canLaunch = await canLaunchUrl(uri);
     if (!canLaunch) {
       throw CouldNotLaunchMailException(address, subject: subject, body: body);
     }
 
-    return launchUrl(emailLaunchString);
+    return launchUrl(uri);
   }
 }
 


### PR DESCRIPTION
Only on iOS, see the following issues for more context:
* https://github.com/flutter/flutter/issues/75552#issuecomment-818777717
* https://github.com/flutter/flutter/issues/73717#issuecomment-823542147