### PR TITLE
feat: add l10n command

### DIFF
--- a/tools/sz_repo_cli/lib/src/commands/commands.dart
+++ b/tools/sz_repo_cli/lib/src/commands/commands.dart
@@ -12,6 +12,7 @@ export 'src/deploy_app_web_command.dart';
 export 'src/do_stuff_command.dart';
 export 'src/exec_command.dart';
 export 'src/fix_comment_spacing_command.dart' show FixCommentSpacingCommand;
+export 'src/l10n_command.dart';
 export 'src/pick_codemagic_goldens_command.dart';
 export 'src/pub_command.dart';
 export 'src/pub_get_command.dart' show PubGetCommand;

--- a/tools/sz_repo_cli/lib/src/commands/src/l10n_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/l10n_command.dart
@@ -1,0 +1,39 @@
+// Copyright (c) 2024 Sharezone UG (haftungsbeschr\u00e4nkt)
+// Licensed under the EUPL-1.2-or-later.
+//
+// You may obtain a copy of the Licence at:
+// https://joinup.ec.europa.eu/software/page/eupl
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+import 'dart:async';
+
+import 'package:sz_repo_cli/src/common/common.dart';
+
+/// Generates localization files and formats them.
+class L10nCommand extends CommandBase {
+  L10nCommand(super.context);
+
+  @override
+  String get name => 'l10n';
+
+  @override
+  String get description => 'Generates localization files and formats them.';
+
+  @override
+  Future<void> run() async {
+    final l10nDir = repo.location
+        .childDirectory('lib')
+        .childDirectory('sharezone_localizations');
+
+    await processRunner.runCommand([
+      'flutter',
+      'gen-l10n',
+    ], workingDirectory: l10nDir);
+    await processRunner.runCommand([
+      'dart',
+      'format',
+      '.',
+    ], workingDirectory: l10nDir);
+  }
+}

--- a/tools/sz_repo_cli/lib/src/main.dart
+++ b/tools/sz_repo_cli/lib/src/main.dart
@@ -32,6 +32,7 @@ import 'package:sz_repo_cli/src/commands/src/deploy_console_command.dart';
 import 'package:sz_repo_cli/src/commands/src/deploy_website_command.dart';
 import 'package:sz_repo_cli/src/commands/src/format_command.dart';
 import 'package:sz_repo_cli/src/commands/src/license_headers_command.dart';
+import 'package:sz_repo_cli/src/commands/src/l10n_command.dart';
 
 import 'commands/commands.dart';
 import 'common/common.dart';
@@ -60,6 +61,7 @@ Future<void> main(List<String> args) async {
         ..addCommand(AnalyzeCommand(context))
         ..addCommand(TestCommand(context))
         ..addCommand(FormatCommand(context))
+        ..addCommand(L10nCommand(context))
         ..addCommand(ExecCommand(context))
         ..addCommand(DoStuffCommand(context))
         ..addCommand(FixCommentSpacingCommand(context))


### PR DESCRIPTION
## Summary
- add `sz l10n` command to generate and format localization files
- wire command into CLI

## Testing
- `dart format tools/sz_repo_cli/lib/src/commands/src/l10n_command.dart tools/sz_repo_cli/lib/src/main.dart tools/sz_repo_cli/lib/src/commands/commands.dart`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68be3566c0e88322858595362de19aaa