### PR TITLE
Fix opening keyboard when selecting event/exam time

### DIFF
--- a/app/lib/timetable/timetable_add_event/timetable_add_event_dialog.dart
+++ b/app/lib/timetable/timetable_add_event/timetable_add_event_dialog.dart
@@ -66,15 +66,14 @@ class TimetableAddEventDialog extends StatefulWidget {
     required this.isExam,
     @visibleForTesting this.controller,
     @visibleForTesting TimeOfDay Function()? showTimePickerTestOverride,
-    @visibleForTesting FocusNode? titleFocusNode,
+    @visibleForTesting this.titleFocusNode,
   }) {
-    this.titleFocusNode = titleFocusNode ?? FocusNode();
     _timePickerOverride = showTimePickerTestOverride;
   }
 
   final bool isExam;
   late AddEventDialogController? controller;
-  late final FocusNode titleFocusNode;
+  late final FocusNode? titleFocusNode;
   static const tag = "timetable-event-dialog";
 
   @override
@@ -84,10 +83,12 @@ class TimetableAddEventDialog extends StatefulWidget {
 
 class _TimetableAddEventDialogState extends State<TimetableAddEventDialog> {
   late AddEventDialogController controller;
+  late FocusNode titleFocusNode;
 
   @override
   void initState() {
     super.initState();
+    titleFocusNode = widget.titleFocusNode ?? FocusNode();
     controller = widget.controller ??
         AddEventDialogController(
           isExam: widget.isExam,
@@ -96,7 +97,7 @@ class _TimetableAddEventDialogState extends State<TimetableAddEventDialog> {
         );
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      delayKeyboard(context: context, focusNode: widget.titleFocusNode);
+      delayKeyboard(context: context, focusNode: titleFocusNode);
     });
   }
 
@@ -133,7 +134,7 @@ class _TimetableAddEventDialogState extends State<TimetableAddEventDialog> {
                     isExam: widget.isExam,
                     titleField: _TitleField(
                       key: EventDialogKeys.titleTextField,
-                      focusNode: widget.titleFocusNode,
+                      focusNode: titleFocusNode,
                       isExam: widget.isExam,
                     )),
                 Expanded(

--- a/app/lib/timetable/timetable_add_event/timetable_add_event_dialog.dart
+++ b/app/lib/timetable/timetable_add_event/timetable_add_event_dialog.dart
@@ -60,7 +60,7 @@ Future<void> _showUserConfirmationOfEventArrival({
 /// Not using final will cause the linter to complain about the lint below, so
 /// we have to ignore it.
 // ignore: must_be_immutable
-class TimetableAddEventDialog extends StatelessWidget {
+class TimetableAddEventDialog extends StatefulWidget {
   TimetableAddEventDialog({
     super.key,
     required this.isExam,
@@ -75,27 +75,39 @@ class TimetableAddEventDialog extends StatelessWidget {
   final bool isExam;
   late AddEventDialogController? controller;
   late final FocusNode titleFocusNode;
-  bool _hasRequestedTitleFocus = false;
-
   static const tag = "timetable-event-dialog";
 
+  @override
+  State<TimetableAddEventDialog> createState() =>
+      _TimetableAddEventDialogState();
+}
+
+class _TimetableAddEventDialogState extends State<TimetableAddEventDialog> {
+  late AddEventDialogController controller;
+
+  @override
+  void initState() {
+    super.initState();
+    controller = widget.controller ??
+        AddEventDialogController(
+          isExam: widget.isExam,
+          api: EventDialogApi(BlocProvider.of<SharezoneContext>(context).api),
+          markdownAnalytics: BlocProvider.of<MarkdownAnalytics>(context),
+        );
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      delayKeyboard(context: context, focusNode: widget.titleFocusNode);
+    });
+  }
+
   bool hasModifiedData() {
-    return controller!.title.isNotEmpty || controller!.description.isNotEmpty;
+    return controller.title.isNotEmpty || controller.description.isNotEmpty;
   }
 
   @override
   Widget build(BuildContext context) {
-    if (!_hasRequestedTitleFocus) {
-      _hasRequestedTitleFocus = true;
-      delayKeyboard(context: context, focusNode: titleFocusNode);
-    }
-    controller ??= AddEventDialogController(
-      isExam: isExam,
-      api: EventDialogApi(BlocProvider.of<SharezoneContext>(context).api),
-      markdownAnalytics: BlocProvider.of<MarkdownAnalytics>(context),
-    );
-    return ChangeNotifierProvider(
-      create: (context) => controller,
+    return ChangeNotifierProvider.value(
+      value: controller,
       builder: (context, __) => PopScope<Object?>(
           canPop: false,
           onPopInvokedWithResult: (didPop, _) async {
@@ -118,11 +130,11 @@ class TimetableAddEventDialog extends StatelessWidget {
               children: <Widget>[
                 _AppBar(
                     editMode: false,
-                    isExam: isExam,
+                    isExam: widget.isExam,
                     titleField: _TitleField(
                       key: EventDialogKeys.titleTextField,
-                      focusNode: titleFocusNode,
-                      isExam: isExam,
+                      focusNode: widget.titleFocusNode,
+                      isExam: widget.isExam,
                     )),
                 Expanded(
                   child: SingleChildScrollView(
@@ -134,11 +146,11 @@ class TimetableAddEventDialog extends StatelessWidget {
                         const _MobileDivider(),
                         const _DateAndTimePicker(),
                         const _MobileDivider(),
-                        _DescriptionField(isExam: isExam),
+                        _DescriptionField(isExam: widget.isExam),
                         const _MobileDivider(),
                         const _Location(),
                         const _MobileDivider(),
-                        _SendNotification(isExam: isExam),
+                        _SendNotification(isExam: widget.isExam),
                       ],
                     ),
                   ),


### PR DESCRIPTION
The issue was that the `delayKeyboard()` was calling the `build()` method.

Fixes #1789 