### PR TITLE
Add iOS timetable widget

### DIFF
--- a/app/ios/Runner/Info.plist
+++ b/app/ios/Runner/Info.plist
@@ -115,9 +115,11 @@
 	<false/>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
-	<key>GADApplicationIdentifier</key>
+        <key>UIApplicationSupportsIndirectInputEvents</key>
+        <true/>
+        <key>AppGroup</key>
+        <string>group.de.codingbrain.sharezone.widget</string>
+        <key>GADApplicationIdentifier</key>
 	<string>ca-app-pub-7730914075870960~4953718516</string>
 </dict>
 </plist>

--- a/app/ios/TimetableWidget/Info.plist
+++ b/app/ios/TimetableWidget/Info.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>$(DEVELOPMENT_LANGUAGE)</string>
+    <key>CFBundleDisplayName</key>
+    <string>Timetable Widget</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleName</key>
+    <string>TimetableWidget</string>
+    <key>CFBundlePackageType</key>
+    <string>BNDL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>$(MARKETING_VERSION)</string>
+    <key>CFBundleVersion</key>
+    <string>$(CURRENT_PROJECT_VERSION)</string>
+    <key>LSRequiresIPhoneOS</key>
+    <true/>
+    <key>NSExtension</key>
+    <dict>
+        <key>NSExtensionPointIdentifier</key>
+        <string>com.apple.widgetkit-extension</string>
+        <key>NSExtensionPrincipalClass</key>
+        <string>$(PRODUCT_MODULE_NAME).TimetableWidget</string>
+    </dict>
+</dict>
+</plist>

--- a/app/ios/TimetableWidget/TimetableWidget.swift
+++ b/app/ios/TimetableWidget/TimetableWidget.swift
@@ -1,0 +1,76 @@
+import WidgetKit
+import SwiftUI
+
+struct Lesson: Decodable {
+    let start: String
+    let end: String
+    let abbr: String
+}
+
+struct Provider: TimelineProvider {
+    func placeholder(in context: Context) -> Entry {
+        Entry(date: Date(), lessons: [])
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (Entry) -> ()) {
+        completion(Entry(date: Date(), lessons: HomeWidgetProvider.shared.loadLessons()))
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<Entry>) -> ()) {
+        let entry = Entry(date: Date(), lessons: HomeWidgetProvider.shared.loadLessons())
+        let nextUpdate = Calendar.current.date(byAdding: .minute, value: 15, to: Date())!
+        completion(Timeline(entries: [entry], policy: .after(nextUpdate)))
+    }
+}
+
+struct Entry: TimelineEntry {
+    let date: Date
+    let lessons: [Lesson]
+}
+
+struct TimetableWidgetEntryView : View {
+    var entry: Provider.Entry
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            ForEach(entry.lessons.prefix(3), id: \.start) { lesson in
+                HStack {
+                    Text(lesson.start)
+                        .font(.system(size: 14))
+                    Text(lesson.abbr)
+                        .font(.system(size: 14))
+                        .bold()
+                }
+            }
+        }.padding()
+    }
+}
+
+@main
+struct TimetableWidget: Widget {
+    let kind: String = "TimetableWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: Provider()) { entry in
+            TimetableWidgetEntryView(entry: entry)
+        }
+        .configurationDisplayName("Today's Timetable")
+        .description("Shows your timetable for today.")
+        .supportedFamilies([.systemSmall, .systemMedium])
+    }
+}
+
+class HomeWidgetProvider {
+    static let shared = HomeWidgetProvider()
+    let appGroupId = "group.de.codingbrain.sharezone.widget"
+
+    func loadLessons() -> [Lesson] {
+        guard let defaults = UserDefaults(suiteName: appGroupId),
+              let dataString = defaults.string(forKey: "timetable"),
+              let data = dataString.data(using: .utf8),
+              let lessons = try? JSONDecoder().decode([Lesson].self, from: data) else {
+            return []
+        }
+        return lessons
+    }
+}

--- a/app/lib/dashboard/bloc/dashboard_bloc.dart
+++ b/app/lib/dashboard/bloc/dashboard_bloc.dart
@@ -34,6 +34,7 @@ import 'package:sharezone/util/api/user_api.dart';
 import 'package:sharezone_utils/streams.dart';
 import 'package:time/time.dart';
 import 'package:user/user.dart';
+import 'package:sharezone/home_widget/timetable_widget_updater.dart';
 
 import '../gateway/dashboard_gateway.dart';
 
@@ -121,7 +122,10 @@ class DashboardBloc extends BlocBase {
         .repeatEvery(const Duration(seconds: 1))
         .map((v) => _buildSortedViews(v, Date.fromDateTime(clock.now())));
 
-    final subscription = viewsStream.listen(_lessonViewsSubject.add);
+    final subscription = viewsStream.listen((views) {
+      _lessonViewsSubject.add(views);
+      updateTimetableWidget(views);
+    });
 
     _subscriptions.add(subscription);
   }

--- a/app/lib/home_widget/timetable_widget_updater.dart
+++ b/app/lib/home_widget/timetable_widget_updater.dart
@@ -1,0 +1,22 @@
+import 'dart:convert';
+
+import 'package:home_widget/home_widget.dart';
+import 'package:sharezone/dashboard/timetable/lesson_view.dart';
+
+/// Saves today's lessons to shared App Group storage and updates the widget.
+Future<void> updateTimetableWidget(List<LessonView> lessons) async {
+  final serialized = [
+    for (final l in lessons)
+      {
+        'start': l.start,
+        'end': l.end,
+        'abbr': l.abbreviation,
+      }
+  ];
+
+  await HomeWidget.saveWidgetData<String>('timetable', jsonEncode(serialized));
+  await HomeWidget.updateWidget(
+    name: 'TimetableWidget',
+    iOSName: 'TimetableWidget',
+  );
+}

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -188,6 +188,7 @@ dependencies:
     path: ../lib/user
   video_player: ^2.9.2
   chewie: ^1.10.0
+  home_widget: ^0.8.0
 
 # Falls hier etwas hinzugefügt wird, MUSS ab jetzt ein Kommentar hinzugefügt:
 # * warum der dependency_override hinzugefügt wird.


### PR DESCRIPTION
## Summary
- add `home_widget` dependency
- provide helper to update timetable widget
- update dashboard bloc to write widget data
- create iOS WidgetKit extension for today's timetable
- configure AppGroup in iOS

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877e4b19b3c83228bce6c7c29369ceb