### PR TITLE
Revert "Remove renaming the files locally" (#1868) and add `rename` to `downloadFileFromURL` method

### DIFF
--- a/app/lib/filesharing/widgets/file_grid_card.dart
+++ b/app/lib/filesharing/widgets/file_grid_card.dart
@@ -151,6 +151,7 @@ class _ImagePreviewNative extends StatelessWidget {
         cloudFile.downloadURL!,
         cloudFile.name,
         cloudFile.id!,
+        rename: false,
       ),
       builder: (context, resultSnapshot) {
         if (resultSnapshot.hasError) {

--- a/lib/filesharing/files_usecases/lib/src/file_downloader/file_downloader.dart
+++ b/lib/filesharing/files_usecases/lib/src/file_downloader/file_downloader.dart
@@ -9,5 +9,14 @@
 import 'package:files_basics/local_file.dart';
 
 abstract class FileDownloader {
-  Future<LocalFile> downloadFileFromURL(String url, String filename, String id);
+  /// Downloads a file from the given [url], saves it locally and returns a
+  /// [LocalFile] representing the downloaded file.
+  ///
+  /// Renames to [filename], if [rename] is `true`.
+  Future<LocalFile> downloadFileFromURL(
+    String url,
+    String filename,
+    String id, {
+    bool rename = true,
+  });
 }

--- a/lib/filesharing/files_usecases/lib/src/file_downloader/implementation/mobile_file_downloader.dart
+++ b/lib/filesharing/files_usecases/lib/src/file_downloader/implementation/mobile_file_downloader.dart
@@ -8,13 +8,11 @@
 
 import 'dart:io';
 
-import 'package:files_basics/files_models.dart';
-import 'package:path/path.dart' as path;
-
 import 'package:files_basics/local_file.dart';
 import 'package:files_basics/local_file_io.dart';
 import 'package:files_usecases/src/file_downloader/file_downloader.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+import 'package:path/path.dart' as path;
 import 'package:platform_check/platform_check.dart';
 
 class MobileFileDownloader extends FileDownloader {
@@ -22,9 +20,14 @@ class MobileFileDownloader extends FileDownloader {
   Future<LocalFile> downloadFileFromURL(
     String url,
     String filename,
-    String id,
-  ) async {
+    String id, {
+    bool rename = true,
+  }) async {
     File fileWithID = await DefaultCacheManager().getSingleFile(url);
+    if (!rename) {
+      return LocalFileIo.fromFile(fileWithID);
+    }
+
     final filePath =
         '${path.dirname(fileWithID.path)}/$id.${FileUtils.getExtension(filename)}';
 

--- a/lib/filesharing/files_usecases/lib/src/file_downloader/implementation/mobile_file_downloader.dart
+++ b/lib/filesharing/files_usecases/lib/src/file_downloader/implementation/mobile_file_downloader.dart
@@ -6,10 +6,16 @@
 //
 // SPDX-License-Identifier: EUPL-1.2
 
+import 'dart:io';
+
+import 'package:files_basics/files_models.dart';
+import 'package:path/path.dart' as path;
+
 import 'package:files_basics/local_file.dart';
 import 'package:files_basics/local_file_io.dart';
 import 'package:files_usecases/src/file_downloader/file_downloader.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+import 'package:platform_check/platform_check.dart';
 
 class MobileFileDownloader extends FileDownloader {
   @override
@@ -18,8 +24,36 @@ class MobileFileDownloader extends FileDownloader {
     String filename,
     String id,
   ) async {
-    final file = await DefaultCacheManager().getSingleFile(url);
-    return LocalFileIo.fromFile(file);
+    File fileWithID = await DefaultCacheManager().getSingleFile(url);
+    final filePath =
+        '${path.dirname(fileWithID.path)}/$id.${FileUtils.getExtension(filename)}';
+
+    // Da unsere Dateien die ID als Namen haben, müssen diese umbenannt werden.
+    // Deswegen muss erst geprüft werden, ob der Pfad, welcher vom [DefaulCacheManger]
+    // zurückgegeben wurde, existiert. Existiert dieser Pfad, wurde die Datei gerade
+    // heruntergeladen und muss noch umbenannt werden. Die ID wird dann durch den
+    // richtigen Namen ersetzt. Wird dann beim nächsten Mal die Datei aufgerufen,
+    // befindet sich bei dem Path, welchen der [DefaultCacheManger] zurückgegeben hat,
+    // keine Datei. Das liegt daran, weil wir vorher die Datei mit dem richtigen Namen
+    // benannt haben. Wir müssen dann auch an diesem Ort suchen, also nach dem [filePath].
+    fileWithID =
+        await fileWithID.exists()
+            ? await fileWithID.rename(filePath)
+            : File(filePath);
+
+    if (PlatformCheck.isMacOS) {
+      filename = filename.replaceAll(RegExp(r"""[();:"` <>&']"""), '');
+
+      // Falls der Dateiname vor der Extention leer ist, soll ein _ hinzufügen werden.
+      if (filename.lastIndexOf('.') == 0) {
+        filename = '_$filename';
+      }
+    }
+
+    final fileWithNamePath = '${path.dirname(fileWithID.path)}/$filename';
+    final fileWithName = await fileWithID.copy(fileWithNamePath);
+
+    return LocalFileIo.fromFile(fileWithName);
   }
 }
 

--- a/lib/filesharing/files_usecases/lib/src/file_downloader/implementation/web_file_downloader.dart
+++ b/lib/filesharing/files_usecases/lib/src/file_downloader/implementation/web_file_downloader.dart
@@ -17,8 +17,9 @@ class WebFileDownloader extends FileDownloader {
   Future<LocalFile> downloadFileFromURL(
     String url,
     String filename,
-    String id,
-  ) async {
+    String id, {
+    bool rename = true,
+  }) async {
     final response = await http.get(Uri.parse(url));
     return LocalFileData.fromData(response.bodyBytes, url, filename, null);
   }

--- a/lib/filesharing/files_usecases/lib/src/file_viewer/pages/image_file_page.dart
+++ b/lib/filesharing/files_usecases/lib/src/file_viewer/pages/image_file_page.dart
@@ -86,6 +86,7 @@ class _ImageFilePageState extends State<ImageFilePage> {
         widget.downloadURL,
         widget.name,
         widget.id,
+        rename: false,
       ),
       builder: (context, snapshot) {
         if (!snapshot.hasData) {

--- a/lib/filesharing/filesharing_logic/pubspec.yaml
+++ b/lib/filesharing/filesharing_logic/pubspec.yaml
@@ -30,6 +30,7 @@ dependencies:
   firebase_storage: ^12.4.3
   meta: ^1.16.0
   mime: ^2.0.0
+  path: ^1.9.1
   permission_handler: ^11.3.1
   helper_functions:
     path: ../../helper_functions


### PR DESCRIPTION
Unfortunately, [`flutter_cache_manager`](https://pub.dev/packages/flutter_cache_manager) does not use the Content-Disposition header as expected. Consequently, both iOS and Android attempted to open a file with a UUID as its name and no file extension. Reverting #1868 resolves this issue. However, renaming in `downloadFileFromURL` breaks the file grid view (sometimes the OS throws an error). To prevent this, I added a `rename` parameter to `downloadFileFromURL`. Setting the rename parameter to `false` will prevent the file from being renamed, which is necessary for the file grid view.