### PR TITLE
Add --debug flag Android integration tests

### DIFF
--- a/.github/workflows/integration_tests_app_ci.yml
+++ b/.github/workflows/integration_tests_app_ci.yml
@@ -110,10 +110,14 @@ jobs:
           # We are using the prod flavor because we were not able to set up
           # Firebase Test Lab with the dev flavor. We always got "No tests
           # found.".
+          # Using --debug mode since --release mode will not include
+          # package:integration_test, see
+          # https://github.com/flutter/website/pull/11744
           flutter build apk \
             --target=lib/main_prod.dart \
             --flavor prod \
-            --config-only
+            --config-only \
+            --debug
 
       - name: Build Instrumentation Test
         run: |

--- a/.github/workflows/integration_tests_app_ci.yml
+++ b/.github/workflows/integration_tests_app_ci.yml
@@ -110,6 +110,7 @@ jobs:
           # We are using the prod flavor because we were not able to set up
           # Firebase Test Lab with the dev flavor. We always got "No tests
           # found.".
+          #
           # Using --debug mode since --release mode will not include
           # package:integration_test, see
           # https://github.com/flutter/website/pull/11744


### PR DESCRIPTION
Our Android integration tests also worked before but I just saw the following docs PR which mentions the `--debug` flag: https://github.com/flutter/website/pull/11744/files