### PR TITLE
Downgrade Firebase CLI from v14 to v13

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -98,7 +98,7 @@ jobs:
           node-version: "20"
 
       - name: Install Firebase CLI
-        run: npm i -g firebase-tools@14.1.0
+        run: npm i -g firebase-tools@13.35.1
 
       - name: Build and deploy web-app
         env:
@@ -198,7 +198,7 @@ jobs:
             --output-type apk
 
       - name: Install Firebase CLI
-        run: sudo npm i -g firebase-tools@14.1.0
+        run: sudo npm i -g firebase-tools@13.35.1
 
       - name: Publish to Firebase Distribution
         working-directory: app

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -152,7 +152,7 @@ jobs:
           node-version: "20"
 
       - name: Install Firebase CLI
-        run: npm i -g firebase-tools@14.1.0
+        run: npm i -g firebase-tools@13.35.1
 
       - name: Build and deploy web-app
         env:

--- a/.github/workflows/console_cd.yml
+++ b/.github/workflows/console_cd.yml
@@ -92,7 +92,7 @@ jobs:
           echo $(pwd)/bin >> $GITHUB_PATH
 
       - name: Install Firebase CLI
-        run: npm i -g firebase-tools@14.1.0
+        run: npm i -g firebase-tools@13.35.1
 
       - name: Setup Node.js
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e

--- a/.github/workflows/docs_cd.yml
+++ b/.github/workflows/docs_cd.yml
@@ -77,7 +77,7 @@ jobs:
           entryPoint: "./docs"
           target: docs
           projectId: ${{ matrix.environment.projectId }}
-          firebaseToolsVersion: 14.1.0
+          firebaseToolsVersion: 13.35.1
         env:
           # Required to deploy Next.js applications to Firebase Hosting
           FIREBASE_CLI_EXPERIMENTS: webframeworks

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -140,7 +140,7 @@ jobs:
       - run: echo $(realpath ./bin) >> $GITHUB_PATH
 
       - name: Install Firebase CLI
-        run: npm i -g firebase-tools@14.1.0
+        run: npm i -g firebase-tools@13.35.1
 
       - name: Setup Node.js
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e

--- a/.github/workflows/unsafe_app_ci.yml
+++ b/.github/workflows/unsafe_app_ci.yml
@@ -184,4 +184,4 @@ jobs:
           # of pull requests, we will run out of quota (we get 429 errors).
           expires: "3d"
           target: "test-web-app"
-          firebaseToolsVersion: 14.1.0
+          firebaseToolsVersion: 13.35.1

--- a/.github/workflows/unsafe_console_ci.yml
+++ b/.github/workflows/unsafe_console_ci.yml
@@ -178,4 +178,4 @@ jobs:
           # of pull requests, we will run out of quota (we get 429 errors).
           expires: "3d"
           target: "sharezone-console"
-          firebaseToolsVersion: 14.1.0
+          firebaseToolsVersion: 13.35.1

--- a/.github/workflows/unsafe_docs_ci.yml
+++ b/.github/workflows/unsafe_docs_ci.yml
@@ -147,7 +147,7 @@ jobs:
           # of pull requests, we will run out of quota (we get 429 errors).
           expires: "3d"
           target: "docs"
-          firebaseToolsVersion: 14.1.0
+          firebaseToolsVersion: 13.35.1
         env:
           # Required to deploy Next.js applications to Firebase Hosting
           FIREBASE_CLI_EXPERIMENTS: webframeworks

--- a/.github/workflows/unsafe_website_ci.yml
+++ b/.github/workflows/unsafe_website_ci.yml
@@ -178,4 +178,4 @@ jobs:
           # of pull requests, we will run out of quota (we get 429 errors).
           expires: "3d"
           target: "sharezone-website"
-          firebaseToolsVersion: 14.1.0
+          firebaseToolsVersion: 13.35.1

--- a/.github/workflows/website_cd.yml
+++ b/.github/workflows/website_cd.yml
@@ -92,7 +92,7 @@ jobs:
           echo $(pwd)/bin >> $GITHUB_PATH
 
       - name: Install Firebase CLI
-        run: npm i -g firebase-tools@14.1.0
+        run: npm i -g firebase-tools@13.35.1
 
       - name: Setup Node.js
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e


### PR DESCRIPTION
https://github.com/firebase/firebase-tools/issues/8378#issuecomment-2762187226 mentioned that 14.0.1 fixed the issue with the Next.js deployment failure but the still exist, see my comment: https://github.com/firebase/firebase-tools/issues/8378#issuecomment-2808851762. According to [this comment](https://github.com/firebase/firebase-tools/issues/8378#issuecomment-2762062584), we can use Firebase CLI v13 instead of v14 as a workaround for now (should be fixed in the next few weeks).