### PR TITLE
Fix multiple join tries when using join links

### DIFF
--- a/app/lib/dynamic_links/dynamic_link_bloc.dart
+++ b/app/lib/dynamic_links/dynamic_link_bloc.dart
@@ -27,8 +27,6 @@ class DynamicLinkBloc extends BlocBase {
   /// can't be called in the constructor, because otherwise the dynamic link
   /// wouldn't work on ios at a cold start of the app.
   Future<void> initialisere() async {
-    final initData = await appLinks.getInitialLink();
-    _konvertiereZuEingehendemLink(initData, isInitialLink: true);
     appLinks.uriLinkStream.listen(
       (incommingLink) async => _konvertiereZuEingehendemLink(incommingLink),
       onError: (e) async {

--- a/app/lib/main/course_join_listener.dart
+++ b/app/lib/main/course_join_listener.dart
@@ -99,15 +99,15 @@ class _CourseJoinListenerState extends State<CourseJoinListener> {
   }
 
   void onBeitrittsStreamError(dynamic error) {
-    if (error is KursBereitsBeigetretenException) {
-      Future.delayed(const Duration(microseconds: 200)).then((_) {
+    Future.delayed(const Duration(microseconds: 200)).then((_) {
+      if (error is KursBereitsBeigetretenException) {
         showErrorNotification("Du bist der Gruppe bereits beigetreten");
-      });
-    } else {
-      showErrorNotification(
-        "Ein Fehler ist aufgetreten: $error. Bitte kontaktiere den Support.",
-      );
-    }
+      } else {
+        showErrorNotification(
+          "Ein Fehler ist aufgetreten: $error. Bitte kontaktiere den Support.",
+        );
+      }
+    });
   }
 
   @override

--- a/app/lib/main/course_join_listener.dart
+++ b/app/lib/main/course_join_listener.dart
@@ -6,6 +6,8 @@
 //
 // SPDX-License-Identifier: EUPL-1.2
 
+import 'dart:async';
+
 import 'package:common_domain_models/common_domain_models.dart';
 import 'package:flutter/material.dart';
 import 'package:group_domain_models/group_domain_models.dart' hide Sharecode;
@@ -16,88 +18,118 @@ import 'package:sharezone/groups/group_join/bloc/group_join_function.dart';
 import 'package:sharezone/groups/group_join/models/group_join_result.dart';
 import 'package:sharezone_widgets/sharezone_widgets.dart';
 
-class CourseJoinListener extends StatelessWidget {
+class CourseJoinListener extends StatefulWidget {
   final Stream<Beitrittsversuch?> beitrittsversuche;
-  final Widget? child;
+  final Widget child;
   final GroupJoinFunction groupJoinFunction;
 
   const CourseJoinListener({
     super.key,
     required this.beitrittsversuche,
     required this.groupJoinFunction,
-    this.child,
+    required this.child,
   });
 
   @override
-  Widget build(BuildContext context) {
-    return StreamBuilder<Beitrittsversuch?>(
-      stream: beitrittsversuche,
-      builder: (context, snapshot) {
-        if (snapshot.hasError) {
-          if (snapshot.error is KursBereitsBeigetretenException) {
-            Future.delayed(const Duration(microseconds: 200)).then((_) {
-              showSimpleNotification(
-                const Text('Du bist der Gruppe bereits beigetreten!'),
-                autoDismiss: true,
-                slideDismissDirection: DismissDirection.horizontal,
-                trailing: const Icon(Icons.error_outline, color: Colors.red),
-                leading: const Icon(Icons.link),
-              );
-            });
-          }
-        }
-        if (snapshot.hasData) {
-          final sharecode = snapshot.data!.sharecode;
-          _joinGroup(sharecode);
-        }
-        return child!;
-      },
+  State<CourseJoinListener> createState() => _CourseJoinListenerState();
+}
+
+class _CourseJoinListenerState extends State<CourseJoinListener> {
+  StreamSubscription<Beitrittsversuch?>? _beitrittsversucheSubscription;
+
+  void showLinkNotification(String message, {Widget? trailing}) {
+    showSimpleNotification(
+      Text(message),
+      autoDismiss: true,
+      slideDismissDirection: DismissDirection.horizontal,
+      trailing: trailing,
+      leading: const Icon(Icons.link),
+      duration: const Duration(seconds: 5),
     );
   }
 
-  Future<void> _joinGroup(Sharecode sharecode) async {
-    Future.delayed(const Duration(microseconds: 200)).then((_) {
-      showSimpleNotification(
-        Text("$sharecode beitreten..."),
-        autoDismiss: true,
-        slideDismissDirection: DismissDirection.horizontal,
-        trailing: const SizedBox(
-          height: 25,
-          width: 25,
-          child: AccentColorCircularProgressIndicator(),
-        ),
-        leading: const Icon(Icons.link),
+  void showErrorNotification(String message) {
+    showLinkNotification(
+      message,
+      trailing: const Icon(Icons.error_outline, color: Colors.red),
+    );
+  }
+
+  void showLoadingNotification(String message) {
+    showLinkNotification(
+      message,
+      trailing: const SizedBox(
+        height: 25,
+        width: 25,
+        child: AccentColorCircularProgressIndicator(),
+      ),
+    );
+  }
+
+  void showSuccessNotification(String message) {
+    showLinkNotification(
+      message,
+      trailing: const Icon(Icons.check, color: Colors.lightGreen),
+    );
+  }
+
+  Future<void> joinGroup(Sharecode sharecode) async {
+    Future.delayed(const Duration(microseconds: 200)).then((_) async {
+      showLoadingNotification("$sharecode beitreten...");
+      final result = await widget.groupJoinFunction.runGroupJoinFunction(
+        enteredValue: '$sharecode',
+        version: 1,
       );
-      groupJoinFunction
-          .runGroupJoinFunction(enteredValue: '$sharecode', version: 1)
-          .then((groupJoinResult) {
-            if (groupJoinResult is SuccessfulJoinResult) {
-              final groupInfo = groupJoinResult.groupInfo;
-              final groupname = groupInfo.name;
-              showSimpleNotification(
-                Text(
-                  groupInfo.groupType == GroupType.course
-                      ? 'Du bist dem Kurs "${groupname ?? "???"}" beigetreten'
-                      : 'Du bist der Klasse "${groupname ?? "???"}" beigetreten',
-                ),
-                autoDismiss: true,
-                slideDismissDirection: DismissDirection.horizontal,
-                trailing: const Icon(Icons.check, color: Colors.lightGreen),
-                leading: const Icon(Icons.link),
-              );
-            } else if (groupJoinResult is ErrorJoinResult) {
-              showSimpleNotification(
-                const Text(
-                  'Ein Fehler ist beim Beitreten aufgetreten! Versuche es erneut oder schreibe den Support an.',
-                ),
-                autoDismiss: true,
-                slideDismissDirection: DismissDirection.horizontal,
-                trailing: const Icon(Icons.error, color: Colors.red),
-                leading: const Icon(Icons.link),
-                duration: const Duration(seconds: 3),
-              );
-            }
-          });
+      if (result is SuccessfulJoinResult) {
+        final groupInfo = result.groupInfo;
+        final groupName = groupInfo.name;
+        final message = switch (groupInfo.groupType) {
+          GroupType.course =>
+            'Du bist dem Kurs "${groupName ?? "???"}" beigetreten',
+          GroupType.schoolclass =>
+            'Du bist der Klasse "${groupName ?? "???"}" beigetreten',
+        };
+        showSuccessNotification(message);
+      } else if (result is ErrorJoinResult) {
+        showErrorNotification(
+          'Ein Fehler ist beim Beitreten aufgetreten! Versuche es erneut oder schreibe den Support an.',
+        );
+      }
     });
+  }
+
+  void onBeitrittsStreamError(dynamic error) {
+    if (error is KursBereitsBeigetretenException) {
+      Future.delayed(const Duration(microseconds: 200)).then((_) {
+        showErrorNotification("Du bist der Gruppe bereits beigetreten");
+      });
+    } else {
+      showErrorNotification(
+        "Ein Fehler ist aufgetreten: $error. Bitte kontaktiere den Support.",
+      );
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _beitrittsversucheSubscription = widget.beitrittsversuche.listen((
+      beitrittsversuch,
+    ) {
+      if (beitrittsversuch == null) return;
+      final sharecode = beitrittsversuch.sharecode;
+      joinGroup(sharecode);
+    }, onError: onBeitrittsStreamError);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.child;
+  }
+
+  @override
+  void dispose() {
+    _beitrittsversucheSubscription?.cancel();
+    super.dispose();
   }
 }


### PR DESCRIPTION
The problem was:
* the `CourseJoinListener`. We called the `joinGroup` function inside the `build` method. This function was then called multiple times by Flutter.
* `final initData = await appLinks.getInitialLink();` -> this triggers as second join try

I refactored `app/lib/main/course_join_listener.dart` and tried to make it more readable.