### PR TITLE
Fix: Sign out button icon now visible in light mode

### DIFF
--- a/app/lib/groups/src/widgets/danger_section.dart
+++ b/app/lib/groups/src/widgets/danger_section.dart
@@ -79,7 +79,10 @@ class DangerButtonOutlined extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.only(bottom: 12),
       child: FilledButton.icon(
-        icon: icon,
+        icon: IconTheme(
+          data: IconThemeData(color: Colors.red),
+          child: icon,
+        ),
         style: FilledButton.styleFrom(
           shadowColor: Colors.transparent,
           foregroundColor: Colors.red,


### PR DESCRIPTION
Title
Fix: Sign out button icon now visible in light mode
Description
This PR fixes issue #1854 where the icon in the sign out button was white on a white background, making it not visible in light mode.
Changes
Wrapped the icon in DangerButtonOutlined with an IconTheme widget that explicitly sets the color to red
This ensures the icon is consistently visible in both light and dark modes
Technical Details
The issue occurred because the exit icon in the sign out button wasn't properly inheriting the intended color in light mode. By explicitly setting the icon color through IconTheme, we ensure it's always visible regardless of theme settings.
Closes #1854 