### PR TITLE
Upgrading Android Gradle Plugin to 8.6.0

### DIFF
--- a/app/android/settings.gradle
+++ b/app/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version '8.3.0' apply false
+    id "com.android.application" version '8.6.0' apply false
     id "org.jetbrains.kotlin.android" version "2.1.0" apply false
     id "com.google.gms.google-services" version "4.4.0" apply false
     id "com.google.firebase.crashlytics" version "2.9.9" apply false


### PR DESCRIPTION
From Flutter build:

> Warning: Flutter support for your project's Android Gradle Plugin version (Android Gradle Plugin version 8.3.0) will soon be dropped. Please upgrade your Android Gradle Plugin version to a version of at least Android Gradle Plugin version 8.6.0 soon.