### PR TITLE
Expose the error message for `qr_code_scanner` as parameter

### DIFF
--- a/lib/qr_code_scanner/lib/src/scanner.dart
+++ b/lib/qr_code_scanner/lib/src/scanner.dart
@@ -126,7 +126,7 @@ class _Error extends StatelessWidget {
         ConstrainedBox(
           constraints: const BoxConstraints(maxWidth: 220),
           child: Text(
-            '$couldNotStartQrScannerMessage\n\n${exception.errorDetails?.message} (${exception.errorDetails?.message}, ${exception.errorCode})',
+            '$couldNotStartQrScannerMessage\n\n${exception.errorDetails?.message} (${exception.errorCode})',
             style: TextStyle(
               color: Theme.of(context).colorScheme.error,
               fontSize: 12,


### PR DESCRIPTION
Closes #2094 