### PR TITLE
⚡ Bolt: Optimize passed lesson card rendering

### DIFF
--- a/app/lib/dashboard/timetable/lesson_card.dart
+++ b/app/lib/dashboard/timetable/lesson_card.dart
@@ -100,20 +100,29 @@ class _PassedLessonFade extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Determine the split point for the fade effect.
+    // 1.0 (top) corresponds to percentTimePassed = 0.
+    // 0.0 (bottom) corresponds to percentTimePassed = 1.
+    // So splitPoint = 1 - percentTimePassed.
+    final splitPoint = 1 - (percentTimePassed ?? 0.0);
+
     return AnimatedSwitcher(
       duration: const Duration(milliseconds: 375),
-      child: Stack(
+      child: ShaderMask(
         key: ValueKey("$lessonID;$hasAlreadyTakenPlace"),
-        children: <Widget>[
-          Opacity(opacity: 0.5, child: child),
-          ClipRRect(
-            child: Align(
-              alignment: Alignment.topCenter,
-              heightFactor: 1 - percentTimePassed!,
-              child: child,
-            ),
-          ),
-        ],
+        shaderCallback: (rect) {
+          return LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+            stops: [splitPoint, splitPoint],
+            colors: [
+              Colors.white,
+              Colors.white.withValues(alpha: 0.5),
+            ],
+          ).createShader(rect);
+        },
+        blendMode: BlendMode.modulate,
+        child: child,
       ),
     );
   }

--- a/website/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/website/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -9,6 +9,7 @@ import device_info_plus
 import firebase_analytics
 import firebase_core
 import firebase_crashlytics
+import shared_preferences_foundation
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
@@ -16,5 +17,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FirebaseAnalyticsPlugin.register(with: registry.registrar(forPlugin: "FirebaseAnalyticsPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   FLTFirebaseCrashlyticsPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCrashlyticsPlugin"))
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }


### PR DESCRIPTION
Replaced the Stack/Opacity/ClipRRect implementation of `_PassedLessonFade` with a single `ShaderMask` using a `LinearGradient`.

The previous implementation rendered the complex `CustomCard` (containing ~20 widgets) twice to achieve the "faded bottom part" effect. This doubled the widget depth and painting cost for every passed lesson card.

This change reduces widget tree depth and eliminates double rendering of lesson cards. Expected to improve scrolling performance in the dashboard.

---
*PR created automatically by Jules for task [10298638585072329051](https://jules.google.com/task/10298638585072329051) started by @nilsreichardt*