### PR TITLE
Remove emojis from changelog when running `sz deploy ios/macos`

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -502,6 +502,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  emoji_regex:
+    dependency: transitive
+    description:
+      name: emoji_regex
+      sha256: "3a25dd4d16f98b6f76dc37cc9ae49b8511891ac4b87beac9443a1e9f4634b6c7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.5"
   encrypt:
     dependency: transitive
     description:

--- a/tools/sz_repo_cli/lib/src/common/src/app_store_connect_utils.dart
+++ b/tools/sz_repo_cli/lib/src/common/src/app_store_connect_utils.dart
@@ -15,6 +15,7 @@ import 'package:sz_repo_cli/src/common/src/process_runner_utils.dart';
 import 'package:sz_repo_cli/src/common/src/apple_track.dart';
 import 'package:sz_repo_cli/src/common/src/sharezone_repo.dart';
 import 'package:sz_repo_cli/src/common/src/throw_if_command_is_not_installed.dart';
+import 'package:emoji_regex/emoji_regex.dart';
 
 const certificateKeyOptionName = 'certificate-key';
 const privateKeyOptionName = 'private-key';
@@ -168,6 +169,7 @@ Future<void> publishToAppStoreConnect(
   String? whatsNew,
 }) async {
   final track = _getAppleTrack(stage: stage, stageToTracks: stageToTracks);
+  final sanitizedWhatsNew = whatsNew == null ? null : _removeEmojis(whatsNew);
 
   await processRunner.run([
     'app-store-connect',
@@ -178,7 +180,7 @@ Future<void> publishToAppStoreConnect(
     // The app version will be automatically released right after it has
     // been approved by App Review.
     'AFTER_APPROVAL',
-    if (whatsNew != null) ...['--whats-new', whatsNew],
+    if (sanitizedWhatsNew != null) ...['--whats-new', sanitizedWhatsNew],
     if (track is AppStoreTrack) ...['--app-store'],
     if (track is TestFlightTrack) ...[
       '--beta-group',
@@ -221,6 +223,13 @@ AppleTrack _getAppleTrack({
     throw Exception('Unknown track for stage: $stage');
   }
   return track;
+}
+
+/// Removes emojis from changelog because Apple does not allow them.
+///
+/// For more details: https://github.com/SharezoneApp/sharezone-app/issues/399.
+String _removeEmojis(String input) {
+  return input.replaceAll(emojiRegex(), '');
 }
 
 Future<void> throwIfCodemagicCliToolsAreNotInstalled(

--- a/tools/sz_repo_cli/pubspec.yaml
+++ b/tools/sz_repo_cli/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   process_runner: ^4.2.0
   file: ^7.0.1
   clock: ^1.1.2
+  emoji_regex: ^0.0.5
 
 dev_dependencies:
   sharezone_lints:


### PR DESCRIPTION
Apple does not allow emojis in the changelog.

Closes #399