### PR TITLE
Fix broken join group QR codes

### DIFF
--- a/app/lib/groups/src/widgets/group_qr_code.dart
+++ b/app/lib/groups/src/widgets/group_qr_code.dart
@@ -23,7 +23,10 @@ class GroupQrCode extends StatelessWidget {
     return QrImageView(
       backgroundColor: Colors.white,
       data: groupInfo.joinLink ?? groupInfo.sharecode ?? "",
-      version: 3,
+      // See https://www.qrcode.com/en/about/version.html for more information
+      // about QR code versions.
+      version: 5, // 37x37 modules
+      errorCorrectionLevel: QrErrorCorrectLevel.M, // ~15% error correction
     );
   }
 }


### PR DESCRIPTION
https://github.com/SharezoneApp/sharezone-app/pull/1914 changed the length of a `joinLink`. The QR code with the correction level L only supports max input 440 bits. However, our new join links are longer than 440 bits. Therefore, we needed to increase the version of the displayed QR Code.

Closes #1930