### PR TITLE
Add blackboard picture utils, gated upload flow, localization and unit tests

### DIFF
--- a/app/lib/blackboard/blackboard_card.dart
+++ b/app/lib/blackboard/blackboard_card.dart
@@ -13,6 +13,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:sharezone/blackboard/blocs/blackboard_card_bloc.dart';
 import 'package:sharezone/blackboard/details/blackboard_details.dart';
+import 'package:sharezone/blackboard/blackboard_picture_utils.dart';
 import 'package:sharezone/main/application_bloc.dart';
 import 'package:helper_functions/helper_functions.dart';
 import 'package:sharezone_utils/launch_link.dart';
@@ -283,7 +284,7 @@ class _Picture extends StatelessWidget {
         decoration: BoxDecoration(
           image: DecorationImage(
             fit: BoxFit.cover,
-            image: AssetImage(view.pictureURL!),
+            image: getBlackboardPictureProvider(view.pictureURL!),
           ),
         ),
       ),

--- a/app/lib/blackboard/blackboard_dialog.dart
+++ b/app/lib/blackboard/blackboard_dialog.dart
@@ -16,6 +16,7 @@ import 'package:sharezone/blackboard/blackboard_card.dart';
 import 'package:sharezone/blackboard/blackboard_item.dart';
 import 'package:sharezone/blackboard/blackboard_page.dart';
 import 'package:sharezone/blackboard/blackboard_picture.dart';
+import 'package:sharezone/blackboard/blackboard_picture_utils.dart';
 import 'package:sharezone/blackboard/blocs/blackboard_dialog_bloc.dart';
 import 'package:sharezone/filesharing/dialog/attach_file.dart';
 import 'package:sharezone/filesharing/dialog/course_tile.dart';
@@ -409,8 +410,13 @@ class _CourseTile extends StatelessWidget {
 
 class _PictureTile extends StatelessWidget {
   Future<void> onTap(BuildContext context, BlackboardDialogBloc bloc) async {
+    final courseId = bloc.currentCourse?.id;
     final path =
-        await Navigator.pushNamed(context, BlackboardDialogChoosePicture.tag)
+        await Navigator.pushNamed(
+          context,
+          BlackboardDialogChoosePicture.tag,
+          arguments: BlackboardDialogChoosePictureArgs(courseId: courseId),
+        )
             as String?;
     if (path != null) bloc.changePictureURL(path);
   }
@@ -449,8 +455,8 @@ class _PictureTile extends StatelessWidget {
               builder: (context, snapshot) {
                 if (!hasData) return const Text("Titelbild auswählen");
                 return InkWell(
-                  child: Image.asset(
-                    snapshot.data!,
+                  child: Image(
+                    image: getBlackboardPictureProvider(snapshot.data!),
                     height: 120,
                     fit: BoxFit.cover,
                   ),

--- a/app/lib/blackboard/blackboard_picture_utils.dart
+++ b/app/lib/blackboard/blackboard_picture_utils.dart
@@ -1,0 +1,22 @@
+// Copyright (c) 2024 Sharezone UG (haftungsbeschränkt)
+// Licensed under the EUPL-1.2-or-later.
+//
+// You may obtain a copy of the Licence at:
+// https://joinup.ec.europa.eu/software/page/eupl
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+import 'package:flutter/material.dart';
+
+bool isRemoteBlackboardPicture(String? pictureUrl) {
+  if (pictureUrl == null) return false;
+  return pictureUrl.startsWith('http://') ||
+      pictureUrl.startsWith('https://');
+}
+
+ImageProvider getBlackboardPictureProvider(String pictureUrl) {
+  if (isRemoteBlackboardPicture(pictureUrl)) {
+    return NetworkImage(pictureUrl);
+  }
+  return AssetImage(pictureUrl);
+}

--- a/app/lib/blackboard/blocs/blackboard_dialog_bloc.dart
+++ b/app/lib/blackboard/blocs/blackboard_dialog_bloc.dart
@@ -72,6 +72,7 @@ class BlackboardDialogBloc extends BlocBase with BlackboardValidators {
   Stream<List<LocalFile>> get localFiles => _localFilesSubject;
   Stream<List<CloudFile>> get cloudFiles => _cloudFilesSubject;
   Stream<bool> get sendNotification => _sendNotificationSubject;
+  Course? get currentCourse => _courseSegmentSubject.valueOrNull;
 
   Function(String) get changeTitle => _titleSubject.sink.add;
   Function(Course) get changeCourseSegment => _courseSegmentSubject.sink.add;

--- a/app/lib/blackboard/details/blackboard_details.dart
+++ b/app/lib/blackboard/details/blackboard_details.dart
@@ -12,6 +12,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:sharezone/blackboard/blackboard_dialog.dart';
 import 'package:sharezone/blackboard/blackboard_item.dart';
+import 'package:sharezone/blackboard/blackboard_picture_utils.dart';
 import 'package:sharezone/blackboard/blackboard_view.dart';
 import 'package:sharezone/blackboard/details/blackboard_item_read_by_users_list/blackboard_item_read_by_users_list_page.dart';
 import 'package:sharezone/comments/comments_gateway.dart';
@@ -177,8 +178,8 @@ class _PageWithPicture extends StatelessWidget {
           flexibleSpace: FlexibleSpaceBar(
             background: Hero(
               tag: view.id,
-              child: Image.asset(
-                view.pictureURL!,
+              child: Image(
+                image: getBlackboardPictureProvider(view.pictureURL!),
                 fit: BoxFit.cover,
                 height: _appBarHeight,
               ),

--- a/app/lib/main/sharezone_app.dart
+++ b/app/lib/main/sharezone_app.dart
@@ -194,8 +194,14 @@ class _SharezoneAppState extends State<SharezoneApp>
                     (context) =>
                         const UseAccountOnMultipleDevicesInstructions(),
                 MyProfilePage.tag: (context) => const MyProfilePage(),
-                BlackboardDialogChoosePicture.tag:
-                    (context) => const BlackboardDialogChoosePicture(),
+                BlackboardDialogChoosePicture.tag: (context) {
+                  final args =
+                      ModalRoute.of(context)?.settings.arguments
+                          as BlackboardDialogChoosePictureArgs?;
+                  return BlackboardDialogChoosePicture(
+                    courseId: args?.courseId,
+                  );
+                },
                 TimetableAddPage.tag: (context) => const TimetableAddPage(),
                 WebAppSettingsPage.tag: (context) => const WebAppSettingsPage(),
                 ImprintPage.tag: (context) => const ImprintPage(),

--- a/app/lib/sharezone_plus/subscription_service/subscription_service.dart
+++ b/app/lib/sharezone_plus/subscription_service/subscription_service.dart
@@ -110,6 +110,7 @@ enum SharezonePlusFeature {
   iCalLinks,
   substitutions,
   addTeachersToTimetable,
+  infoSheetTitleImageUpload,
 }
 
 void trySetSharezonePlusAnalyticsUserProperties(

--- a/app/test/blackboard/blackboard_picture_utils_test.dart
+++ b/app/test/blackboard/blackboard_picture_utils_test.dart
@@ -1,0 +1,36 @@
+// Copyright (c) 2024 Sharezone UG (haftungsbeschränkt)
+// Licensed under the EUPL-1.2-or-later.
+//
+// You may obtain a copy of the Licence at:
+// https://joinup.ec.europa.eu/software/page/eupl
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sharezone/blackboard/blackboard_picture_utils.dart';
+
+void main() {
+  group('blackboard_picture_utils', () {
+    test('isRemoteBlackboardPicture detects remote URLs', () {
+      expect(isRemoteBlackboardPicture(null), isFalse);
+      expect(isRemoteBlackboardPicture('assets/wallpaper/foo.png'), isFalse);
+      expect(isRemoteBlackboardPicture('http://example.com/foo.png'), isTrue);
+      expect(isRemoteBlackboardPicture('https://example.com/foo.png'), isTrue);
+    });
+
+    test('getBlackboardPictureProvider returns matching provider', () {
+      final assetProvider = getBlackboardPictureProvider(
+        'assets/wallpaper/foo.png',
+      );
+      expect(assetProvider, isA<AssetImage>());
+      expect((assetProvider as AssetImage).assetName, 'assets/wallpaper/foo.png');
+
+      final networkProvider = getBlackboardPictureProvider(
+        'https://example.com/foo.png',
+      );
+      expect(networkProvider, isA<NetworkImage>());
+      expect((networkProvider as NetworkImage).url, 'https://example.com/foo.png');
+    });
+  });
+}

--- a/lib/sharezone_localizations/l10n/app_de.arb
+++ b/lib/sharezone_localizations/l10n/app_de.arb
@@ -1037,6 +1037,26 @@
   "websiteWelcomeDescriptionSemanticLabel": "Beschreibung der Sharezone App",
   "websiteWelcomeHeadline": "Simpel. Sicher. Stabil.",
   "websiteWelcomeHeadlineSemanticLabel": "Überschrift der Sharezone App",
+  "blackboardTitleImagePlusDialogTitle": "Eigenes Titelbild",
+  "@blackboardTitleImagePlusDialogTitle": {
+    "description": "Title for the Sharezone Plus dialog that explains the title image upload for information sheets."
+  },
+  "blackboardTitleImagePlusDialogDescription": "Mit Sharezone Plus kannst du eigene Bilder als Titelbild für Infozettel hochladen.",
+  "@blackboardTitleImagePlusDialogDescription": {
+    "description": "Description for the Sharezone Plus dialog that explains the title image upload for information sheets."
+  },
+  "blackboardTitleImageSelectCourseFirst": "Bitte wähle zuerst einen Kurs aus, bevor du ein Titelbild hochlädst.",
+  "@blackboardTitleImageSelectCourseFirst": {
+    "description": "Message shown when a user tries to upload a title image without selecting a course."
+  },
+  "blackboardTitleImageUploading": "Titelbild wird hochgeladen...",
+  "@blackboardTitleImageUploading": {
+    "description": "Loading text shown while the title image is uploading."
+  },
+  "blackboardTitleImageUploadFailed": "Titelbild konnte nicht hochgeladen werden. Bitte versuche es erneut.",
+  "@blackboardTitleImageUploadFailed": {
+    "description": "Error message shown when the title image upload fails."
+  },
   "writePermissionEveryone": "Alle",
   "writePermissionOnlyAdmins": "Nur Admins"
 }

--- a/lib/sharezone_localizations/l10n/app_en.arb
+++ b/lib/sharezone_localizations/l10n/app_en.arb
@@ -570,6 +570,11 @@
   "websiteWelcomeDescriptionSemanticLabel": "Description of the Sharezone app",
   "websiteWelcomeHeadline": "Simple. Secure. Stable.",
   "websiteWelcomeHeadlineSemanticLabel": "Headline of the Sharezone app",
+  "blackboardTitleImagePlusDialogTitle": "Custom title image",
+  "blackboardTitleImagePlusDialogDescription": "With Sharezone Plus you can upload your own images as title images for information sheets.",
+  "blackboardTitleImageSelectCourseFirst": "Please select a course before uploading a title image.",
+  "blackboardTitleImageUploading": "Uploading title image...",
+  "blackboardTitleImageUploadFailed": "The title image could not be uploaded. Please try again.",
   "writePermissionEveryone": "Everyone",
   "writePermissionOnlyAdmins": "Only admins"
 }

--- a/lib/sharezone_localizations/lib/localizations/sharezone_localizations.gen.dart
+++ b/lib/sharezone_localizations/lib/localizations/sharezone_localizations.gen.dart
@@ -3348,6 +3348,36 @@ abstract class SharezoneLocalizations {
   /// **'Überschrift der Sharezone App'**
   String get websiteWelcomeHeadlineSemanticLabel;
 
+  /// Title for the Sharezone Plus dialog that explains the title image upload for information sheets.
+  ///
+  /// In de, this message translates to:
+  /// **'Eigenes Titelbild'**
+  String get blackboardTitleImagePlusDialogTitle;
+
+  /// Description for the Sharezone Plus dialog that explains the title image upload for information sheets.
+  ///
+  /// In de, this message translates to:
+  /// **'Mit Sharezone Plus kannst du eigene Bilder als Titelbild für Infozettel hochladen.'**
+  String get blackboardTitleImagePlusDialogDescription;
+
+  /// Message shown when a user tries to upload a title image without selecting a course.
+  ///
+  /// In de, this message translates to:
+  /// **'Bitte wähle zuerst einen Kurs aus, bevor du ein Titelbild hochlädst.'**
+  String get blackboardTitleImageSelectCourseFirst;
+
+  /// Loading text shown while the title image is uploading.
+  ///
+  /// In de, this message translates to:
+  /// **'Titelbild wird hochgeladen...'**
+  String get blackboardTitleImageUploading;
+
+  /// Error message shown when the title image upload fails.
+  ///
+  /// In de, this message translates to:
+  /// **'Titelbild konnte nicht hochgeladen werden. Bitte versuche es erneut.'**
+  String get blackboardTitleImageUploadFailed;
+
   /// No description provided for @writePermissionEveryone.
   ///
   /// In de, this message translates to:

--- a/lib/sharezone_localizations/lib/localizations/sharezone_localizations_de.gen.dart
+++ b/lib/sharezone_localizations/lib/localizations/sharezone_localizations_de.gen.dart
@@ -1897,6 +1897,24 @@ class SharezoneLocalizationsDe extends SharezoneLocalizations {
       'Überschrift der Sharezone App';
 
   @override
+  String get blackboardTitleImagePlusDialogTitle => 'Eigenes Titelbild';
+
+  @override
+  String get blackboardTitleImagePlusDialogDescription =>
+      'Mit Sharezone Plus kannst du eigene Bilder als Titelbild für Infozettel hochladen.';
+
+  @override
+  String get blackboardTitleImageSelectCourseFirst =>
+      'Bitte wähle zuerst einen Kurs aus, bevor du ein Titelbild hochlädst.';
+
+  @override
+  String get blackboardTitleImageUploading => 'Titelbild wird hochgeladen...';
+
+  @override
+  String get blackboardTitleImageUploadFailed =>
+      'Titelbild konnte nicht hochgeladen werden. Bitte versuche es erneut.';
+
+  @override
   String get writePermissionEveryone => 'Alle';
 
   @override

--- a/lib/sharezone_localizations/lib/localizations/sharezone_localizations_en.gen.dart
+++ b/lib/sharezone_localizations/lib/localizations/sharezone_localizations_en.gen.dart
@@ -1879,6 +1879,24 @@ class SharezoneLocalizationsEn extends SharezoneLocalizations {
       'Headline of the Sharezone app';
 
   @override
+  String get blackboardTitleImagePlusDialogTitle => 'Custom title image';
+
+  @override
+  String get blackboardTitleImagePlusDialogDescription =>
+      'With Sharezone Plus you can upload your own images as title images for information sheets.';
+
+  @override
+  String get blackboardTitleImageSelectCourseFirst =>
+      'Please select a course before uploading a title image.';
+
+  @override
+  String get blackboardTitleImageUploading => 'Uploading title image...';
+
+  @override
+  String get blackboardTitleImageUploadFailed =>
+      'The title image could not be uploaded. Please try again.';
+
+  @override
   String get writePermissionEveryone => 'Everyone';
 
   @override


### PR DESCRIPTION
### Motivation
- Allow users to upload custom title images for info sheets and reuse the existing course `attachments` infrastructure so uploads count against course storage and are cleaned up by course delete logic.
- Render title images from both local assets and remote URLs to unify image handling across blackboard views.
- Gate the upload flow behind Sharezone Plus and show a helpful dialog when the feature is locked.

### Description
- Added `app/lib/blackboard/blackboard_picture_utils.dart` with `isRemoteBlackboardPicture` and `getBlackboardPictureProvider` and replaced `Image.asset` usages with `Image(image: getBlackboardPictureProvider(...))` in dialog, card and details views.
- Implemented a picture chooser and upload flow in `app/lib/blackboard/blackboard_picture.dart` that accepts camera/gallery images via `FilePicker`, checks `SubscriptionService` for the `SharezonePlusFeature.infoSheetTitleImageUpload` flag, shows upload progress, uploads to `fileUploader` into the `attachments` folder, and returns the uploaded file URL.
- Added `BlackboardDialogChoosePictureArgs` and passed `courseId` through the dialog route, exposed `currentCourse` getter on `BlackboardDialogBloc`, and registered a route handler in `sharezone_app.dart` that reads the arguments.
- Added the `infoSheetTitleImageUpload` enum value to `SubscriptionService`, localized strings in `lib/sharezone_localizations/l10n` and updated generated localization files to support the new dialogs/messages.
- Added unit tests `app/test/blackboard/blackboard_picture_utils_test.dart` to validate remote detection and provider selection for blackboard pictures.

### Testing
- Ran `fvm flutter test app/test/blackboard/blackboard_picture_utils_test.dart`, and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69826226981c8322bd6eb21fdbb10217)