### PR TITLE
Add error for developers in grade system tests.

### DIFF
--- a/app/test/grades/grade_types_test.dart
+++ b/app/test/grades/grade_types_test.dart
@@ -329,6 +329,7 @@ void main() {
           id: const TermId('foo'),
           subjects: [subjectWith(id: const SubjectId('bar'))],
         ),
+        throwErrorForSubjectsWithNoGrades: false,
       );
 
       addGrade() => controller.addGrade(
@@ -350,6 +351,7 @@ void main() {
           id: const TermId('foo'),
           subjects: [subjectWith(id: const SubjectId('bar'))],
         ),
+        throwErrorForSubjectsWithNoGrades: false,
       );
 
       addGrades() {

--- a/app/test/grades/grading_systems_test.dart
+++ b/app/test/grades/grading_systems_test.dart
@@ -432,12 +432,15 @@ void main() {
         final controller = GradesTestController();
         final service = controller.service;
 
-        controller.createTerm(termWith(
-            id: const TermId('1'),
-            gradingSystem: gradingSystem,
-            subjects: [
-              subjectWith(id: const SubjectId('math')),
-            ]));
+        controller.createTerm(
+          termWith(
+              id: const TermId('1'),
+              gradingSystem: gradingSystem,
+              subjects: [
+                subjectWith(id: const SubjectId('math')),
+              ]),
+          throwErrorForSubjectsWithNoGrades: false,
+        );
 
         final pg = service.getPossibleGrades(gradingSystem);
         expect(pg, isA<ContinuousNumericalPossibleGradesResult>());
@@ -488,12 +491,15 @@ void main() {
         final controller = GradesTestController();
         final service = controller.service;
 
-        controller.createTerm(termWith(
-            id: const TermId('1'),
-            gradingSystem: gradingSystem,
-            subjects: [
-              subjectWith(id: const SubjectId('math')),
-            ]));
+        controller.createTerm(
+          termWith(
+              id: const TermId('1'),
+              gradingSystem: gradingSystem,
+              subjects: [
+                subjectWith(id: const SubjectId('math')),
+              ]),
+          throwErrorForSubjectsWithNoGrades: false,
+        );
 
         final pg = service.getPossibleGrades(gradingSystem);
         expect(pg, isA<ContinuousNumericalPossibleGradesResult>());
@@ -554,13 +560,16 @@ void main() {
         final controller = GradesTestController();
         final service = controller.service;
 
-        controller.createTerm(termWith(
-            id: const TermId('1'),
-            gradingSystem: gradingSystem,
-            subjects: [
-              subjectWith(id: const SubjectId('math')),
-              subjectWith(id: const SubjectId('english')),
-            ]));
+        controller.createTerm(
+          termWith(
+              id: const TermId('1'),
+              gradingSystem: gradingSystem,
+              subjects: [
+                subjectWith(id: const SubjectId('math')),
+                subjectWith(id: const SubjectId('english')),
+              ]),
+          throwErrorForSubjectsWithNoGrades: false,
+        );
 
         final pg = service.getPossibleGrades(gradingSystem);
         expect(pg, isA<ContinuousNumericalPossibleGradesResult>());
@@ -740,9 +749,15 @@ void main() {
     test('A suffix is only returned by percentage grade system', () {
       final controller = GradesTestController();
 
-      controller.createTerm(termWith(id: const TermId('1'), subjects: [
-        subjectWith(id: const SubjectId('math')),
-      ]));
+      controller.createTerm(
+        termWith(
+          id: const TermId('1'),
+          subjects: [
+            subjectWith(id: const SubjectId('math')),
+          ],
+        ),
+        throwErrorForSubjectsWithNoGrades: false,
+      );
 
       for (final gradingSystem in GradingSystem.values) {
         final gradeId = GradeId(randomAlpha(5));


### PR DESCRIPTION
Adds `bool throwErrorForSubjectsWithNoGrades` to `GradesTestController.createTerm`. This is to prevent developers from being confused when they create a term with a subject that has no grades and then try to access the subject of the term. This would throw an error as the term won't have the subject added, as it has no grades for it (yet).

Example for confusing behavior:
```
testController.createTerm(termWith(id: TermId('foo'), subjects: [
  subjectWith(id: SubjectId('maths')),
]));
// Throws error as the term does not have the 'maths' subject, because 
// it was not added to the term because there is no grade for 'maths' fo
// this term.
testController.term(TermId('foo')).subject(SubjectId('maths')).name;
```

Now there would be an error thrown when calling `testController.createTerm` which makes debugging easier.