### PR TITLE
Remove padding from room text

### DIFF
--- a/app/lib/timetable/timetable_page/lesson/timetable_lesson_tile.dart
+++ b/app/lib/timetable/timetable_page/lesson/timetable_lesson_tile.dart
@@ -179,15 +179,12 @@ class Room extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(top: 4),
-      child: Text(
-        room,
-        style: TextStyle(
-          color: color,
-          fontSize: 12,
-          decoration: isStrikeThrough ? TextDecoration.lineThrough : null,
-        ),
+    return Text(
+      room,
+      style: TextStyle(
+        color: color,
+        fontSize: 12,
+        decoration: isStrikeThrough ? TextDecoration.lineThrough : null,
       ),
     );
   }


### PR DESCRIPTION
| Before | After |
|--------|--------|
| <img width="1312" alt="image" src="https://github.com/user-attachments/assets/427c1f3f-7835-49b8-9ee6-44ce6cb1c8ce" /> | <img width="1312" alt="Screenshot 2025-05-16 at 11 09 01" src="https://github.com/user-attachments/assets/0db14476-9846-4560-8951-6cb41271b142" /> |

Making the view a bit more compact, since the lessons box is very small for lessons with a length of 30/45 minutes.