### PR TITLE
Change "Lifetime" to "Lebenslang" in the UI

### DIFF
--- a/lib/sharezone_plus/sharezone_plus_page_ui/lib/src/buy_section.dart
+++ b/lib/sharezone_plus/sharezone_plus_page_ui/lib/src/buy_section.dart
@@ -91,7 +91,7 @@ class BuySection extends StatelessWidget {
                 ),
                 const SizedBox(height: 6),
                 _PeriodOption(
-                  name: 'Lifetime (einmaliger Kauf)',
+                  name: 'Lebenslang (einmaliger Kauf)',
                   price: lifetimePrice,
                   period: PurchasePeriod.lifetime,
                   currentPeriod: currentPeriod,


### PR DESCRIPTION
I have the feeling that a few people are not understanding the word "Lifetime". Some parents write:

>  "Live-Time" Funktionen

I hope the change to the German word will clear up the confusion.