### PR TITLE
Upgrade Kotlin version to 2.1.0

### DIFF
--- a/app/android/settings.gradle
+++ b/app/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version '8.3.0' apply false
-    id "org.jetbrains.kotlin.android" version "1.9.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
     id "com.google.gms.google-services" version "4.4.0" apply false
     id "com.google.firebase.crashlytics" version "2.9.9" apply false
     id "com.google.firebase.firebase-perf" version "1.4.2" apply false

--- a/lib/qr_code_scanner/example/android/build.gradle
+++ b/lib/qr_code_scanner/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '2.1.0'
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
From Flutter build:

> Warning: Flutter support for your project's Kotlin version (1.9.0) will soon be dropped. Please upgrade your Kotlin version to a version of at least 2.1.0 soon.