### PR TITLE
Remove renaming the files locally

### DIFF
--- a/lib/filesharing/files_usecases/lib/src/file_downloader/implementation/mobile_file_downloader.dart
+++ b/lib/filesharing/files_usecases/lib/src/file_downloader/implementation/mobile_file_downloader.dart
@@ -6,16 +6,10 @@
 //
 // SPDX-License-Identifier: EUPL-1.2
 
-import 'dart:io';
-
-import 'package:files_basics/files_models.dart';
-import 'package:path/path.dart' as path;
-
 import 'package:files_basics/local_file.dart';
 import 'package:files_basics/local_file_io.dart';
 import 'package:files_usecases/src/file_downloader/file_downloader.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
-import 'package:platform_check/platform_check.dart';
 
 class MobileFileDownloader extends FileDownloader {
   @override
@@ -24,36 +18,8 @@ class MobileFileDownloader extends FileDownloader {
     String filename,
     String id,
   ) async {
-    File fileWithID = await DefaultCacheManager().getSingleFile(url);
-    final filePath =
-        '${path.dirname(fileWithID.path)}/$id.${FileUtils.getExtension(filename)}';
-
-    // Da unsere Dateien die ID als Namen haben, müssen diese umbenannt werden.
-    // Deswegen muss erst geprüft werden, ob der Pfad, welcher vom [DefaulCacheManger]
-    // zurückgegeben wurde, existiert. Existiert dieser Pfad, wurde die Datei gerade
-    // heruntergeladen und muss noch umbenannt werden. Die ID wird dann durch den
-    // richtigen Namen ersetzt. Wird dann beim nächsten Mal die Datei aufgerufen,
-    // befindet sich bei dem Path, welchen der [DefaultCacheManger] zurückgegeben hat,
-    // keine Datei. Das liegt daran, weil wir vorher die Datei mit dem richtigen Namen
-    // benannt haben. Wir müssen dann auch an diesem Ort suchen, also nach dem [filePath].
-    fileWithID =
-        await fileWithID.exists()
-            ? await fileWithID.rename(filePath)
-            : File(filePath);
-
-    if (PlatformCheck.isMacOS) {
-      filename = filename.replaceAll(RegExp(r"""[();:"` <>&']"""), '');
-
-      // Falls der Dateiname vor der Extention leer ist, soll ein _ hinzufügen werden.
-      if (filename.lastIndexOf('.') == 0) {
-        filename = '_$filename';
-      }
-    }
-
-    final fileWithNamePath = '${path.dirname(fileWithID.path)}/$filename';
-    final fileWithName = await fileWithID.copy(fileWithNamePath);
-
-    return LocalFileIo.fromFile(fileWithName);
+    final file = await DefaultCacheManager().getSingleFile(url);
+    return LocalFileIo.fromFile(file);
   }
 }
 

--- a/lib/filesharing/filesharing_logic/pubspec.yaml
+++ b/lib/filesharing/filesharing_logic/pubspec.yaml
@@ -30,7 +30,6 @@ dependencies:
   firebase_storage: ^12.4.3
   meta: ^1.16.0
   mime: ^2.0.0
-  path: ^1.9.1
   permission_handler: ^11.3.1
   helper_functions:
     path: ../../helper_functions


### PR DESCRIPTION
This is causing problems for #1865, and I don't think it's necessary anymore since we're setting the 'Content-Disposition' header in the files:

https://github.com/SharezoneApp/sharezone-app/blob/08cca5a9adb7089b5aab47187d55476c15584f07/lib/filesharing/filesharing_logic/lib/src/file_uploader/implementation/firebase_file_uploader.dart#L76