### PR TITLE
Set `GITHUB_TOKEN` permissions to none in workflows where we don't have it yet

### DIFF
--- a/.github/workflows/add_ticket_to_board.yml
+++ b/.github/workflows/add_ticket_to_board.yml
@@ -15,6 +15,12 @@ on:
     types:
       - opened
 
+# Set permissions to none.
+#
+# Using the broad default permissions is considered a bad security practice
+# and would cause alerts from our scanning tools.
+permissions: {}
+
 jobs:
   add-to-project:
     name: Add issue to board

--- a/.github/workflows/cli_ci.yml
+++ b/.github/workflows/cli_ci.yml
@@ -33,6 +33,12 @@ on:
     types:
       - checks_requested
 
+# Set permissions to none.
+#
+# Using the broad default permissions is considered a bad security practice
+# and would cause alerts from our scanning tools.
+permissions: {}
+
 env:
   CI_CD_DART_SCRIPTS_PACKAGE_PATH: "tools/sz_repo_cli/"
 

--- a/.github/workflows/integration_tests_app_fallback_ci.yml
+++ b/.github/workflows/integration_tests_app_fallback_ci.yml
@@ -22,6 +22,12 @@ name: integration-tests-app-fallback-ci
 on:
   pull_request:
 
+# Set permissions to none.
+#
+# Using the broad default permissions is considered a bad security practice
+# and would cause alerts from our scanning tools.
+permissions: {}
+
 jobs:
   android-integration-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/label_app_preview.yaml
+++ b/.github/workflows/label_app_preview.yaml
@@ -18,6 +18,12 @@ on:
       - labeled
       - synchronize
 
+# Set permissions to none.
+#
+# Using the broad default permissions is considered a bad security practice
+# and would cause alerts from our scanning tools.
+permissions: {}
+
 jobs:
   label_app_preview:
     # Only run this job if the PR is labeled with "build-app-preview".


### PR DESCRIPTION
In most workflows we already set the default permissions of the `GITHUB_TOKEN` to none (`permissions: {}`). However, we forgot a few workflows. This PR fixes this.