### PR TITLE
Speed up `sz license-headers` command

### DIFF
--- a/bin/add_license_headers.sh
+++ b/bin/add_license_headers.sh
@@ -7,10 +7,10 @@
 #
 # SPDX-License-Identifier: EUPL-1.2
 
-root_dir=$(git rev-parse --show-toplevel)
-
 script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 get_cmd="$script_dir/source_of_truth/get_sot_cmd.sh"
 
 add_license_headers=$($get_cmd add_license_headers)
-eval $"($add_license_headers $root_dir)"
+# We use "git ls-files" and "xargs" to speed up the command, see
+# https://github.com/google/addlicense/issues/32#issuecomment-3855110707.
+eval $"(git ls-files -z | xargs -0 -n 200 $add_license_headers)"

--- a/bin/check_license_headers.sh
+++ b/bin/check_license_headers.sh
@@ -7,10 +7,10 @@
 #
 # SPDX-License-Identifier: EUPL-1.2
 
-root_dir=$(git rev-parse --show-toplevel)
-
 script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 get_cmd="$script_dir/source_of_truth/get_sot_cmd.sh"
 
 check_license_headers=$($get_cmd check_license_headers)
-eval $"($check_license_headers $root_dir)"
+# We use "git ls-files" and "xargs" to speed up the command, see
+# https://github.com/google/addlicense/issues/32#issuecomment-3855110707.
+eval $"(git ls-files -z | xargs -0 -n 200 $check_license_headers)"

--- a/tools/sz_repo_cli/lib/src/commands/src/check_license_headers_command.dart
+++ b/tools/sz_repo_cli/lib/src/commands/src/check_license_headers_command.dart
@@ -52,6 +52,14 @@ Future<ProcessRunnerResult> runLicenseHeaderCommand(
   required String commandKey,
   required SharezoneRepo repo,
 }) {
+  if (Platform.isMacOS || Platform.isLinux) {
+    // Our shell scripts for `addlicense` use some optimizations that are not
+    // available on Windows.
+    return processRunner.run([
+      'bin/$commandKey.sh',
+    ], workingDirectory: repo.location);
+  }
+
   return runSourceOfTruthCommand(
     processRunner,
     commandKey: commandKey,


### PR DESCRIPTION
| Command | Before | After |
| -- | -- | -- |
| `bin/check_license_headers.sh` | 2.96s | 0.27s |
| `bin/add_license_headers.sh` | 2.70s | 0.23s |
| `sz lh check` | 5.19s | 1.51s |
| `sz lh add` | 3.90s | 1.49s |

How is the speed up possible? The `--ignore` flag of `addlicense` first reads every file in our repository and then filters out the ignored files. Directories like `node_modules` and `build` have many files which `addlicense` will all read. With this PR, only Git tracked files are passed to the `addlicense` command.

Uses https://github.com/google/addlicense/issues/32#issuecomment-3855110707.