### PR TITLE
🛡️ Sentinel: Enforce strict URL scheme validation

### DIFF
--- a/lib/url_launcher_extended/lib/src/url_launcher_extended.dart
+++ b/lib/url_launcher_extended/lib/src/url_launcher_extended.dart
@@ -12,6 +12,14 @@ import 'package:url_launcher/url_launcher_string.dart';
 /// [UrlLauncherExtended] adds the ability to mocks the `url_launcher` by
 /// wrapping the methods into a class and adds some helpful methods.
 class UrlLauncherExtended {
+  static const _allowedSchemes = [
+    'http',
+    'https',
+    'mailto',
+    'tel',
+    'sms',
+  ];
+
   /// Passes [url] to the underlying platform for handling.
   ///
   /// [mode] support varies significantly by platform:
@@ -50,6 +58,12 @@ class UrlLauncherExtended {
     WebViewConfiguration webViewConfiguration = const WebViewConfiguration(),
     String? webOnlyWindowName,
   }) async {
+    if (!_allowedSchemes.contains(url.scheme)) {
+      throw ArgumentError(
+        'Scheme \'${url.scheme}\' is not allowed. Allowed schemes: ${_allowedSchemes.join(', ')}',
+      );
+    }
+
     return url_launcher.launchUrl(
       url,
       mode: mode,
@@ -85,6 +99,10 @@ class UrlLauncherExtended {
   ///
   /// (Copied form url_launcher)
   Future<bool> canLaunchUrl(Uri url) {
+    if (!_allowedSchemes.contains(url.scheme)) {
+      return Future.value(false);
+    }
+
     return url_launcher.canLaunchUrl(url);
   }
 

--- a/lib/url_launcher_extended/test/url_launcher_extended_security_test.dart
+++ b/lib/url_launcher_extended/test/url_launcher_extended_security_test.dart
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Sharezone UG (haftungsbeschränkt)
+// Licensed under the EUPL-1.2-or-later.
+//
+// You may obtain a copy of the Licence at:
+// https://joinup.ec.europa.eu/software/page/eupl
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:url_launcher_extended/src/url_launcher_extended.dart';
+// ignore: depend_on_referenced_packages
+import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
+// ignore: depend_on_referenced_packages
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+// ignore: depend_on_referenced_packages
+import 'package:url_launcher_platform_interface/link.dart';
+
+class MockUrlLauncher extends MockPlatformInterfaceMixin implements UrlLauncherPlatform {
+  String? launchUrlCalledWith;
+  String? canLaunchUrlCalledWith;
+
+  @override
+  Future<bool> launchUrl(String url, LaunchOptions options) async {
+    launchUrlCalledWith = url;
+    return true;
+  }
+
+  @override
+  Future<bool> canLaunch(String url) async {
+    canLaunchUrlCalledWith = url;
+    return true;
+  }
+
+  @override
+  Future<void> closeWebView() async {}
+
+  @override
+  Future<bool> supportsMode(PreferredLaunchMode mode) async => true;
+
+  @override
+  Future<bool> supportsCloseForMode(PreferredLaunchMode mode) async => true;
+
+  // Deprecated member, but required to be implemented
+  @override
+  Future<bool> launch(String url, {required bool useSafariVC, required bool useWebView, required bool enableJavaScript, required bool enableDomStorage, required bool universalLinksOnly, required Map<String, String> headers, String? webOnlyWindowName}) async {
+    launchUrlCalledWith = url;
+    return true;
+  }
+
+  @override
+  LinkDelegate? get linkDelegate => null;
+}
+
+void main() {
+  test('Security: launchUrl throws ArgumentError for disallowed schemes', () async {
+    final mock = MockUrlLauncher();
+    UrlLauncherPlatform.instance = mock;
+
+    final launcher = UrlLauncherExtended();
+    final dangerousUrl = Uri.parse('javascript:alert("XSS")');
+
+    // Expect ArgumentError when launching a disallowed scheme
+    expect(
+      () => launcher.launchUrl(dangerousUrl),
+      throwsA(isA<ArgumentError>()),
+    );
+
+    // Ensure platform method was NOT called (if exception thrown before)
+    expect(mock.launchUrlCalledWith, isNull);
+  });
+
+  test('Security: canLaunchUrl returns false for disallowed schemes', () async {
+    final mock = MockUrlLauncher();
+    UrlLauncherPlatform.instance = mock;
+
+    final launcher = UrlLauncherExtended();
+    final dangerousUrl = Uri.parse('javascript:alert("XSS")');
+
+    // Expect false when checking a disallowed scheme
+    final canLaunch = await launcher.canLaunchUrl(dangerousUrl);
+    expect(canLaunch, isFalse);
+
+    // Ensure platform method was NOT called
+    expect(mock.canLaunchUrlCalledWith, isNull);
+  });
+
+  test('Security: canLaunchUrl returns true (or platform result) for allowed schemes', () async {
+    final mock = MockUrlLauncher();
+    UrlLauncherPlatform.instance = mock;
+
+    final launcher = UrlLauncherExtended();
+    final allowedUrl = Uri.parse('https://example.com');
+
+    // Expect true (mock returns true)
+    final canLaunch = await launcher.canLaunchUrl(allowedUrl);
+    expect(canLaunch, isTrue);
+
+    // Ensure platform method WAS called
+    expect(mock.canLaunchUrlCalledWith, 'https://example.com');
+  });
+}


### PR DESCRIPTION
Implemented scheme validation for `url_launcher_extended`. Now only `http`, `https`, `mailto`, `tel`, and `sms` schemes are allowed. Other schemes will cause `launchUrl` to throw `ArgumentError` and `canLaunchUrl` to return `false`. Added unit tests to verify this behavior.

---
*PR created automatically by Jules for task [12808072820331924025](https://jules.google.com/task/12808072820331924025) started by @nilsreichardt*