### PR TITLE
Use bash script for VS Code "Add license header to files" task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -19,6 +19,13 @@
         {
             "label": "Add license header to files",
             "type": "shell",
+            // We don't use the Sharezone Repo CLI (`sz lh add`) because just
+            // using bash commands is way faster.
+            //
+            // Bash script: 0.23s
+            // Sharezone Repo CLI: 1.49s
+            //
+            // See https://github.com/SharezoneApp/sharezone-app/pull/2157
             "command": "bin/add_license_headers.sh",
             "options": {
                 "cwd": "${workspaceFolder}"


### PR DESCRIPTION
Uses the optimization implemented with https://github.com/SharezoneApp/sharezone-app/pull/2157.