### PR TITLE
Add course (school-class) filter to homework lists and tests

### DIFF
--- a/app/lib/homework/student/student_homework_page.dart
+++ b/app/lib/homework/student/student_homework_page.dart
@@ -22,6 +22,7 @@ import 'package:sharezone/navigation/models/navigation_item.dart';
 import 'package:sharezone/navigation/scaffold/app_bar_configuration.dart';
 import 'package:sharezone/navigation/scaffold/bottom_bar_configuration.dart';
 import 'package:sharezone/navigation/scaffold/sharezone_main_scaffold.dart';
+import 'package:sharezone/timetable/timetable_page/school_class_filter/school_class_filter.dart';
 import 'package:sharezone_widgets/sharezone_widgets.dart';
 
 import 'src/completed_homework_list.dart';
@@ -76,6 +77,9 @@ class StudentHomeworkPage extends StatelessWidget {
                 mainAxisSize: MainAxisSize.min,
                 children: [
                   AdBanner(adUnitId: getAdUnitId(context)),
+                  SchoolClassFilterBottomBar(
+                    backgroundColor: bottomBarBackgroundColor,
+                  ),
                   AnimatedTabVisibility(
                     visibleInTabIndicies: const [0],
                     // Else the Sort shown in the button and the current sort

--- a/app/lib/homework/teacher_and_parent/teacher_and_parent_homework_page.dart
+++ b/app/lib/homework/teacher_and_parent/teacher_and_parent_homework_page.dart
@@ -18,6 +18,7 @@ import 'package:sharezone/navigation/models/navigation_item.dart';
 import 'package:sharezone/navigation/scaffold/app_bar_configuration.dart';
 import 'package:sharezone/navigation/scaffold/bottom_bar_configuration.dart';
 import 'package:sharezone/navigation/scaffold/sharezone_main_scaffold.dart';
+import 'package:sharezone/timetable/timetable_page/school_class_filter/school_class_filter.dart';
 import 'package:sharezone_widgets/sharezone_widgets.dart';
 
 import 'src/teacher_and_parent_src.dart';
@@ -52,22 +53,30 @@ class TeacherAndParentHomeworkPage extends StatelessWidget {
             body: const TeacherHomeworkBody(),
             navigationItem: NavigationItem.homework,
             bottomBarConfiguration: BottomBarConfiguration(
-              bottomBar: AnimatedTabVisibility(
-                visibleInTabIndicies: const [0],
-                // Else the Sort shown in the button and the current sort
-                // could get out of order
-                maintainState: true,
-                child: HomeworkBottomActionBar(
-                  currentHomeworkSortStream: bloc.stream
-                      .whereType<Success>()
-                      .map((s) => s.open.sorting),
-                  backgroundColor: bottomBarBackgroundColor,
-                  showOverflowMenu: false,
-                  // Not visible since we don't show the overflow menu
-                  onCompletedAllOverdue: () => throw UnimplementedError(),
-                  onSortingChanged:
-                      (newSort) => bloc.add(OpenHwSortingChanged(newSort)),
-                ),
+              bottomBar: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  SchoolClassFilterBottomBar(
+                    backgroundColor: bottomBarBackgroundColor,
+                  ),
+                  AnimatedTabVisibility(
+                    visibleInTabIndicies: const [0],
+                    // Else the Sort shown in the button and the current sort
+                    // could get out of order
+                    maintainState: true,
+                    child: HomeworkBottomActionBar(
+                      currentHomeworkSortStream: bloc.stream
+                          .whereType<Success>()
+                          .map((s) => s.open.sorting),
+                      backgroundColor: bottomBarBackgroundColor,
+                      showOverflowMenu: false,
+                      // Not visible since we don't show the overflow menu
+                      onCompletedAllOverdue: () => throw UnimplementedError(),
+                      onSortingChanged:
+                          (newSort) => bloc.add(OpenHwSortingChanged(newSort)),
+                    ),
+                  ),
+                ],
               ),
             ),
             floatingActionButton: const BottomOfScrollViewInvisibility(

--- a/lib/hausaufgabenheft_logik/lib/src/shared/setup/dependencies.dart
+++ b/lib/hausaufgabenheft_logik/lib/src/shared/setup/dependencies.dart
@@ -6,6 +6,8 @@
 //
 // SPDX-License-Identifier: EUPL-1.2
 
+import 'package:common_domain_models/common_domain_models.dart';
+import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:hausaufgabenheft_logik/src/shared/homework_page_api.dart';
 import 'package:key_value_store/key_value_store.dart';
 import 'package:sharezone_localizations/sharezone_localizations.dart';
@@ -19,10 +21,15 @@ class HausaufgabenheftDependencies {
 
   final DateTime Function()? getCurrentDateTime;
 
+  /// Optional filter stream for course IDs. If provided and non-empty, homework
+  /// lists will only include items from the given course IDs.
+  final Stream<ISet<CourseId>>? courseFilterStream;
+
   HausaufgabenheftDependencies({
     required this.api,
     required this.keyValueStore,
     required this.localizations,
     this.getCurrentDateTime,
+    this.courseFilterStream,
   });
 }

--- a/lib/hausaufgabenheft_logik/lib/src/student/create_student_homework_page_bloc.dart
+++ b/lib/hausaufgabenheft_logik/lib/src/student/create_student_homework_page_bloc.dart
@@ -44,6 +44,7 @@ StudentHomeworkPageBloc createStudentHomeworkPageBloc(
     openHomeworkListViewFactory: openHomeworkListViewFactory,
     viewFactory: viewFactory,
     homeworkApi: dependencies.api.students,
+    courseFilterStream: dependencies.courseFilterStream,
     numberOfInitialCompletedHomeworksToLoad:
         config.nrOfInitialCompletedHomeworksToLoad,
     homeworkSortingCache: HomeworkSortingCache(dependencies.keyValueStore),

--- a/lib/hausaufgabenheft_logik/lib/src/teacher_and_parent/create_teacher_and_parent_homework_page_bloc.dart
+++ b/lib/hausaufgabenheft_logik/lib/src/teacher_and_parent/create_teacher_and_parent_homework_page_bloc.dart
@@ -43,6 +43,7 @@ TeacherAndParentHomeworkPageBloc createTeacherAndParentHomeworkPageBloc(
     openHomeworkListViewFactory: openHomeworkListViewFactory,
     viewFactory: viewFactory,
     homeworkApi: dependencies.api.teachersAndParents,
+    courseFilterStream: dependencies.courseFilterStream,
     numberOfInitialCompletedHomeworksToLoad:
         config.nrOfInitialCompletedHomeworksToLoad,
     homeworkSortingCache: HomeworkSortingCache(dependencies.keyValueStore),

--- a/lib/hausaufgabenheft_logik/test/create_homework_util.dart
+++ b/lib/hausaufgabenheft_logik/test/create_homework_util.dart
@@ -19,13 +19,14 @@ StudentHomeworkReadModel createHomework({
   String id = 'willBeRandom',
   bool done = false,
   bool withSubmissions = false,
+  CourseId courseId = const CourseId('testCourseId'),
   Color? subjectColor,
   String abbreviation = 'Abb',
 }) {
   id = id == 'willBeRandom' ? randomAlphaNumeric(5) : id;
   return StudentHomeworkReadModel(
     id: HomeworkId(id),
-    courseId: const CourseId('testCourseId'),
+    courseId: courseId,
     todoDate: todoDate.asDateTime(),
     subject: Subject(subject, color: subjectColor, abbreviation: abbreviation),
     title: Title(title),


### PR DESCRIPTION
### Motivation
- Parents and teachers need the ability to scope homework lists to a selected school class (mapped to course IDs) so each child/class view shows only relevant assignments. 
- Reuse the existing timetable school-class selection instead of introducing complex account/child switching flows. 
- Add automated tests to verify course-based filtering for both student and teacher/homework flows.

### Description
- Plumb an optional `courseFilterStream` through `HausaufgabenheftDependencies` and pass it into the student and teacher/homework page bloc factories so homework logic can receive an external `Stream<ISet<CourseId>>`.
- Create `homeworkCourseFilterStream` in `sharezone_bloc_providers.dart` by observing `TimetableBloc.schoolClassFilterView`, mapping the selected class to its `CourseId`s via `SchoolClassGateway`, converting to an `ISet<CourseId>` and `shareReplay`-ing the result.
- Wire the course filter into `StudentHomeworkPageBloc` and `TeacherAndParentHomeworkPageBloc` by extending their combine-latest streams to include the course filter and applying `_filterByCourse(...)` to open/completed/archived lists before view factories are created.
- Surface the `SchoolClassFilterBottomBar` in the bottom bar of both `StudentHomeworkPage` and `TeacherAndParentHomeworkPage` so users can pick a class from the UI and affect homework lists.
- Test helper updates: extended `createHomework` to accept a `CourseId` and added `createTeacherHomework` for teacher/homework tests.

### Testing
- Added tests `Filters open and completed homeworks by course` (student) and `Filters open and archived homeworks by course` (teacher) in `lib/hausaufgabenheft_logik/test/homework_page_bloc_test.dart` which exercise dynamic filtering and unfiltering via a `BehaviorSubject<ISet<CourseId>>`.
- Ran `fvm flutter test lib/hausaufgabenheft_logik/test/homework_page_bloc_test.dart` and the test run completed successfully (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698262995fd0832282637402f4f0dc05)